### PR TITLE
[23923] Fix RTPSParticipantAttributes internal data races

### DIFF
--- a/include/fastdds/dds/publisher/DataWriter.hpp
+++ b/include/fastdds/dds/publisher/DataWriter.hpp
@@ -485,7 +485,7 @@ public:
      *
      * @param [out] subscription_data subscription data struct
      * @param subscription_handle InstanceHandle_t of the subscription
-     * @return RETCODE_OK if successfull, RETCODE_BAD_PARAMETER otherwise
+     * @return RETCODE_OK if successful, RETCODE_BAD_PARAMETER otherwise
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_matched_subscription_data(
             SubscriptionBuiltinTopicData& subscription_data,
@@ -495,7 +495,7 @@ public:
      * @brief Fills the given vector with the InstanceHandle_t of matched DataReaders
      *
      * @param [out] subscription_handles Vector where the InstanceHandle_t are returned
-     * @return RETCODE_OK if successfull, RETCODE_ERROR otherwise
+     * @return RETCODE_OK if successful, RETCODE_ERROR otherwise
      */
     FASTDDS_EXPORTED_API ReturnCode_t get_matched_subscriptions(
             std::vector<InstanceHandle_t>& subscription_handles) const;

--- a/include/fastdds/rtps/attributes/RTPSParticipantAttributes.hpp
+++ b/include/fastdds/rtps/attributes/RTPSParticipantAttributes.hpp
@@ -345,6 +345,33 @@ private:
 };
 
 /**
+ * Class MutableDiscoverySettings, to define the mutable attributes of the several discovery protocols available
+ * @ingroup RTPS_ATTRIBUTES_MODULE
+ */
+class MutableDiscoverySettings
+{
+public:
+
+    //! Discovery Server initial connections, needed if `discoveryProtocol` = CLIENT | SUPER_CLIENT | SERVER | BACKUP
+    eprosima::fastdds::rtps::LocatorList m_DiscoveryServers;
+
+    MutableDiscoverySettings() = default;
+
+    MutableDiscoverySettings(
+            const DiscoverySettings& discovery_settings)
+        : m_DiscoveryServers(discovery_settings.m_DiscoveryServers)
+    {
+    }
+
+    bool operator ==(
+            const MutableDiscoverySettings& b) const
+    {
+        return (this->m_DiscoveryServers == b.m_DiscoveryServers);
+    }
+
+};
+
+/**
  * Class BuiltinAttributes, to define the behavior of the RTPSParticipant builtin protocols.
  * @ingroup RTPS_ATTRIBUTES_MODULE
  */
@@ -430,11 +457,11 @@ class BuiltinMutableAttributes
 {
 public:
 
+    //! Discovery protocol related attributes
+    MutableDiscoverySettings discovery_config;
+
     //! Metatraffic Unicast Locator List
     LocatorList_t metatrafficUnicastLocatorList;
-
-    //! Metatraffic Multicast Locator List.
-    LocatorList_t metatrafficMulticastLocatorList;
 
     //! The collection of external locators to use for communication on metatraffic topics.
     fastdds::rtps::ExternalLocators metatraffic_external_unicast_locators;
@@ -443,8 +470,8 @@ public:
 
     BuiltinMutableAttributes(
             const BuiltinAttributes& builtin)
-        : metatrafficUnicastLocatorList(builtin.metatrafficUnicastLocatorList)
-        , metatrafficMulticastLocatorList(builtin.metatrafficMulticastLocatorList)
+        : discovery_config(builtin.discovery_config)
+        , metatrafficUnicastLocatorList(builtin.metatrafficUnicastLocatorList)
         , metatraffic_external_unicast_locators(builtin.metatraffic_external_unicast_locators)
     {
     }
@@ -454,8 +481,8 @@ public:
     bool operator ==(
             const BuiltinMutableAttributes& b) const
     {
-        return (this->metatrafficUnicastLocatorList == b.metatrafficUnicastLocatorList) &&
-               (this->metatrafficMulticastLocatorList == b.metatrafficMulticastLocatorList) &&
+        return (this->discovery_config == b.discovery_config) &&
+               (this->metatrafficUnicastLocatorList == b.metatrafficUnicastLocatorList) &&
                (this->metatraffic_external_unicast_locators == b.metatraffic_external_unicast_locators);
     }
 
@@ -470,7 +497,10 @@ class BuiltinConstantAttributes
 {
 public:
 
-    //! Discovery protocol related attributes
+    /**
+     * Discovery protocol related attributes. Only the discovery server list is mutable, which must be
+     * accessed through the BuiltinMutableAttributes class. Its value in this class is only used as initial value.
+     */
     DiscoverySettings discovery_config;
 
     //! Indicates to use the WriterLiveliness protocol.
@@ -478,6 +508,9 @@ public:
 
     //! Network Configuration
     NetworkConfigSet_t network_configuration = 0;
+
+    //! Metatraffic Multicast Locator List
+    LocatorList_t metatrafficMulticastLocatorList;
 
     //! Initial peers.
     LocatorList_t initialPeersList;
@@ -512,6 +545,7 @@ public:
         : discovery_config(builtin.discovery_config)
         , use_WriterLivelinessProtocol(builtin.use_WriterLivelinessProtocol)
         , network_configuration(builtin.network_configuration)
+        , metatrafficMulticastLocatorList(builtin.metatrafficMulticastLocatorList)
         , initialPeersList(builtin.initialPeersList)
         , readerHistoryMemoryPolicy(builtin.readerHistoryMemoryPolicy)
         , readerPayloadSize(builtin.readerPayloadSize)
@@ -531,6 +565,7 @@ public:
         return (this->discovery_config == b.discovery_config) &&
                (this->use_WriterLivelinessProtocol == b.use_WriterLivelinessProtocol) &&
                (this->network_configuration == b.network_configuration) &&
+               (this->metatrafficMulticastLocatorList == b.metatrafficMulticastLocatorList) &&
                (this->initialPeersList == b.initialPeersList) &&
                (this->readerHistoryMemoryPolicy == b.readerHistoryMemoryPolicy) &&
                (this->readerPayloadSize == b.readerPayloadSize) &&
@@ -720,7 +755,7 @@ private:
 };
 
 /**
- * Class RTPSMutablePartAttributes used to define mutable aspects of a RTPSParticipant.
+ * Class RTPSParticipantMutableAttributes used to define mutable aspects of a RTPSParticipant.
  * @ingroup RTPS_ATTRIBUTES_MODULE
  */
 class RTPSParticipantMutableAttributes
@@ -747,7 +782,6 @@ public:
                (this->default_external_unicast_locators == b.default_external_unicast_locators) &&
                (this->userData == b.userData) &&
                (this->builtin == b.builtin);
-
     }
 
     /**
@@ -896,13 +930,6 @@ public:
 
     //! Property policies
     PropertyPolicy properties;
-
-    //! Set the name of the participant.
-    inline void setName(
-            const char* nam)
-    {
-        name = nam;
-    }
 
     //! Get the name of the participant.
     inline const char* getName() const

--- a/include/fastdds/rtps/attributes/RTPSParticipantAttributes.hpp
+++ b/include/fastdds/rtps/attributes/RTPSParticipantAttributes.hpp
@@ -703,14 +703,17 @@ inline void BuiltinAttributes::compose(
 {
     // Constant Discovery settings
     discovery_config.discoveryProtocol = builtin_const.discovery_config.discoveryProtocol;
-    discovery_config.use_SIMPLE_EndpointDiscoveryProtocol = builtin_const.discovery_config.use_SIMPLE_EndpointDiscoveryProtocol;
-    discovery_config.use_STATIC_EndpointDiscoveryProtocol = builtin_const.discovery_config.use_STATIC_EndpointDiscoveryProtocol;
+    discovery_config.use_SIMPLE_EndpointDiscoveryProtocol =
+            builtin_const.discovery_config.use_SIMPLE_EndpointDiscoveryProtocol;
+    discovery_config.use_STATIC_EndpointDiscoveryProtocol =
+            builtin_const.discovery_config.use_STATIC_EndpointDiscoveryProtocol;
     discovery_config.leaseDuration = builtin_const.discovery_config.leaseDuration;
     discovery_config.leaseDuration_announcementperiod = builtin_const.discovery_config.leaseDuration_announcementperiod;
     discovery_config.initial_announcements = builtin_const.discovery_config.initial_announcements;
     discovery_config.m_simpleEDP = builtin_const.discovery_config.m_simpleEDP;
     discovery_config.m_PDPfactory = builtin_const.discovery_config.m_PDPfactory;
-    discovery_config.discoveryServer_client_syncperiod = builtin_const.discovery_config.discoveryServer_client_syncperiod;
+    discovery_config.discoveryServer_client_syncperiod =
+            builtin_const.discovery_config.discoveryServer_client_syncperiod;
     discovery_config.ignoreParticipantFlags = builtin_const.discovery_config.ignoreParticipantFlags;
     // Mutable Discovery settings
     discovery_config.m_DiscoveryServers = builtin_mutable.discovery_config.m_DiscoveryServers;

--- a/include/fastdds/rtps/attributes/RTPSParticipantAttributes.hpp
+++ b/include/fastdds/rtps/attributes/RTPSParticipantAttributes.hpp
@@ -371,6 +371,110 @@ public:
 
 };
 
+/**
+ * Class ConstantDiscoverySettings, to define the constant attributes of the several discovery protocols available
+ * @ingroup RTPS_ATTRIBUTES_MODULE
+ */
+class ConstantDiscoverySettings
+{
+public:
+
+    //! Chosen discovery protocol
+    DiscoveryProtocol discoveryProtocol = DiscoveryProtocol::SIMPLE;
+
+    /**
+     * If set to true, SimpleEDP would be used.
+     */
+    bool use_SIMPLE_EndpointDiscoveryProtocol = true;
+
+    /**
+     * If set to true, StaticEDP based on an XML file would be implemented.
+     * The XML filename must be provided.
+     */
+    bool use_STATIC_EndpointDiscoveryProtocol = false;
+
+    /**
+     * Lease Duration of the RTPSParticipant,
+     * indicating how much time remote RTPSParticipants should consider this RTPSParticipant alive.
+     */
+    dds::Duration_t leaseDuration = { 20, 0 };
+
+    /**
+     * The period for the RTPSParticipant to send its Discovery Message to all other discovered RTPSParticipants
+     * as well as to all Multicast ports.
+     */
+    dds::Duration_t leaseDuration_announcementperiod = { 3, 0 };
+
+    //!Initial announcements configuration
+    InitialAnnouncementConfig initial_announcements;
+
+    //!Attributes of the SimpleEDP protocol
+    SimpleEDPAttributes m_simpleEDP;
+
+    //! function that returns a PDP object (only if EXTERNAL selected)
+    PDPFactory m_PDPfactory{};
+    /**
+     * The period for the RTPSParticipant to:
+     *  send its Discovery Message to its servers
+     *  check for EDP endpoints matching
+     */
+    dds::Duration_t discoveryServer_client_syncperiod = { 0, 450 * 1000000}; // 450 milliseconds
+
+    //! Filtering participants out depending on location
+    ParticipantFilteringFlags ignoreParticipantFlags = ParticipantFilteringFlags::NO_FILTER;
+
+    ConstantDiscoverySettings() = default;
+
+    ConstantDiscoverySettings(
+            const DiscoverySettings& discovery_settings)
+        : discoveryProtocol(discovery_settings.discoveryProtocol)
+        , use_SIMPLE_EndpointDiscoveryProtocol(discovery_settings.use_SIMPLE_EndpointDiscoveryProtocol)
+        , use_STATIC_EndpointDiscoveryProtocol(discovery_settings.use_STATIC_EndpointDiscoveryProtocol)
+        , leaseDuration(discovery_settings.leaseDuration)
+        , leaseDuration_announcementperiod(discovery_settings.leaseDuration_announcementperiod)
+        , initial_announcements(discovery_settings.initial_announcements)
+        , m_simpleEDP(discovery_settings.m_simpleEDP)
+        , m_PDPfactory(discovery_settings.m_PDPfactory)
+        , discoveryServer_client_syncperiod(discovery_settings.discoveryServer_client_syncperiod)
+        , ignoreParticipantFlags(discovery_settings.ignoreParticipantFlags)
+        , static_edp_xml_config_(discovery_settings.static_edp_xml_config())
+    {
+    }
+
+    bool operator ==(
+            const ConstantDiscoverySettings& b) const
+    {
+        return (this->discoveryProtocol == b.discoveryProtocol) &&
+               (this->use_SIMPLE_EndpointDiscoveryProtocol == b.use_SIMPLE_EndpointDiscoveryProtocol) &&
+               (this->use_STATIC_EndpointDiscoveryProtocol == b.use_STATIC_EndpointDiscoveryProtocol) &&
+               (this->discoveryServer_client_syncperiod == b.discoveryServer_client_syncperiod) &&
+               (this->m_PDPfactory == b.m_PDPfactory) &&
+               (this->leaseDuration == b.leaseDuration) &&
+               (this->leaseDuration_announcementperiod == b.leaseDuration_announcementperiod) &&
+               (this->initial_announcements == b.initial_announcements) &&
+               (this->m_simpleEDP == b.m_simpleEDP) &&
+               (this->static_edp_xml_config_ == b.static_edp_xml_config_) &&
+               (this->ignoreParticipantFlags == b.ignoreParticipantFlags);
+    }
+
+    /**
+     * Get the static endpoint XML configuration.
+     * @return URI specifying the static endpoint XML configuration.
+     * The string could contain a filename (file://) or the XML content directly (data://).
+     */
+    const char* static_edp_xml_config() const
+    {
+        return static_edp_xml_config_.c_str();
+    }
+
+private:
+
+    //! URI specifying the static EDP XML configuration, only necessary if use_STATIC_EndpointDiscoveryProtocol=true
+    //! This string could contain a filename or the XML content directly.
+    std::string static_edp_xml_config_ = "";
+
+};
+
 // Forward declaration to allow assignment from Constant and Mutable attributes.
 class BuiltinConstantAttributes;
 class BuiltinMutableAttributes;
@@ -513,10 +617,10 @@ class BuiltinConstantAttributes
 public:
 
     /**
-     * Discovery protocol related attributes. Only the discovery server list is mutable, which must be
+     * Discovery protocol related constant attributes. Only the discovery server list is mutable, which must be
      * accessed through the BuiltinMutableAttributes class. Its value in this class is only used as initial value.
      */
-    DiscoverySettings discovery_config;
+    ConstantDiscoverySettings discovery_config;
 
     //! Indicates to use the WriterLiveliness protocol.
     bool use_WriterLivelinessProtocol = true;
@@ -597,13 +701,23 @@ inline void BuiltinAttributes::compose(
         const BuiltinConstantAttributes& builtin_const,
         const BuiltinMutableAttributes& builtin_mutable)
 {
-    discovery_config = builtin_const.discovery_config;
+    // Constant Discovery settings
+    discovery_config.discoveryProtocol = builtin_const.discovery_config.discoveryProtocol;
+    discovery_config.use_SIMPLE_EndpointDiscoveryProtocol = builtin_const.discovery_config.use_SIMPLE_EndpointDiscoveryProtocol;
+    discovery_config.use_STATIC_EndpointDiscoveryProtocol = builtin_const.discovery_config.use_STATIC_EndpointDiscoveryProtocol;
+    discovery_config.leaseDuration = builtin_const.discovery_config.leaseDuration;
+    discovery_config.leaseDuration_announcementperiod = builtin_const.discovery_config.leaseDuration_announcementperiod;
+    discovery_config.initial_announcements = builtin_const.discovery_config.initial_announcements;
+    discovery_config.m_simpleEDP = builtin_const.discovery_config.m_simpleEDP;
+    discovery_config.m_PDPfactory = builtin_const.discovery_config.m_PDPfactory;
+    discovery_config.discoveryServer_client_syncperiod = builtin_const.discovery_config.discoveryServer_client_syncperiod;
+    discovery_config.ignoreParticipantFlags = builtin_const.discovery_config.ignoreParticipantFlags;
+    // Mutable Discovery settings
     discovery_config.m_DiscoveryServers = builtin_mutable.discovery_config.m_DiscoveryServers;
+    // Constant settings
     use_WriterLivelinessProtocol = builtin_const.use_WriterLivelinessProtocol;
     network_configuration = builtin_const.network_configuration;
-    metatrafficUnicastLocatorList = builtin_mutable.metatrafficUnicastLocatorList;
     metatrafficMulticastLocatorList = builtin_const.metatrafficMulticastLocatorList;
-    metatraffic_external_unicast_locators = builtin_mutable.metatraffic_external_unicast_locators;
     initialPeersList = builtin_const.initialPeersList;
     readerHistoryMemoryPolicy = builtin_const.readerHistoryMemoryPolicy;
     readerPayloadSize = builtin_const.readerPayloadSize;
@@ -612,6 +726,9 @@ inline void BuiltinAttributes::compose(
     mutation_tries = builtin_const.mutation_tries;
     avoid_builtin_multicast = builtin_const.avoid_builtin_multicast;
     flow_controller_name = builtin_const.flow_controller_name;
+    // Mutable settings
+    metatrafficUnicastLocatorList = builtin_mutable.metatrafficUnicastLocatorList;
+    metatraffic_external_unicast_locators = builtin_mutable.metatraffic_external_unicast_locators;
 }
 
 /**

--- a/include/fastdds/rtps/attributes/RTPSParticipantAttributes.hpp
+++ b/include/fastdds/rtps/attributes/RTPSParticipantAttributes.hpp
@@ -371,6 +371,10 @@ public:
 
 };
 
+// Forward declaration to allow assignment from Constant and Mutable attributes.
+class BuiltinConstantAttributes;
+class BuiltinMutableAttributes;
+
 /**
  * Class BuiltinAttributes, to define the behavior of the RTPSParticipant builtin protocols.
  * @ingroup RTPS_ATTRIBUTES_MODULE
@@ -426,6 +430,17 @@ public:
     BuiltinAttributes() = default;
 
     virtual ~BuiltinAttributes() = default;
+
+    /**
+     * Composes this object from a BuiltinConstantAttributes and a BuiltinMutableAttributes.
+     * Every field is assigned: constant fields are taken from @c builtin_const, mutable fields
+     * are taken from @c builtin_mutable.
+     * @param builtin_const Constant builtin attributes to copy from.
+     * @param builtin_mutable Mutable builtin attributes to copy from.
+     */
+    void compose(
+            const BuiltinConstantAttributes& builtin_const,
+            const BuiltinMutableAttributes& builtin_mutable);
 
     bool operator ==(
             const BuiltinAttributes& b) const
@@ -577,6 +592,27 @@ public:
     }
 
 };
+
+inline void BuiltinAttributes::compose(
+        const BuiltinConstantAttributes& builtin_const,
+        const BuiltinMutableAttributes& builtin_mutable)
+{
+    discovery_config = builtin_const.discovery_config;
+    discovery_config.m_DiscoveryServers = builtin_mutable.discovery_config.m_DiscoveryServers;
+    use_WriterLivelinessProtocol = builtin_const.use_WriterLivelinessProtocol;
+    network_configuration = builtin_const.network_configuration;
+    metatrafficUnicastLocatorList = builtin_mutable.metatrafficUnicastLocatorList;
+    metatrafficMulticastLocatorList = builtin_const.metatrafficMulticastLocatorList;
+    metatraffic_external_unicast_locators = builtin_mutable.metatraffic_external_unicast_locators;
+    initialPeersList = builtin_const.initialPeersList;
+    readerHistoryMemoryPolicy = builtin_const.readerHistoryMemoryPolicy;
+    readerPayloadSize = builtin_const.readerPayloadSize;
+    writerHistoryMemoryPolicy = builtin_const.writerHistoryMemoryPolicy;
+    writerPayloadSize = builtin_const.writerPayloadSize;
+    mutation_tries = builtin_const.mutation_tries;
+    avoid_builtin_multicast = builtin_const.avoid_builtin_multicast;
+    flow_controller_name = builtin_const.flow_controller_name;
+}
 
 /**
  * Class RTPSParticipantAttributes used to define different aspects of a RTPSParticipant.

--- a/include/fastdds/rtps/attributes/RTPSParticipantAttributes.hpp
+++ b/include/fastdds/rtps/attributes/RTPSParticipantAttributes.hpp
@@ -737,9 +737,9 @@ inline void BuiltinAttributes::compose(
  */
 class RTPSParticipantAttributes
 {
-    using FlowControllerDescriptorList = std::vector<std::shared_ptr<fastdds::rtps::FlowControllerDescriptor>>;
-
 public:
+
+    using FlowControllerDescriptorList = std::vector<std::shared_ptr<fastdds::rtps::FlowControllerDescriptor>>;
 
     RTPSParticipantAttributes() = default;
 
@@ -961,9 +961,9 @@ public:
  */
 class RTPSParticipantConstantAttributes
 {
-    using FlowControllerDescriptorList = std::vector<std::shared_ptr<fastdds::rtps::FlowControllerDescriptor>>;
-
 public:
+
+    using FlowControllerDescriptorList = std::vector<std::shared_ptr<fastdds::rtps::FlowControllerDescriptor>>;
 
     RTPSParticipantConstantAttributes() = default;
 

--- a/include/fastdds/rtps/attributes/RTPSParticipantAttributes.hpp
+++ b/include/fastdds/rtps/attributes/RTPSParticipantAttributes.hpp
@@ -422,6 +422,128 @@ public:
 };
 
 /**
+ * Class BuiltinMutableAttributes, to define the behavior of the mutable RTPSParticipant builtin protocols.
+ * This class is a subset of BuiltinAttributes. It is separated to keep the logic of constant and mutable attributes separated.
+ * @ingroup RTPS_ATTRIBUTES_MODULE
+ */
+class BuiltinMutableAttributes
+{
+public:
+
+    //! Metatraffic Unicast Locator List
+    LocatorList_t metatrafficUnicastLocatorList;
+
+    //! Metatraffic Multicast Locator List.
+    LocatorList_t metatrafficMulticastLocatorList;
+
+    //! The collection of external locators to use for communication on metatraffic topics.
+    fastdds::rtps::ExternalLocators metatraffic_external_unicast_locators;
+
+    BuiltinMutableAttributes() = default;
+
+    BuiltinMutableAttributes(
+            const BuiltinAttributes& builtin)
+        : metatrafficUnicastLocatorList(builtin.metatrafficUnicastLocatorList)
+        , metatrafficMulticastLocatorList(builtin.metatrafficMulticastLocatorList)
+        , metatraffic_external_unicast_locators(builtin.metatraffic_external_unicast_locators)
+    {
+    }
+
+    ~BuiltinMutableAttributes() = default;
+
+    bool operator ==(
+            const BuiltinMutableAttributes& b) const
+    {
+        return (this->metatrafficUnicastLocatorList == b.metatrafficUnicastLocatorList) &&
+               (this->metatrafficMulticastLocatorList == b.metatrafficMulticastLocatorList) &&
+               (this->metatraffic_external_unicast_locators == b.metatraffic_external_unicast_locators);
+    }
+
+};
+
+/**
+ * Class BuiltinConstantAttributes, to define the behavior of the constant RTPSParticipant builtin protocols.
+ * This class is a subset of BuiltinAttributes. It is separated to keep the logic of constant and mutable attributes separated.
+ * @ingroup RTPS_ATTRIBUTES_MODULE
+ */
+class BuiltinConstantAttributes
+{
+public:
+
+    //! Discovery protocol related attributes
+    DiscoverySettings discovery_config;
+
+    //! Indicates to use the WriterLiveliness protocol.
+    bool use_WriterLivelinessProtocol = true;
+
+    //! Network Configuration
+    NetworkConfigSet_t network_configuration = 0;
+
+    //! Initial peers.
+    LocatorList_t initialPeersList;
+
+    //! Memory policy for builtin readers
+    MemoryManagementPolicy_t readerHistoryMemoryPolicy =
+            MemoryManagementPolicy_t::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+
+    //! Maximum payload size for builtin readers
+    uint32_t readerPayloadSize = BUILTIN_DATA_MAX_SIZE;
+
+    //! Memory policy for builtin writers
+    MemoryManagementPolicy_t writerHistoryMemoryPolicy =
+            MemoryManagementPolicy_t::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+
+    //! Maximum payload size for builtin writers
+    uint32_t writerPayloadSize = BUILTIN_DATA_MAX_SIZE;
+
+    //! Mutation tries if the port is being used.
+    uint32_t mutation_tries = 100u;
+
+    //! Set to true to avoid multicast traffic on builtin endpoints
+    bool avoid_builtin_multicast = true;
+
+    //! Flow controller name to use for the builtin writers
+    std::string flow_controller_name = "";
+
+    BuiltinConstantAttributes() = default;
+
+    BuiltinConstantAttributes(
+            const BuiltinAttributes& builtin)
+        : discovery_config(builtin.discovery_config)
+        , use_WriterLivelinessProtocol(builtin.use_WriterLivelinessProtocol)
+        , network_configuration(builtin.network_configuration)
+        , initialPeersList(builtin.initialPeersList)
+        , readerHistoryMemoryPolicy(builtin.readerHistoryMemoryPolicy)
+        , readerPayloadSize(builtin.readerPayloadSize)
+        , writerHistoryMemoryPolicy(builtin.writerHistoryMemoryPolicy)
+        , writerPayloadSize(builtin.writerPayloadSize)
+        , mutation_tries(builtin.mutation_tries)
+        , avoid_builtin_multicast(builtin.avoid_builtin_multicast)
+        , flow_controller_name(builtin.flow_controller_name)
+    {
+    }
+
+    ~BuiltinConstantAttributes() = default;
+
+    bool operator ==(
+            const BuiltinConstantAttributes& b) const
+    {
+        return (this->discovery_config == b.discovery_config) &&
+               (this->use_WriterLivelinessProtocol == b.use_WriterLivelinessProtocol) &&
+               (this->network_configuration == b.network_configuration) &&
+               (this->initialPeersList == b.initialPeersList) &&
+               (this->readerHistoryMemoryPolicy == b.readerHistoryMemoryPolicy) &&
+               (this->readerPayloadSize == b.readerPayloadSize) &&
+               (this->writerHistoryMemoryPolicy == b.writerHistoryMemoryPolicy) &&
+               (this->writerPayloadSize == b.writerPayloadSize) &&
+               (this->mutation_tries == b.mutation_tries) &&
+               (this->flow_controller_name == b.flow_controller_name) &&
+               (this->avoid_builtin_multicast == b.avoid_builtin_multicast);
+    }
+
+};
+
+/**
  * Class RTPSParticipantAttributes used to define different aspects of a RTPSParticipant.
  * @ingroup RTPS_ATTRIBUTES_MODULE
  */
@@ -596,6 +718,234 @@ private:
     //! Name of the participant.
     fastcdr::string_255 name{"RTPSParticipant"};
 };
+
+/**
+ * Class RTPSMutablePartAttributes used to define mutable aspects of a RTPSParticipant.
+ * @ingroup RTPS_ATTRIBUTES_MODULE
+ */
+class RTPSParticipantMutableAttributes
+{
+public:
+
+    RTPSParticipantMutableAttributes() = default;
+
+    RTPSParticipantMutableAttributes(
+            const RTPSParticipantAttributes& attrs)
+        : defaultUnicastLocatorList(attrs.defaultUnicastLocatorList)
+        , default_external_unicast_locators(attrs.default_external_unicast_locators)
+        , userData(attrs.userData)
+        , builtin(attrs.builtin)
+    {
+    }
+
+    ~RTPSParticipantMutableAttributes() = default;
+
+    bool operator ==(
+            const RTPSParticipantMutableAttributes& b) const
+    {
+        return (this->defaultUnicastLocatorList == b.defaultUnicastLocatorList) &&
+               (this->default_external_unicast_locators == b.default_external_unicast_locators) &&
+               (this->userData == b.userData) &&
+               (this->builtin == b.builtin);
+
+    }
+
+    /**
+     * Default list of Unicast Locators to be used for any Endpoint defined inside this RTPSParticipant in the case
+     * that it was defined with NO UnicastLocators. At least ONE locator should be included in this list.
+     */
+    LocatorList_t defaultUnicastLocatorList;
+
+    /**
+     * The collection of external locators to use for communication on user created topics.
+     */
+    fastdds::rtps::ExternalLocators default_external_unicast_locators;
+
+    //! User Data of the participant
+    std::vector<octet> userData;
+
+    //! Builtin parameters.
+    BuiltinMutableAttributes builtin;
+};
+
+/**
+ * Class RTPSParticipantConstantAttributes used to define constant aspects of a RTPSParticipant.
+ * @ingroup RTPS_ATTRIBUTES_MODULE
+ */
+class RTPSParticipantConstantAttributes
+{
+    using FlowControllerDescriptorList = std::vector<std::shared_ptr<fastdds::rtps::FlowControllerDescriptor>>;
+
+public:
+
+    RTPSParticipantConstantAttributes() = default;
+
+    RTPSParticipantConstantAttributes(
+            const RTPSParticipantAttributes& attrs)
+        : defaultMulticastLocatorList(attrs.defaultMulticastLocatorList)
+        , ignore_non_matching_locators(attrs.ignore_non_matching_locators)
+        , sendSocketBufferSize(attrs.sendSocketBufferSize)
+        , listenSocketBufferSize(attrs.listenSocketBufferSize)
+        , netmaskFilter(attrs.netmaskFilter)
+        , prefix(attrs.prefix)
+        , builtin(attrs.builtin)
+        , port(attrs.port)
+        , participantID(attrs.participantID)
+        , easy_mode_ip(attrs.easy_mode_ip)
+        , userTransports(attrs.userTransports)
+        , useBuiltinTransports(attrs.useBuiltinTransports)
+        , allocation(attrs.allocation)
+        , properties(attrs.properties)
+        , flow_controllers(attrs.flow_controllers)
+        , builtin_controllers_sender_thread(attrs.builtin_controllers_sender_thread)
+        , timed_events_thread(attrs.timed_events_thread)
+        , discovery_server_thread(attrs.discovery_server_thread)
+        , typelookup_service_thread(attrs.typelookup_service_thread)
+        , builtin_transports_reception_threads(attrs.builtin_transports_reception_threads)
+#if HAVE_SECURITY
+        , security_log_thread(attrs.security_log_thread)
+#endif // if HAVE_SECURITY
+        , max_msg_size_no_frag(attrs.max_msg_size_no_frag)
+        , name(attrs.getName())
+    {
+    }
+
+    ~RTPSParticipantConstantAttributes() = default;
+
+    bool operator ==(
+            const RTPSParticipantConstantAttributes& b) const
+    {
+        return (this->defaultMulticastLocatorList == b.defaultMulticastLocatorList) &&
+               (this->ignore_non_matching_locators == b.ignore_non_matching_locators) &&
+               (this->sendSocketBufferSize == b.sendSocketBufferSize) &&
+               (this->listenSocketBufferSize == b.listenSocketBufferSize) &&
+               (this->netmaskFilter == b.netmaskFilter) &&
+               (this->builtin == b.builtin) &&
+               (this->port == b.port) &&
+               (this->participantID == b.participantID) &&
+               (this->easy_mode_ip == b.easy_mode_ip) &&
+               (this->useBuiltinTransports == b.useBuiltinTransports) &&
+               (this->allocation == b.allocation) &&
+               (this->properties == b.properties) &&
+               (this->prefix == b.prefix) &&
+               (this->flow_controllers == b.flow_controllers) &&
+               (this->builtin_controllers_sender_thread == b.builtin_controllers_sender_thread) &&
+               (this->timed_events_thread == b.timed_events_thread) &&
+#if HAVE_SECURITY
+               (this->security_log_thread == b.security_log_thread) &&
+#endif // if HAVE_SECURITY
+               (this->discovery_server_thread == b.discovery_server_thread) &&
+               (this->typelookup_service_thread == b.typelookup_service_thread) &&
+               (this->builtin_transports_reception_threads == b.builtin_transports_reception_threads);
+    }
+
+    /**
+     * Default list of Multicast Locators to be used for any Endpoint defined inside this RTPSParticipant in the
+     * case that it was defined with NO MulticastLocators. This is usually left empty.
+     */
+    LocatorList_t defaultMulticastLocatorList;
+
+    /**
+     * Whether locators that don't match with the announced locators should be kept.
+     */
+    bool ignore_non_matching_locators = false;
+
+    /*!
+     * @brief Send socket buffer size for the send resource. Zero value indicates to use default system buffer size.
+     * Default value: 0.
+     */
+    uint32_t sendSocketBufferSize = 0;
+
+    /*! Listen socket buffer for all listen resources. Zero value indicates to use default system buffer size.
+     * Default value: 0.
+     */
+    uint32_t listenSocketBufferSize = 0;
+
+    //! Netmask filter configuration
+    fastdds::rtps::NetmaskFilterKind netmaskFilter = fastdds::rtps::NetmaskFilterKind::AUTO;
+
+    //! Optionally allows user to define the GuidPrefix_t
+    GuidPrefix_t prefix;
+
+    inline bool ReadguidPrefix(
+            const char* pfx)
+    {
+        return bool(std::istringstream(pfx) >> prefix);
+    }
+
+    //! Builtin parameters.
+    BuiltinConstantAttributes builtin;
+
+    //! Port Parameters
+    PortParameters port;
+
+    //! Participant ID
+    int32_t participantID = -1;
+
+    //! IP of the Host where master Server is located (EASY_MODE context)
+    std::string easy_mode_ip = "";
+
+    //! User defined transports to use alongside or in place of builtins.
+    std::vector<std::shared_ptr<fastdds::rtps::TransportDescriptorInterface>> userTransports;
+
+    //! Set as false to disable the creation of the default transports.
+    bool useBuiltinTransports = true;
+
+    //! Holds allocation limits affecting collections managed by a participant.
+    RTPSParticipantAllocationAttributes allocation;
+
+    //! Property policies
+    PropertyPolicy properties;
+
+    //! Set the name of the participant.
+    inline void setName(
+            const char* nam)
+    {
+        name = nam;
+    }
+
+    //! Get the name of the participant.
+    inline const char* getName() const
+    {
+        return name.c_str();
+    }
+
+    //! Flow controllers.
+    FlowControllerDescriptorList flow_controllers;
+
+    //! Thread settings for the builtin flow controllers sender threads
+    fastdds::rtps::ThreadSettings builtin_controllers_sender_thread;
+
+    //! Thread settings for the timed events thread
+    fastdds::rtps::ThreadSettings timed_events_thread;
+
+    //! Thread settings for the discovery server thread
+    fastdds::rtps::ThreadSettings discovery_server_thread;
+
+    //! Thread settings for the builtin TypeLookup service requests and replies threads
+    fastdds::rtps::ThreadSettings typelookup_service_thread;
+
+    //! Thread settings for the builtin transports reception threads
+    fastdds::rtps::ThreadSettings builtin_transports_reception_threads;
+
+#if HAVE_SECURITY
+    //! Thread settings for the security log thread
+    fastdds::rtps::ThreadSettings security_log_thread;
+#endif // if HAVE_SECURITY
+
+    /*! Maximum message size used to avoid fragmentation, set ONLY in LARGE_DATA. If this value is
+     * not zero, the network factory will allow the initialization of UDP transports with maxMessageSize
+     * higher than 65500K.
+     */
+    uint32_t max_msg_size_no_frag = 0;
+
+private:
+
+    //! Name of the participant.
+    fastcdr::string_255 name{"RTPSParticipant"};
+
+};
+
 
 }  // namespace rtps
 }  // namespace fastdds

--- a/include/fastdds/rtps/participant/RTPSParticipant.hpp
+++ b/include/fastdds/rtps/participant/RTPSParticipant.hpp
@@ -236,7 +236,7 @@ public:
      * Get a reference of the current state of the RTPSParticipantParameters.
      * @return RTPSParticipantAttributes reference.
      */
-    const RTPSParticipantAttributes& get_attributes() const;
+    RTPSParticipantAttributes get_attributes() const;
 
     /**
      * Retrieves the maximum message size.

--- a/include/fastdds/rtps/participant/RTPSParticipant.hpp
+++ b/include/fastdds/rtps/participant/RTPSParticipant.hpp
@@ -246,8 +246,7 @@ public:
             "Make RTPSParticipantAttributes a composition of RTPSParticipantConstantAttributes and RTPSParticipantMutableAttributes");
     /**
      * @brief Get a const reference of RTPSParticipantConstantAttributes of this RTPSParticipantImpl.
-     * This method is thread safe because it returns a const reference to the internal attributes.
-     * @warning It must not be used to access mutable attributes as it could return outdated values.
+     * This method is thread safe because it returns a const reference to the internal constant attributes.
      * @return A const reference to the RTPSParticipantConstantAttributes of this RTPSParticipantImpl.
      */
     const RTPSParticipantConstantAttributes& get_const_attributes() const;
@@ -256,7 +255,7 @@ public:
             "Make RTPSParticipantAttributes a composition of RTPSParticipantConstantAttributes and RTPSParticipantMutableAttributes");
     /**
      * @brief Get a const copy of RTPSParticipantMutableAttributes of this RTPSParticipantImpl.
-     * This method is thread safe because it returns a const copy of the internal attributes.
+     * This method is thread safe because it returns a const copy of the internal mutable attributes.
      * @return A const copy of the RTPSParticipantMutableAttributes of this RTPSParticipantImpl.
      */
     const RTPSParticipantMutableAttributes get_mutable_attributes() const;

--- a/include/fastdds/rtps/participant/RTPSParticipant.hpp
+++ b/include/fastdds/rtps/participant/RTPSParticipant.hpp
@@ -232,32 +232,41 @@ public:
      */
     std::vector<std::string> getParticipantNames() const;
 
+    FASTDDS_TODO_BEFORE(4, 0,
+            "Make RTPSParticipantAttributes a composition of RTPSParticipantConstantAttributes and RTPSParticipantMutableAttributes");
     /**
-     * Get a reference of the current state of the RTPSParticipantParameters.
+     * Get a reference of the current state of the RTPSParticipantAttributes.
      * @warning The returned reference is not thread safe. It is recommended to use copy_attributes()
      * instead to get a thread safe copy of the attributes.
      * @return RTPSParticipantAttributes reference.
      */
-    FASTDDS_TODO_BEFORE(4, 0,
-            "Make RTPSParticipantAttributes a composition of RTPSParticipantConstantAttributes and RTPSParticipantMutableAttributes");
     const RTPSParticipantAttributes& get_attributes() const;
 
+    FASTDDS_TODO_BEFORE(4, 0,
+            "Make RTPSParticipantAttributes a composition of RTPSParticipantConstantAttributes and RTPSParticipantMutableAttributes");
     /**
-     * @brief Get a const reference of the constant RTPSParticipantAttributes of this RTPSParticipantImpl.
+     * @brief Get a const reference of RTPSParticipantConstantAttributes of this RTPSParticipantImpl.
      * This method is thread safe because it returns a const reference to the internal attributes.
      * @warning It must not be used to access mutable attributes as it could return outdated values.
-     * @return A const reference to the RTPSParticipantAttributes of this RTPSParticipantImpl.
+     * @return A const reference to the RTPSParticipantConstantAttributes of this RTPSParticipantImpl.
      */
-    FASTDDS_TODO_BEFORE(4, 0,
-            "Make RTPSParticipantAttributes a composition of RTPSParticipantConstantAttributes and RTPSParticipantMutableAttributes");
     const RTPSParticipantConstantAttributes& get_const_attributes() const;
 
-    /**
-     * Get a copy of the current state of the RTPSParticipantParameters.
-     * @return RTPSParticipantAttributes copy.
-     */
     FASTDDS_TODO_BEFORE(4, 0,
             "Make RTPSParticipantAttributes a composition of RTPSParticipantConstantAttributes and RTPSParticipantMutableAttributes");
+    /**
+     * @brief Get a const copy of RTPSParticipantMutableAttributes of this RTPSParticipantImpl.
+     * This method is thread safe because it returns a const copy of the internal attributes.
+     * @return A const copy of the RTPSParticipantMutableAttributes of this RTPSParticipantImpl.
+     */
+    const RTPSParticipantMutableAttributes get_mutable_attributes() const;
+
+    FASTDDS_TODO_BEFORE(4, 0,
+            "Make RTPSParticipantAttributes a composition of RTPSParticipantConstantAttributes and RTPSParticipantMutableAttributes");
+    /**
+     * Get a copy of the current state of the RTPSParticipantAttributes.
+     * @return RTPSParticipantAttributes copy.
+     */
     RTPSParticipantAttributes copy_attributes() const;
 
     /**

--- a/include/fastdds/rtps/participant/RTPSParticipant.hpp
+++ b/include/fastdds/rtps/participant/RTPSParticipant.hpp
@@ -238,7 +238,8 @@ public:
      * instead to get a thread safe copy of the attributes.
      * @return RTPSParticipantAttributes reference.
      */
-    FASTDDS_TODO_BEFORE(4, 0, "Refactor to differentiate mutable and constant objects and make getters thread safe");
+    FASTDDS_TODO_BEFORE(4, 0,
+            "Make RTPSParticipantAttributes a composition of RTPSParticipantConstantAttributes and RTPSParticipantMutableAttributes");
     const RTPSParticipantAttributes& get_attributes() const;
 
     /**
@@ -247,14 +248,16 @@ public:
      * @warning It must not be used to access mutable attributes as it could return outdated values.
      * @return A const reference to the RTPSParticipantAttributes of this RTPSParticipantImpl.
      */
-    FASTDDS_TODO_BEFORE(4, 0, "Refactor to differentiate mutable and constant objects and make getters thread safe");
-    const RTPSParticipantAttributes& get_const_attributes() const;
+    FASTDDS_TODO_BEFORE(4, 0,
+            "Make RTPSParticipantAttributes a composition of RTPSParticipantConstantAttributes and RTPSParticipantMutableAttributes");
+    const RTPSParticipantConstantAttributes& get_const_attributes() const;
 
     /**
      * Get a copy of the current state of the RTPSParticipantParameters.
      * @return RTPSParticipantAttributes copy.
      */
-    FASTDDS_TODO_BEFORE(4, 0, "Refactor to differentiate mutable and constant objects and make getters thread safe");
+    FASTDDS_TODO_BEFORE(4, 0,
+            "Make RTPSParticipantAttributes a composition of RTPSParticipantConstantAttributes and RTPSParticipantMutableAttributes");
     RTPSParticipantAttributes copy_attributes() const;
 
     /**

--- a/include/fastdds/rtps/participant/RTPSParticipant.hpp
+++ b/include/fastdds/rtps/participant/RTPSParticipant.hpp
@@ -234,6 +234,8 @@ public:
 
     /**
      * Get a reference of the current state of the RTPSParticipantParameters.
+     * @warning The returned reference is not thread safe. It is recommended to use copy_attributes()
+     * instead to get a thread safe copy of the attributes.
      * @return RTPSParticipantAttributes reference.
      */
     FASTDDS_TODO_BEFORE(4, 0, "Make this method return a copy and delete copy_attributes()");

--- a/include/fastdds/rtps/participant/RTPSParticipant.hpp
+++ b/include/fastdds/rtps/participant/RTPSParticipant.hpp
@@ -238,13 +238,23 @@ public:
      * instead to get a thread safe copy of the attributes.
      * @return RTPSParticipantAttributes reference.
      */
-    FASTDDS_TODO_BEFORE(4, 0, "Make this method return a copy and delete copy_attributes()");
+    FASTDDS_TODO_BEFORE(4, 0, "Refactor to differentiate mutable and constant objects and make getters thread safe");
     const RTPSParticipantAttributes& get_attributes() const;
+
+    /**
+     * @brief Get a const reference of the constant RTPSParticipantAttributes of this RTPSParticipantImpl.
+     * This method is thread safe because it returns a const reference to the internal attributes.
+     * @warning It must not be used to access mutable attributes as it could return outdated values.
+     * @return A const reference to the RTPSParticipantAttributes of this RTPSParticipantImpl.
+     */
+    FASTDDS_TODO_BEFORE(4, 0, "Refactor to differentiate mutable and constant objects and make getters thread safe");
+    const RTPSParticipantAttributes& get_const_attributes() const;
 
     /**
      * Get a copy of the current state of the RTPSParticipantParameters.
      * @return RTPSParticipantAttributes copy.
      */
+    FASTDDS_TODO_BEFORE(4, 0, "Refactor to differentiate mutable and constant objects and make getters thread safe");
     RTPSParticipantAttributes copy_attributes() const;
 
     /**

--- a/include/fastdds/rtps/participant/RTPSParticipant.hpp
+++ b/include/fastdds/rtps/participant/RTPSParticipant.hpp
@@ -236,7 +236,14 @@ public:
      * Get a reference of the current state of the RTPSParticipantParameters.
      * @return RTPSParticipantAttributes reference.
      */
+    FASTDDS_TODO_BEFORE(4, 0, "Make this method return a copy and delete copy_attributes()");
     const RTPSParticipantAttributes& get_attributes() const;
+
+    /**
+     * Get a copy of the current state of the RTPSParticipantParameters.
+     * @return RTPSParticipantAttributes copy.
+     */
+    RTPSParticipantAttributes copy_attributes() const;
 
     /**
      * Retrieves the maximum message size.

--- a/include/fastdds/rtps/participant/RTPSParticipant.hpp
+++ b/include/fastdds/rtps/participant/RTPSParticipant.hpp
@@ -236,7 +236,7 @@ public:
      * Get a reference of the current state of the RTPSParticipantParameters.
      * @return RTPSParticipantAttributes reference.
      */
-    RTPSParticipantAttributes get_attributes() const;
+    const RTPSParticipantAttributes& get_attributes() const;
 
     /**
      * Retrieves the maximum message size.

--- a/src/cpp/fastdds/builtin/type_lookup_service/TypeLookupManager.cpp
+++ b/src/cpp/fastdds/builtin/type_lookup_service/TypeLookupManager.cpp
@@ -127,7 +127,7 @@ bool TypeLookupManager::init(
 {
     participant_ = protocols->mp_participantImpl;
     builtin_protocols_ = protocols;
-    auto locators_allocations = participant_->copy_attributes().allocation.locators;
+    const auto& locators_allocations = participant_->get_const_attributes().allocation.locators;
 
     local_instance_name_ = get_instance_name(participant_->getGuid());
 

--- a/src/cpp/fastdds/builtin/type_lookup_service/TypeLookupManager.cpp
+++ b/src/cpp/fastdds/builtin/type_lookup_service/TypeLookupManager.cpp
@@ -127,7 +127,7 @@ bool TypeLookupManager::init(
 {
     participant_ = protocols->mp_participantImpl;
     builtin_protocols_ = protocols;
-    auto locators_allocations = participant_->get_attributes().allocation.locators;
+    auto locators_allocations = participant_->copy_attributes().allocation.locators;
 
     local_instance_name_ = get_instance_name(participant_->getGuid());
 

--- a/src/cpp/fastdds/builtin/type_lookup_service/TypeLookupReplyListener.cpp
+++ b/src/cpp/fastdds/builtin/type_lookup_service/TypeLookupReplyListener.cpp
@@ -59,7 +59,7 @@ void TypeLookupReplyListener::start_reply_processor_thread()
                 };
         // Create and start the processing thread
         replies_processor_thread = eprosima::create_thread(thread_func,
-                        typelookup_manager_->participant_->get_attributes().typelookup_service_thread,
+                        typelookup_manager_->participant_->copy_attributes().typelookup_service_thread,
                         "dds.tls.replies.%u");
     }
 }

--- a/src/cpp/fastdds/builtin/type_lookup_service/TypeLookupReplyListener.cpp
+++ b/src/cpp/fastdds/builtin/type_lookup_service/TypeLookupReplyListener.cpp
@@ -59,7 +59,7 @@ void TypeLookupReplyListener::start_reply_processor_thread()
                 };
         // Create and start the processing thread
         replies_processor_thread = eprosima::create_thread(thread_func,
-                        typelookup_manager_->participant_->copy_attributes().typelookup_service_thread,
+                        typelookup_manager_->participant_->get_const_attributes().typelookup_service_thread,
                         "dds.tls.replies.%u");
     }
 }

--- a/src/cpp/fastdds/builtin/type_lookup_service/TypeLookupRequestListener.cpp
+++ b/src/cpp/fastdds/builtin/type_lookup_service/TypeLookupRequestListener.cpp
@@ -112,7 +112,7 @@ void TypeLookupRequestListener::start_request_processor_thread()
                 };
         // Create and start the processing thread
         request_processor_thread = eprosima::create_thread(thread_func,
-                        typelookup_manager_->participant_->get_attributes().typelookup_service_thread,
+                        typelookup_manager_->participant_->copy_attributes().typelookup_service_thread,
                         "dds.tls.requests.%u");
     }
 }

--- a/src/cpp/fastdds/builtin/type_lookup_service/TypeLookupRequestListener.cpp
+++ b/src/cpp/fastdds/builtin/type_lookup_service/TypeLookupRequestListener.cpp
@@ -112,7 +112,7 @@ void TypeLookupRequestListener::start_request_processor_thread()
                 };
         // Create and start the processing thread
         request_processor_thread = eprosima::create_thread(thread_func,
-                        typelookup_manager_->participant_->copy_attributes().typelookup_service_thread,
+                        typelookup_manager_->participant_->get_const_attributes().typelookup_service_thread,
                         "dds.tls.requests.%u");
     }
 }

--- a/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantImpl.cpp
@@ -432,7 +432,7 @@ ReturnCode_t DomainParticipantImpl::set_qos(
             else
             {
                 // Trigger update of network interfaces by calling update_attributes with current attributes
-                patt = rtps_participant->get_attributes();
+                patt = rtps_participant->copy_attributes();
             }
         }
     }

--- a/src/cpp/rtps/builtin/BuiltinProtocols.cpp
+++ b/src/cpp/rtps/builtin/BuiltinProtocols.cpp
@@ -86,7 +86,7 @@ bool BuiltinProtocols::initBuiltinProtocols(
 
     filter_server_remote_locators(p_part->network_factory());
 
-    const RTPSParticipantAllocationAttributes& allocation = p_part->get_attributes().allocation;
+    RTPSParticipantAllocationAttributes allocation = p_part->get_attributes().allocation;
 
     // PDP
     switch (m_att.discovery_config.discoveryProtocol)

--- a/src/cpp/rtps/builtin/BuiltinProtocols.cpp
+++ b/src/cpp/rtps/builtin/BuiltinProtocols.cpp
@@ -86,7 +86,7 @@ bool BuiltinProtocols::initBuiltinProtocols(
 
     filter_server_remote_locators(p_part->network_factory());
 
-    RTPSParticipantAllocationAttributes allocation = p_part->copy_attributes().allocation;
+    const RTPSParticipantAllocationAttributes& allocation = p_part->get_const_attributes().allocation;
 
     // PDP
     switch (m_att.discovery_config.discoveryProtocol)

--- a/src/cpp/rtps/builtin/BuiltinProtocols.cpp
+++ b/src/cpp/rtps/builtin/BuiltinProtocols.cpp
@@ -86,7 +86,7 @@ bool BuiltinProtocols::initBuiltinProtocols(
 
     filter_server_remote_locators(p_part->network_factory());
 
-    RTPSParticipantAllocationAttributes allocation = p_part->get_attributes().allocation;
+    RTPSParticipantAllocationAttributes allocation = p_part->copy_attributes().allocation;
 
     // PDP
     switch (m_att.discovery_config.discoveryProtocol)

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
@@ -755,7 +755,8 @@ void EDPSimple::assignRemoteEndpoints(
     const NetworkFactory& network = mp_RTPSParticipant->network_factory();
     uint32_t endp = pdata.m_available_builtin_endpoints;
     uint32_t auxendp;
-    bool use_multicast_locators = !mp_PDP->getRTPSParticipant()->get_const_attributes().builtin.avoid_builtin_multicast ||
+    bool use_multicast_locators =
+            !mp_PDP->getRTPSParticipant()->get_const_attributes().builtin.avoid_builtin_multicast ||
             pdata.metatraffic_locators.unicast.empty();
 
     auto temp_reader_proxy_data = get_temporary_reader_proxies_pool().get();

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
@@ -755,7 +755,7 @@ void EDPSimple::assignRemoteEndpoints(
     const NetworkFactory& network = mp_RTPSParticipant->network_factory();
     uint32_t endp = pdata.m_available_builtin_endpoints;
     uint32_t auxendp;
-    bool use_multicast_locators = !mp_PDP->getRTPSParticipant()->get_attributes().builtin.avoid_builtin_multicast ||
+    bool use_multicast_locators = !mp_PDP->getRTPSParticipant()->copy_attributes().builtin.avoid_builtin_multicast ||
             pdata.metatraffic_locators.unicast.empty();
 
     auto temp_reader_proxy_data = get_temporary_reader_proxies_pool().get();

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
@@ -755,7 +755,7 @@ void EDPSimple::assignRemoteEndpoints(
     const NetworkFactory& network = mp_RTPSParticipant->network_factory();
     uint32_t endp = pdata.m_available_builtin_endpoints;
     uint32_t auxendp;
-    bool use_multicast_locators = !mp_PDP->getRTPSParticipant()->copy_attributes().builtin.avoid_builtin_multicast ||
+    bool use_multicast_locators = !mp_PDP->getRTPSParticipant()->get_const_attributes().builtin.avoid_builtin_multicast ||
             pdata.metatraffic_locators.unicast.empty();
 
     auto temp_reader_proxy_data = get_temporary_reader_proxies_pool().get();

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPStatic.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPStatic.cpp
@@ -137,7 +137,7 @@ bool EDPStatic::initEDP(
     }
 
     // Check there is a Participant's property changing the exchange format.
-    auto& properties = mp_RTPSParticipant->get_attributes().properties.properties();
+    auto properties = mp_RTPSParticipant->get_attributes().properties.properties();
     for (auto& property : properties)
     {
         if (0 == property.name().compare(exchange_format_property_name))

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPStatic.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPStatic.cpp
@@ -137,8 +137,8 @@ bool EDPStatic::initEDP(
     }
 
     // Check there is a Participant's property changing the exchange format.
-    auto properties = mp_RTPSParticipant->copy_attributes().properties.properties();
-    for (auto& property : properties)
+    const auto& properties = mp_RTPSParticipant->get_const_attributes().properties.properties();
+    for (const auto& property : properties)
     {
         if (0 == property.name().compare(exchange_format_property_name))
         {

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPStatic.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPStatic.cpp
@@ -137,7 +137,7 @@ bool EDPStatic::initEDP(
     }
 
     // Check there is a Participant's property changing the exchange format.
-    auto properties = mp_RTPSParticipant->get_attributes().properties.properties();
+    auto properties = mp_RTPSParticipant->copy_attributes().properties.properties();
     for (auto& property : properties)
     {
         if (0 == property.name().compare(exchange_format_property_name))

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -179,7 +179,7 @@ ParticipantProxyData* PDP::add_participant_proxy_data(
         {
             // Pool is empty but limit has not been reached, so we create a new entry.
             ++participant_proxies_number_;
-            ret_val = new ParticipantProxyData(mp_RTPSParticipant->copy_attributes().allocation);
+            ret_val = new ParticipantProxyData(mp_RTPSParticipant->get_const_attributes().allocation);
             if (participant_guid != mp_RTPSParticipant->getGuid())
             {
                 ret_val->lease_duration_event = new TimedEvent(mp_RTPSParticipant->getEventResource(),
@@ -487,8 +487,7 @@ bool PDP::initPDP(
 {
     EPROSIMA_LOG_INFO(RTPS_PDP, "Beginning");
     mp_RTPSParticipant = part;
-    m_discovery = mp_RTPSParticipant->copy_attributes().builtin;
-    initial_announcements_ = m_discovery.discovery_config.initial_announcements;
+    initial_announcements_ = mp_RTPSParticipant->get_const_attributes().builtin.discovery_config.initial_announcements;
     //CREATE ENDPOINTS
     if (!createPDPEndpoints())
     {
@@ -967,7 +966,7 @@ ReaderProxyData* PDP::addReaderProxyData(
                     // Pool is empty but limit has not been reached, so we create a new entry.
                     ++reader_proxies_number_;
 
-                    auto allocations = mp_RTPSParticipant->copy_attributes().allocation;
+                    const auto& allocations = mp_RTPSParticipant->get_const_attributes().allocation;
 
                     ret_val = new ReaderProxyData(
                         allocations.locators.max_unicast_locators,
@@ -1055,7 +1054,7 @@ WriterProxyData* PDP::addWriterProxyData(
                     // Pool is empty but limit has not been reached, so we create a new entry.
                     ++writer_proxies_number_;
 
-                    auto allocations = mp_RTPSParticipant->copy_attributes().allocation;
+                    const auto& allocations = mp_RTPSParticipant->get_const_attributes().allocation;
 
                     ret_val = new WriterProxyData(
                         allocations.locators.max_unicast_locators,
@@ -1518,7 +1517,7 @@ void PDP::resend_ininitial_announcements()
 void PDP::set_external_participant_properties_(
         ParticipantProxyData* participant_data)
 {
-    auto part_attributes = mp_RTPSParticipant->copy_attributes();
+    const RTPSParticipantAttributes& part_attributes = mp_RTPSParticipant->get_const_attributes();
 
     // For each property add it if it should be sent (it is propagated)
     for (auto const& property : part_attributes.properties.properties())
@@ -1588,8 +1587,6 @@ static void set_builtin_endpoint_locators(
         const PDP* pdp,
         const BuiltinProtocols* builtin)
 {
-    RTPSParticipantAttributes pattr = pdp->getRTPSParticipant()->copy_attributes();
-
     auto part_data = pdp->getLocalParticipantProxyData();
     if (nullptr == part_data)
     {
@@ -1615,14 +1612,14 @@ static void set_builtin_endpoint_locators(
 
     // External locators are always taken from the same place
     endpoint.external_unicast_locators = pdp->builtin_attributes().metatraffic_external_unicast_locators;
-    endpoint.ignore_non_matching_locators = pattr.ignore_non_matching_locators;
+    endpoint.ignore_non_matching_locators = pdp->getRTPSParticipant()->get_const_attributes().ignore_non_matching_locators;
 }
 
 ReaderAttributes PDP::create_builtin_reader_attributes()
 {
     ReaderAttributes attributes;
 
-    RTPSParticipantAttributes pattr = getRTPSParticipant()->copy_attributes();
+    const RTPSParticipantAttributes& pattr = getRTPSParticipant()->get_const_attributes();
     set_builtin_matched_allocation(attributes.matched_writers_allocation, pattr);
 
     // Builtin endpoints are always reliable, transient local, keyed topics
@@ -1646,7 +1643,7 @@ WriterAttributes PDP::create_builtin_writer_attributes()
 {
     WriterAttributes attributes;
 
-    RTPSParticipantAttributes pattr = getRTPSParticipant()->copy_attributes();
+    const RTPSParticipantAttributes& pattr = getRTPSParticipant()->get_const_attributes();
     set_builtin_matched_allocation(attributes.matched_readers_allocation, pattr);
 
     // Builtin endpoints are always reliable, transient local, keyed topics

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -1517,7 +1517,7 @@ void PDP::resend_ininitial_announcements()
 void PDP::set_external_participant_properties_(
         ParticipantProxyData* participant_data)
 {
-    const RTPSParticipantAttributes& part_attributes = mp_RTPSParticipant->get_const_attributes();
+    const RTPSParticipantConstantAttributes& part_attributes = mp_RTPSParticipant->get_const_attributes();
 
     // For each property add it if it should be sent (it is propagated)
     for (auto const& property : part_attributes.properties.properties())
@@ -1565,7 +1565,7 @@ void PDP::set_external_participant_properties_(
 
 static void set_builtin_matched_allocation(
         ResourceLimitedContainerConfig& allocation,
-        const RTPSParticipantAttributes& pattr)
+        const RTPSParticipantConstantAttributes& pattr)
 {
     // Matched endpoints will depend on total number of participants
     allocation = pattr.allocation.participants;
@@ -1620,7 +1620,7 @@ ReaderAttributes PDP::create_builtin_reader_attributes()
 {
     ReaderAttributes attributes;
 
-    const RTPSParticipantAttributes& pattr = getRTPSParticipant()->get_const_attributes();
+    const RTPSParticipantConstantAttributes& pattr = getRTPSParticipant()->get_const_attributes();
     set_builtin_matched_allocation(attributes.matched_writers_allocation, pattr);
 
     // Builtin endpoints are always reliable, transient local, keyed topics
@@ -1644,7 +1644,7 @@ WriterAttributes PDP::create_builtin_writer_attributes()
 {
     WriterAttributes attributes;
 
-    const RTPSParticipantAttributes& pattr = getRTPSParticipant()->get_const_attributes();
+    const RTPSParticipantConstantAttributes& pattr = getRTPSParticipant()->get_const_attributes();
     set_builtin_matched_allocation(attributes.matched_readers_allocation, pattr);
 
     // Builtin endpoints are always reliable, transient local, keyed topics

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -306,12 +306,13 @@ std::string PDP::check_participant_type(
 void PDP::initializeParticipantProxyData(
         ParticipantProxyData* participant_data)
 {
-    RTPSParticipantAttributes attributes = mp_RTPSParticipant->copy_attributes();
+    RTPSParticipantMutableAttributes mutable_attrs = mp_RTPSParticipant->get_mutable_attributes();
     bool announce_locators = !mp_RTPSParticipant->is_intraprocess_only();
 
     from_guid_prefix_to_topic_key(participant_data->guid.guidPrefix, participant_data->key.value);
     participant_data->domain_id = mp_RTPSParticipant->get_domain_id();
-    participant_data->lease_duration = attributes.builtin.discovery_config.leaseDuration;
+    participant_data->lease_duration =
+            mp_RTPSParticipant->get_const_attributes().builtin.discovery_config.leaseDuration;
     //set_VendorId_eProsima(participant_data->m_VendorId);
     participant_data->vendor_id = c_VendorId_eProsima;
     participant_data->product_version.major = FASTDDS_VERSION_MAJOR;
@@ -324,7 +325,7 @@ void PDP::initializeParticipantProxyData(
 
     participant_data->m_available_builtin_endpoints |= builtin_endpoints_->builtin_endpoints();
 
-    if (attributes.builtin.use_WriterLivelinessProtocol)
+    if (mp_RTPSParticipant->get_const_attributes().builtin.use_WriterLivelinessProtocol)
     {
         participant_data->m_available_builtin_endpoints |=
                 fastdds::rtps::BUILTIN_ENDPOINT_PARTICIPANT_MESSAGE_DATA_WRITER;
@@ -370,13 +371,14 @@ void PDP::initializeParticipantProxyData(
 
     if (announce_locators)
     {
-        participant_data->m_network_configuration = attributes.builtin.network_configuration;
+        participant_data->m_network_configuration =
+                mp_RTPSParticipant->get_const_attributes().builtin.network_configuration;
 
-        for (const Locator_t& loc : attributes.defaultUnicastLocatorList)
+        for (const Locator_t& loc : mutable_attrs.defaultUnicastLocatorList)
         {
             participant_data->default_locators.add_unicast_locator(loc);
         }
-        for (const Locator_t& loc : attributes.defaultMulticastLocatorList)
+        for (const Locator_t& loc : mp_RTPSParticipant->get_const_attributes().defaultMulticastLocatorList)
         {
             participant_data->default_locators.add_multicast_locator(loc);
         }
@@ -394,7 +396,7 @@ void PDP::initializeParticipantProxyData(
         // If it has not been set, use guid
         if (persistent == c_GuidPrefix_Unknown)
         {
-            persistent = attributes.prefix;
+            persistent = mp_RTPSParticipant->get_const_attributes().prefix;
         }
 
         // If persistent is set, set it into the participant proxy
@@ -428,13 +430,13 @@ void PDP::initializeParticipantProxyData(
         }
 
         fastdds::rtps::network::external_locators::add_external_locators(*participant_data,
-                attributes.builtin.metatraffic_external_unicast_locators,
-                attributes.default_external_unicast_locators);
+                mutable_attrs.builtin.metatraffic_external_unicast_locators,
+                mutable_attrs.default_external_unicast_locators);
     }
 
-    participant_data->participant_name = std::string(attributes.getName());
+    participant_data->participant_name = std::string(mp_RTPSParticipant->get_const_attributes().getName());
 
-    participant_data->user_data = attributes.userData;
+    participant_data->user_data = mutable_attrs.userData;
 
 #if HAVE_SECURITY
     if (mp_RTPSParticipant->is_secure())
@@ -471,13 +473,17 @@ void PDP::initializeParticipantProxyData(
     // Fill wire_protocol qos
     participant_data->wire_protocol = dds::WireProtocolConfigQos();
     participant_data->wire_protocol->prefix = participant_data->guid.guidPrefix;
-    participant_data->wire_protocol->participant_id = attributes.participantID;
-    participant_data->wire_protocol->builtin = attributes.builtin;
-    participant_data->wire_protocol->port = attributes.port;
-    participant_data->wire_protocol->default_unicast_locator_list = attributes.defaultUnicastLocatorList;
-    participant_data->wire_protocol->default_multicast_locator_list = attributes.defaultMulticastLocatorList;
-    participant_data->wire_protocol->default_external_unicast_locators = attributes.default_external_unicast_locators;
-    participant_data->wire_protocol->ignore_non_matching_locators = attributes.ignore_non_matching_locators;
+    participant_data->wire_protocol->participant_id = mp_RTPSParticipant->get_const_attributes().participantID;
+    participant_data->wire_protocol->builtin.compose(mp_RTPSParticipant->get_const_attributes().builtin,
+            mutable_attrs.builtin);
+    participant_data->wire_protocol->port = mp_RTPSParticipant->get_const_attributes().port;
+    participant_data->wire_protocol->default_unicast_locator_list = mutable_attrs.defaultUnicastLocatorList;
+    participant_data->wire_protocol->default_multicast_locator_list =
+            mp_RTPSParticipant->get_const_attributes().defaultMulticastLocatorList;
+    participant_data->wire_protocol->default_external_unicast_locators =
+            mutable_attrs.default_external_unicast_locators;
+    participant_data->wire_protocol->ignore_non_matching_locators =
+            mp_RTPSParticipant->get_const_attributes().ignore_non_matching_locators;
 
     participant_data->should_send_optional_qos(mp_RTPSParticipant->should_send_optional_qos());
 }
@@ -487,7 +493,8 @@ bool PDP::initPDP(
 {
     EPROSIMA_LOG_INFO(RTPS_PDP, "Beginning");
     mp_RTPSParticipant = part;
-    initial_announcements_ = mp_RTPSParticipant->get_const_attributes().builtin.discovery_config.initial_announcements;
+    m_discovery = mp_RTPSParticipant->copy_attributes().builtin;
+    initial_announcements_ = m_discovery.discovery_config.initial_announcements;
     //CREATE ENDPOINTS
     if (!createPDPEndpoints())
     {

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -179,7 +179,7 @@ ParticipantProxyData* PDP::add_participant_proxy_data(
         {
             // Pool is empty but limit has not been reached, so we create a new entry.
             ++participant_proxies_number_;
-            ret_val = new ParticipantProxyData(mp_RTPSParticipant->get_attributes().allocation);
+            ret_val = new ParticipantProxyData(mp_RTPSParticipant->copy_attributes().allocation);
             if (participant_guid != mp_RTPSParticipant->getGuid())
             {
                 ret_val->lease_duration_event = new TimedEvent(mp_RTPSParticipant->getEventResource(),
@@ -306,7 +306,7 @@ std::string PDP::check_participant_type(
 void PDP::initializeParticipantProxyData(
         ParticipantProxyData* participant_data)
 {
-    RTPSParticipantAttributes attributes = mp_RTPSParticipant->get_attributes();
+    RTPSParticipantAttributes attributes = mp_RTPSParticipant->copy_attributes();
     bool announce_locators = !mp_RTPSParticipant->is_intraprocess_only();
 
     from_guid_prefix_to_topic_key(participant_data->guid.guidPrefix, participant_data->key.value);
@@ -487,7 +487,7 @@ bool PDP::initPDP(
 {
     EPROSIMA_LOG_INFO(RTPS_PDP, "Beginning");
     mp_RTPSParticipant = part;
-    m_discovery = mp_RTPSParticipant->get_attributes().builtin;
+    m_discovery = mp_RTPSParticipant->copy_attributes().builtin;
     initial_announcements_ = m_discovery.discovery_config.initial_announcements;
     //CREATE ENDPOINTS
     if (!createPDPEndpoints())
@@ -967,7 +967,7 @@ ReaderProxyData* PDP::addReaderProxyData(
                     // Pool is empty but limit has not been reached, so we create a new entry.
                     ++reader_proxies_number_;
 
-                    auto allocations = mp_RTPSParticipant->get_attributes().allocation;
+                    auto allocations = mp_RTPSParticipant->copy_attributes().allocation;
 
                     ret_val = new ReaderProxyData(
                         allocations.locators.max_unicast_locators,
@@ -1055,7 +1055,7 @@ WriterProxyData* PDP::addWriterProxyData(
                     // Pool is empty but limit has not been reached, so we create a new entry.
                     ++writer_proxies_number_;
 
-                    auto allocations = mp_RTPSParticipant->get_attributes().allocation;
+                    auto allocations = mp_RTPSParticipant->copy_attributes().allocation;
 
                     ret_val = new WriterProxyData(
                         allocations.locators.max_unicast_locators,
@@ -1518,7 +1518,7 @@ void PDP::resend_ininitial_announcements()
 void PDP::set_external_participant_properties_(
         ParticipantProxyData* participant_data)
 {
-    auto part_attributes = mp_RTPSParticipant->get_attributes();
+    auto part_attributes = mp_RTPSParticipant->copy_attributes();
 
     // For each property add it if it should be sent (it is propagated)
     for (auto const& property : part_attributes.properties.properties())
@@ -1588,7 +1588,7 @@ static void set_builtin_endpoint_locators(
         const PDP* pdp,
         const BuiltinProtocols* builtin)
 {
-    RTPSParticipantAttributes pattr = pdp->getRTPSParticipant()->get_attributes();
+    RTPSParticipantAttributes pattr = pdp->getRTPSParticipant()->copy_attributes();
 
     auto part_data = pdp->getLocalParticipantProxyData();
     if (nullptr == part_data)
@@ -1622,7 +1622,7 @@ ReaderAttributes PDP::create_builtin_reader_attributes()
 {
     ReaderAttributes attributes;
 
-    RTPSParticipantAttributes pattr = getRTPSParticipant()->get_attributes();
+    RTPSParticipantAttributes pattr = getRTPSParticipant()->copy_attributes();
     set_builtin_matched_allocation(attributes.matched_writers_allocation, pattr);
 
     // Builtin endpoints are always reliable, transient local, keyed topics
@@ -1646,7 +1646,7 @@ WriterAttributes PDP::create_builtin_writer_attributes()
 {
     WriterAttributes attributes;
 
-    RTPSParticipantAttributes pattr = getRTPSParticipant()->get_attributes();
+    RTPSParticipantAttributes pattr = getRTPSParticipant()->copy_attributes();
     set_builtin_matched_allocation(attributes.matched_readers_allocation, pattr);
 
     // Builtin endpoints are always reliable, transient local, keyed topics

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -1588,7 +1588,7 @@ static void set_builtin_endpoint_locators(
         const PDP* pdp,
         const BuiltinProtocols* builtin)
 {
-    const RTPSParticipantAttributes& pattr = pdp->getRTPSParticipant()->get_attributes();
+    RTPSParticipantAttributes pattr = pdp->getRTPSParticipant()->get_attributes();
 
     auto part_data = pdp->getLocalParticipantProxyData();
     if (nullptr == part_data)
@@ -1622,7 +1622,7 @@ ReaderAttributes PDP::create_builtin_reader_attributes()
 {
     ReaderAttributes attributes;
 
-    const RTPSParticipantAttributes& pattr = getRTPSParticipant()->get_attributes();
+    RTPSParticipantAttributes pattr = getRTPSParticipant()->get_attributes();
     set_builtin_matched_allocation(attributes.matched_writers_allocation, pattr);
 
     // Builtin endpoints are always reliable, transient local, keyed topics
@@ -1646,7 +1646,7 @@ WriterAttributes PDP::create_builtin_writer_attributes()
 {
     WriterAttributes attributes;
 
-    const RTPSParticipantAttributes& pattr = getRTPSParticipant()->get_attributes();
+    RTPSParticipantAttributes pattr = getRTPSParticipant()->get_attributes();
     set_builtin_matched_allocation(attributes.matched_readers_allocation, pattr);
 
     // Builtin endpoints are always reliable, transient local, keyed topics

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -1612,7 +1612,8 @@ static void set_builtin_endpoint_locators(
 
     // External locators are always taken from the same place
     endpoint.external_unicast_locators = pdp->builtin_attributes().metatraffic_external_unicast_locators;
-    endpoint.ignore_non_matching_locators = pdp->getRTPSParticipant()->get_const_attributes().ignore_non_matching_locators;
+    endpoint.ignore_non_matching_locators =
+            pdp->getRTPSParticipant()->get_const_attributes().ignore_non_matching_locators;
 }
 
 ReaderAttributes PDP::create_builtin_reader_attributes()

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
@@ -104,7 +104,7 @@ void PDPClient::initializeParticipantProxyData(
 {
     PDP::initializeParticipantProxyData(participant_data); // TODO: Remember that the PDP version USES security
 
-    auto discovery_config = getRTPSParticipant()->copy_attributes().builtin.discovery_config;
+    const auto& discovery_config = getRTPSParticipant()->get_const_attributes().builtin.discovery_config;
 
     if ((DiscoveryProtocol::CLIENT != discovery_config.discoveryProtocol) &&
             (DiscoveryProtocol::SUPER_CLIENT != discovery_config.discoveryProtocol))

--- a/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPClient.cpp
@@ -104,7 +104,7 @@ void PDPClient::initializeParticipantProxyData(
 {
     PDP::initializeParticipantProxyData(participant_data); // TODO: Remember that the PDP version USES security
 
-    auto discovery_config = getRTPSParticipant()->get_attributes().builtin.discovery_config;
+    auto discovery_config = getRTPSParticipant()->copy_attributes().builtin.discovery_config;
 
     if ((DiscoveryProtocol::CLIENT != discovery_config.discoveryProtocol) &&
             (DiscoveryProtocol::SUPER_CLIENT != discovery_config.discoveryProtocol))

--- a/src/cpp/rtps/builtin/discovery/participant/PDPListener.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPListener.cpp
@@ -123,7 +123,7 @@ void PDPListener::on_new_cache_change_added(
             }
 
             // Filter locators
-            const auto& pattr = parent_pdp_->getRTPSParticipant()->get_attributes();
+            auto pattr = parent_pdp_->getRTPSParticipant()->get_attributes();
             fastdds::rtps::network::external_locators::filter_remote_locators(temp_participant_data_,
                     pattr.builtin.metatraffic_external_unicast_locators, pattr.default_external_unicast_locators,
                     pattr.ignore_non_matching_locators);

--- a/src/cpp/rtps/builtin/discovery/participant/PDPListener.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPListener.cpp
@@ -49,7 +49,7 @@ namespace rtps {
 PDPListener::PDPListener(
         PDP* parent)
     : parent_pdp_(parent)
-    , temp_participant_data_(parent->getRTPSParticipant()->get_attributes().allocation)
+    , temp_participant_data_(parent->getRTPSParticipant()->copy_attributes().allocation)
 {
 }
 
@@ -123,7 +123,7 @@ void PDPListener::on_new_cache_change_added(
             }
 
             // Filter locators
-            auto pattr = parent_pdp_->getRTPSParticipant()->get_attributes();
+            auto pattr = parent_pdp_->getRTPSParticipant()->copy_attributes();
             fastdds::rtps::network::external_locators::filter_remote_locators(temp_participant_data_,
                     pattr.builtin.metatraffic_external_unicast_locators, pattr.default_external_unicast_locators,
                     pattr.ignore_non_matching_locators);

--- a/src/cpp/rtps/builtin/discovery/participant/PDPListener.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPListener.cpp
@@ -49,7 +49,7 @@ namespace rtps {
 PDPListener::PDPListener(
         PDP* parent)
     : parent_pdp_(parent)
-    , temp_participant_data_(parent->getRTPSParticipant()->copy_attributes().allocation)
+    , temp_participant_data_(parent->getRTPSParticipant()->get_const_attributes().allocation)
 {
 }
 

--- a/src/cpp/rtps/builtin/discovery/participant/PDPListener.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPListener.cpp
@@ -76,10 +76,11 @@ void PDPListener::on_new_cache_change_added(
     GUID_t guid;
     iHandle2GUID(guid, change->instanceHandle);
 
+    RTPSParticipantImpl* part = parent_pdp_->getRTPSParticipant();
     if (change->kind == ALIVE)
     {
         // Ignore announcement from own RTPSParticipant
-        if (guid == parent_pdp_->getRTPSParticipant()->getGuid())
+        if (guid == part->getGuid())
         {
             EPROSIMA_LOG_INFO(RTPS_PDP, "Message from own RTPSParticipant, removing");
             parent_pdp_->builtin_endpoints_->remove_from_pdp_reader_history(change);
@@ -105,14 +106,14 @@ void PDPListener::on_new_cache_change_added(
         CDRMessage_t msg(change->serializedPayload);
         temp_participant_data_.clear();
         if (temp_participant_data_.read_from_cdr_message(&msg, true,
-                parent_pdp_->getRTPSParticipant()->network_factory(),
+                part->network_factory(),
                 true, change_in->vendor_id))
         {
             // After correctly reading it
             change->instanceHandle = temp_participant_data_.m_key;
             guid = temp_participant_data_.guid;
 
-            if (parent_pdp_->getRTPSParticipant()->is_participant_ignored(guid.guidPrefix))
+            if (part->is_participant_ignored(guid.guidPrefix))
             {
                 return;
             }
@@ -123,10 +124,11 @@ void PDPListener::on_new_cache_change_added(
             }
 
             // Filter locators
-            auto pattr = parent_pdp_->getRTPSParticipant()->copy_attributes();
+            auto mutable_pattr = part->get_mutable_attributes();
             fastdds::rtps::network::external_locators::filter_remote_locators(temp_participant_data_,
-                    pattr.builtin.metatraffic_external_unicast_locators, pattr.default_external_unicast_locators,
-                    pattr.ignore_non_matching_locators);
+                    mutable_pattr.builtin.metatraffic_external_unicast_locators,
+                    mutable_pattr.default_external_unicast_locators,
+                    part->get_const_attributes().ignore_non_matching_locators);
 
             // Check if participant already exists (updated info)
             ParticipantProxyData* pdata = nullptr;
@@ -167,10 +169,10 @@ void PDPListener::on_new_cache_change_added(
 #ifdef FASTDDS_STATISTICS
             //! Removal of a participant proxy should trigger
             //! a connections update on the local participant connection list
-            if (nullptr != parent_pdp_->getRTPSParticipant()->get_connections_observer())
+            if (nullptr != part->get_connections_observer())
             {
-                parent_pdp_->getRTPSParticipant()->get_connections_observer()->on_local_entity_connections_change(
-                    parent_pdp_->getRTPSParticipant()->getGuid());
+                part->get_connections_observer()->on_local_entity_connections_change(
+                    part->getGuid());
             }
 #endif //FASTDDS_STATISTICS
             reader->getMutex().lock();

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -119,7 +119,7 @@ bool PDPServer::init(
     getRTPSParticipant()->enableReader(edp->publications_reader_.first);
 
     // Initialize server dedicated thread.
-    RTPSParticipantAttributes part_attr = getRTPSParticipant()->copy_attributes();
+    const RTPSParticipantAttributes& part_attr = getRTPSParticipant()->get_const_attributes();
     uint32_t id_for_thread = static_cast<uint32_t>(part_attr.participantID);
     const fastdds::rtps::ThreadSettings& thr_config = part_attr.discovery_server_thread;
     resource_event_thread_.init_thread(thr_config, "dds.ds_ev.%u", id_for_thread);
@@ -360,7 +360,7 @@ void PDPServer::initializeParticipantProxyData(
 {
     PDP::initializeParticipantProxyData(participant_data);
 
-    auto discovery_config = getRTPSParticipant()->copy_attributes().builtin.discovery_config;
+    const auto& discovery_config = getRTPSParticipant()->get_const_attributes().builtin.discovery_config;
 
     if (discovery_config.discoveryProtocol != DiscoveryProtocol::SERVER &&
             discovery_config.discoveryProtocol != DiscoveryProtocol::BACKUP)
@@ -395,7 +395,7 @@ void PDPServer::match_reliable_pdp_endpoints(
     auto endpoints = static_cast<fastdds::rtps::DiscoveryServerPDPEndpoints*>(builtin_endpoints_.get());
     const NetworkFactory& network = mp_RTPSParticipant->network_factory();
     uint32_t endp = pdata.m_available_builtin_endpoints;
-    bool use_multicast_locators = !mp_RTPSParticipant->copy_attributes().builtin.avoid_builtin_multicast ||
+    bool use_multicast_locators = !mp_RTPSParticipant->get_const_attributes().builtin.avoid_builtin_multicast ||
             pdata.metatraffic_locators.unicast.empty();
 
     // Only SERVER and CLIENT participants will be received. All builtin must be there

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -119,7 +119,7 @@ bool PDPServer::init(
     getRTPSParticipant()->enableReader(edp->publications_reader_.first);
 
     // Initialize server dedicated thread.
-    const RTPSParticipantAttributes& part_attr = getRTPSParticipant()->get_attributes();
+    RTPSParticipantAttributes part_attr = getRTPSParticipant()->get_attributes();
     uint32_t id_for_thread = static_cast<uint32_t>(part_attr.participantID);
     const fastdds::rtps::ThreadSettings& thr_config = part_attr.discovery_server_thread;
     resource_event_thread_.init_thread(thr_config, "dds.ds_ev.%u", id_for_thread);

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -119,7 +119,7 @@ bool PDPServer::init(
     getRTPSParticipant()->enableReader(edp->publications_reader_.first);
 
     // Initialize server dedicated thread.
-    const RTPSParticipantAttributes& part_attr = getRTPSParticipant()->get_const_attributes();
+    const RTPSParticipantConstantAttributes& part_attr = getRTPSParticipant()->get_const_attributes();
     uint32_t id_for_thread = static_cast<uint32_t>(part_attr.participantID);
     const fastdds::rtps::ThreadSettings& thr_config = part_attr.discovery_server_thread;
     resource_event_thread_.init_thread(thr_config, "dds.ds_ev.%u", id_for_thread);

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -119,7 +119,7 @@ bool PDPServer::init(
     getRTPSParticipant()->enableReader(edp->publications_reader_.first);
 
     // Initialize server dedicated thread.
-    RTPSParticipantAttributes part_attr = getRTPSParticipant()->get_attributes();
+    RTPSParticipantAttributes part_attr = getRTPSParticipant()->copy_attributes();
     uint32_t id_for_thread = static_cast<uint32_t>(part_attr.participantID);
     const fastdds::rtps::ThreadSettings& thr_config = part_attr.discovery_server_thread;
     resource_event_thread_.init_thread(thr_config, "dds.ds_ev.%u", id_for_thread);
@@ -360,7 +360,7 @@ void PDPServer::initializeParticipantProxyData(
 {
     PDP::initializeParticipantProxyData(participant_data);
 
-    auto discovery_config = getRTPSParticipant()->get_attributes().builtin.discovery_config;
+    auto discovery_config = getRTPSParticipant()->copy_attributes().builtin.discovery_config;
 
     if (discovery_config.discoveryProtocol != DiscoveryProtocol::SERVER &&
             discovery_config.discoveryProtocol != DiscoveryProtocol::BACKUP)
@@ -395,7 +395,7 @@ void PDPServer::match_reliable_pdp_endpoints(
     auto endpoints = static_cast<fastdds::rtps::DiscoveryServerPDPEndpoints*>(builtin_endpoints_.get());
     const NetworkFactory& network = mp_RTPSParticipant->network_factory();
     uint32_t endp = pdata.m_available_builtin_endpoints;
-    bool use_multicast_locators = !mp_RTPSParticipant->get_attributes().builtin.avoid_builtin_multicast ||
+    bool use_multicast_locators = !mp_RTPSParticipant->copy_attributes().builtin.avoid_builtin_multicast ||
             pdata.metatraffic_locators.unicast.empty();
 
     // Only SERVER and CLIENT participants will be received. All builtin must be there

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServerListener.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServerListener.cpp
@@ -155,7 +155,7 @@ void PDPServerListener::on_new_cache_change_added(
             EPROSIMA_LOG_INFO(RTPS_PDP_LISTENER, "Participant type " << participant_type_str);
             bool is_client = ret.second;
 
-            const auto& pattr = pdp_server()->getRTPSParticipant()->get_attributes();
+            auto pattr = pdp_server()->getRTPSParticipant()->get_attributes();
             fastdds::rtps::network::external_locators::filter_remote_locators(participant_data,
                     pattr.builtin.metatraffic_external_unicast_locators, pattr.default_external_unicast_locators,
                     pattr.ignore_non_matching_locators);

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServerListener.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServerListener.cpp
@@ -155,7 +155,7 @@ void PDPServerListener::on_new_cache_change_added(
             EPROSIMA_LOG_INFO(RTPS_PDP_LISTENER, "Participant type " << participant_type_str);
             bool is_client = ret.second;
 
-            auto pattr = pdp_server()->getRTPSParticipant()->get_attributes();
+            auto pattr = pdp_server()->getRTPSParticipant()->copy_attributes();
             fastdds::rtps::network::external_locators::filter_remote_locators(participant_data,
                     pattr.builtin.metatraffic_external_unicast_locators, pattr.default_external_unicast_locators,
                     pattr.ignore_non_matching_locators);

--- a/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
@@ -109,7 +109,7 @@ void PDPSimple::initializeParticipantProxyData(
 {
     PDP::initializeParticipantProxyData(participant_data);
 
-    auto discovery_config = getRTPSParticipant()->copy_attributes().builtin.discovery_config;
+    const auto& discovery_config = getRTPSParticipant()->get_const_attributes().builtin.discovery_config;
 
     if (discovery_config.use_SIMPLE_EndpointDiscoveryProtocol)
     {
@@ -348,8 +348,7 @@ bool PDPSimple::createPDPEndpoints()
 
 bool PDPSimple::create_dcps_participant_endpoints()
 {
-    RTPSParticipantAttributes pattr = mp_RTPSParticipant->copy_attributes();
-    const RTPSParticipantAllocationAttributes& allocation = pattr.allocation;
+    const RTPSParticipantAllocationAttributes& allocation = mp_RTPSParticipant->get_const_attributes().allocation;
     const BuiltinAttributes& builtin_att = mp_builtin->m_att;
     auto endpoints = dynamic_cast<fastdds::rtps::SimplePDPEndpoints*>(builtin_endpoints_.get());
     assert(nullptr != endpoints);
@@ -478,8 +477,7 @@ bool PDPSimple::create_dcps_participant_endpoints()
 #if HAVE_SECURITY
 bool PDPSimple::create_dcps_participant_secure_endpoints()
 {
-    RTPSParticipantAttributes pattr = mp_RTPSParticipant->copy_attributes();
-    const RTPSParticipantAllocationAttributes& allocation = pattr.allocation;
+    const RTPSParticipantAllocationAttributes& allocation = mp_RTPSParticipant->get_const_attributes().allocation;
     const BuiltinAttributes& builtin_att = mp_builtin->m_att;
     auto endpoints = dynamic_cast<fastdds::rtps::SimplePDPEndpointsSecure*>(builtin_endpoints_.get());
     assert(nullptr != endpoints);
@@ -664,7 +662,7 @@ void PDPSimple::match_pdp_remote_endpoints(
     auto endpoints = static_cast<fastdds::rtps::SimplePDPEndpoints*>(builtin_endpoints_.get());
 
     const NetworkFactory& network = mp_RTPSParticipant->network_factory();
-    bool use_multicast_locators = !mp_RTPSParticipant->copy_attributes().builtin.avoid_builtin_multicast ||
+    bool use_multicast_locators = !mp_RTPSParticipant->get_const_attributes().builtin.avoid_builtin_multicast ||
             pdata.metatraffic_locators.unicast.empty();
     const uint32_t endp = pdata.m_available_builtin_endpoints;
 

--- a/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
@@ -348,7 +348,7 @@ bool PDPSimple::createPDPEndpoints()
 
 bool PDPSimple::create_dcps_participant_endpoints()
 {
-    const RTPSParticipantAttributes& pattr = mp_RTPSParticipant->get_attributes();
+    RTPSParticipantAttributes pattr = mp_RTPSParticipant->get_attributes();
     const RTPSParticipantAllocationAttributes& allocation = pattr.allocation;
     const BuiltinAttributes& builtin_att = mp_builtin->m_att;
     auto endpoints = dynamic_cast<fastdds::rtps::SimplePDPEndpoints*>(builtin_endpoints_.get());
@@ -478,7 +478,7 @@ bool PDPSimple::create_dcps_participant_endpoints()
 #if HAVE_SECURITY
 bool PDPSimple::create_dcps_participant_secure_endpoints()
 {
-    const RTPSParticipantAttributes& pattr = mp_RTPSParticipant->get_attributes();
+    RTPSParticipantAttributes pattr = mp_RTPSParticipant->get_attributes();
     const RTPSParticipantAllocationAttributes& allocation = pattr.allocation;
     const BuiltinAttributes& builtin_att = mp_builtin->m_att;
     auto endpoints = dynamic_cast<fastdds::rtps::SimplePDPEndpointsSecure*>(builtin_endpoints_.get());

--- a/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
@@ -109,7 +109,7 @@ void PDPSimple::initializeParticipantProxyData(
 {
     PDP::initializeParticipantProxyData(participant_data);
 
-    auto discovery_config = getRTPSParticipant()->get_attributes().builtin.discovery_config;
+    auto discovery_config = getRTPSParticipant()->copy_attributes().builtin.discovery_config;
 
     if (discovery_config.use_SIMPLE_EndpointDiscoveryProtocol)
     {
@@ -348,7 +348,7 @@ bool PDPSimple::createPDPEndpoints()
 
 bool PDPSimple::create_dcps_participant_endpoints()
 {
-    RTPSParticipantAttributes pattr = mp_RTPSParticipant->get_attributes();
+    RTPSParticipantAttributes pattr = mp_RTPSParticipant->copy_attributes();
     const RTPSParticipantAllocationAttributes& allocation = pattr.allocation;
     const BuiltinAttributes& builtin_att = mp_builtin->m_att;
     auto endpoints = dynamic_cast<fastdds::rtps::SimplePDPEndpoints*>(builtin_endpoints_.get());
@@ -478,7 +478,7 @@ bool PDPSimple::create_dcps_participant_endpoints()
 #if HAVE_SECURITY
 bool PDPSimple::create_dcps_participant_secure_endpoints()
 {
-    RTPSParticipantAttributes pattr = mp_RTPSParticipant->get_attributes();
+    RTPSParticipantAttributes pattr = mp_RTPSParticipant->copy_attributes();
     const RTPSParticipantAllocationAttributes& allocation = pattr.allocation;
     const BuiltinAttributes& builtin_att = mp_builtin->m_att;
     auto endpoints = dynamic_cast<fastdds::rtps::SimplePDPEndpointsSecure*>(builtin_endpoints_.get());
@@ -664,7 +664,7 @@ void PDPSimple::match_pdp_remote_endpoints(
     auto endpoints = static_cast<fastdds::rtps::SimplePDPEndpoints*>(builtin_endpoints_.get());
 
     const NetworkFactory& network = mp_RTPSParticipant->network_factory();
-    bool use_multicast_locators = !mp_RTPSParticipant->get_attributes().builtin.avoid_builtin_multicast ||
+    bool use_multicast_locators = !mp_RTPSParticipant->copy_attributes().builtin.avoid_builtin_multicast ||
             pdata.metatraffic_locators.unicast.empty();
     const uint32_t endp = pdata.m_available_builtin_endpoints;
 

--- a/src/cpp/rtps/builtin/discovery/participant/simple/PDPStatelessWriter.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/simple/PDPStatelessWriter.cpp
@@ -48,7 +48,7 @@ PDPStatelessWriter::PDPStatelessWriter(
         WriterHistory* history,
         WriterListener* listener)
     : StatelessWriter(participant, guid, attributes, flow_controller, history, listener)
-    , interested_readers_(participant->get_attributes().allocation.participants)
+    , interested_readers_(participant->copy_attributes().allocation.participants)
 {
 }
 

--- a/src/cpp/rtps/builtin/discovery/participant/simple/PDPStatelessWriter.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/simple/PDPStatelessWriter.cpp
@@ -48,7 +48,7 @@ PDPStatelessWriter::PDPStatelessWriter(
         WriterHistory* history,
         WriterListener* listener)
     : StatelessWriter(participant, guid, attributes, flow_controller, history, listener)
-    , interested_readers_(participant->copy_attributes().allocation.participants)
+    , interested_readers_(participant->get_const_attributes().allocation.participants)
 {
 }
 

--- a/src/cpp/rtps/builtin/liveliness/WLP.cpp
+++ b/src/cpp/rtps/builtin/liveliness/WLP.cpp
@@ -236,7 +236,7 @@ bool WLP::initWL(
 
 bool WLP::createEndpoints()
 {
-    const RTPSParticipantAttributes& pattr = mp_participant->get_attributes();
+    RTPSParticipantAttributes pattr = mp_participant->get_attributes();
     const ResourceLimitedContainerConfig& participants_allocation = pattr.allocation.participants;
 
     // Built-in writer history
@@ -320,7 +320,7 @@ bool WLP::createEndpoints()
 
 bool WLP::createSecureEndpoints()
 {
-    const RTPSParticipantAttributes& pattr = mp_participant->get_attributes();
+    RTPSParticipantAttributes pattr = mp_participant->get_attributes();
     const ResourceLimitedContainerConfig& participants_allocation = pattr.allocation.participants;
 
     //CREATE WRITER

--- a/src/cpp/rtps/builtin/liveliness/WLP.cpp
+++ b/src/cpp/rtps/builtin/liveliness/WLP.cpp
@@ -108,14 +108,14 @@ WLP::WLP(
     , mp_builtinReaderSecureHistory(nullptr)
 #endif // if HAVE_SECURITY
     , temp_reader_proxy_data_(
-        p->mp_participantImpl->copy_attributes().allocation.locators.max_unicast_locators,
-        p->mp_participantImpl->copy_attributes().allocation.locators.max_multicast_locators,
-        p->mp_participantImpl->copy_attributes().allocation.data_limits,
-        p->mp_participantImpl->copy_attributes().allocation.content_filter)
+        p->mp_participantImpl->get_const_attributes().allocation.locators.max_unicast_locators,
+        p->mp_participantImpl->get_const_attributes().allocation.locators.max_multicast_locators,
+        p->mp_participantImpl->get_const_attributes().allocation.data_limits,
+        p->mp_participantImpl->get_const_attributes().allocation.content_filter)
     , temp_writer_proxy_data_(
-        p->mp_participantImpl->copy_attributes().allocation.locators.max_unicast_locators,
-        p->mp_participantImpl->copy_attributes().allocation.locators.max_multicast_locators,
-        p->mp_participantImpl->copy_attributes().allocation.data_limits)
+        p->mp_participantImpl->get_const_attributes().allocation.locators.max_unicast_locators,
+        p->mp_participantImpl->get_const_attributes().allocation.locators.max_multicast_locators,
+        p->mp_participantImpl->get_const_attributes().allocation.data_limits)
 {
     GUID_t tmp_guid = p->mp_participantImpl->getGuid();
     tmp_guid.entityId = 0;
@@ -236,8 +236,8 @@ bool WLP::initWL(
 
 bool WLP::createEndpoints()
 {
-    RTPSParticipantAttributes pattr = mp_participant->copy_attributes();
-    const ResourceLimitedContainerConfig& participants_allocation = pattr.allocation.participants;
+    const ResourceLimitedContainerConfig& participants_allocation =
+            mp_participant->get_const_attributes().allocation.participants;
 
     // Built-in writer history
     HistoryAttributes hatt;
@@ -320,8 +320,8 @@ bool WLP::createEndpoints()
 
 bool WLP::createSecureEndpoints()
 {
-    RTPSParticipantAttributes pattr = mp_participant->copy_attributes();
-    const ResourceLimitedContainerConfig& participants_allocation = pattr.allocation.participants;
+    const ResourceLimitedContainerConfig& participants_allocation =
+            mp_participant->get_const_attributes().allocation.participants;
 
     //CREATE WRITER
     HistoryAttributes hatt;
@@ -454,7 +454,7 @@ bool WLP::assignRemoteEndpoints(
     const NetworkFactory& network = mp_participant->network_factory();
     uint32_t endp = pdata.m_available_builtin_endpoints;
     uint32_t auxendp = endp;
-    bool use_multicast_locators = !mp_participant->copy_attributes().builtin.avoid_builtin_multicast ||
+    bool use_multicast_locators = !mp_participant->get_const_attributes().builtin.avoid_builtin_multicast ||
             pdata.metatraffic_locators.unicast.empty();
 
     std::lock_guard<std::mutex> data_guard(temp_data_lock_);

--- a/src/cpp/rtps/builtin/liveliness/WLP.cpp
+++ b/src/cpp/rtps/builtin/liveliness/WLP.cpp
@@ -108,14 +108,14 @@ WLP::WLP(
     , mp_builtinReaderSecureHistory(nullptr)
 #endif // if HAVE_SECURITY
     , temp_reader_proxy_data_(
-        p->mp_participantImpl->get_attributes().allocation.locators.max_unicast_locators,
-        p->mp_participantImpl->get_attributes().allocation.locators.max_multicast_locators,
-        p->mp_participantImpl->get_attributes().allocation.data_limits,
-        p->mp_participantImpl->get_attributes().allocation.content_filter)
+        p->mp_participantImpl->copy_attributes().allocation.locators.max_unicast_locators,
+        p->mp_participantImpl->copy_attributes().allocation.locators.max_multicast_locators,
+        p->mp_participantImpl->copy_attributes().allocation.data_limits,
+        p->mp_participantImpl->copy_attributes().allocation.content_filter)
     , temp_writer_proxy_data_(
-        p->mp_participantImpl->get_attributes().allocation.locators.max_unicast_locators,
-        p->mp_participantImpl->get_attributes().allocation.locators.max_multicast_locators,
-        p->mp_participantImpl->get_attributes().allocation.data_limits)
+        p->mp_participantImpl->copy_attributes().allocation.locators.max_unicast_locators,
+        p->mp_participantImpl->copy_attributes().allocation.locators.max_multicast_locators,
+        p->mp_participantImpl->copy_attributes().allocation.data_limits)
 {
     GUID_t tmp_guid = p->mp_participantImpl->getGuid();
     tmp_guid.entityId = 0;
@@ -236,7 +236,7 @@ bool WLP::initWL(
 
 bool WLP::createEndpoints()
 {
-    RTPSParticipantAttributes pattr = mp_participant->get_attributes();
+    RTPSParticipantAttributes pattr = mp_participant->copy_attributes();
     const ResourceLimitedContainerConfig& participants_allocation = pattr.allocation.participants;
 
     // Built-in writer history
@@ -320,7 +320,7 @@ bool WLP::createEndpoints()
 
 bool WLP::createSecureEndpoints()
 {
-    RTPSParticipantAttributes pattr = mp_participant->get_attributes();
+    RTPSParticipantAttributes pattr = mp_participant->copy_attributes();
     const ResourceLimitedContainerConfig& participants_allocation = pattr.allocation.participants;
 
     //CREATE WRITER
@@ -454,7 +454,7 @@ bool WLP::assignRemoteEndpoints(
     const NetworkFactory& network = mp_participant->network_factory();
     uint32_t endp = pdata.m_available_builtin_endpoints;
     uint32_t auxendp = endp;
-    bool use_multicast_locators = !mp_participant->get_attributes().builtin.avoid_builtin_multicast ||
+    bool use_multicast_locators = !mp_participant->copy_attributes().builtin.avoid_builtin_multicast ||
             pdata.metatraffic_locators.unicast.empty();
 
     std::lock_guard<std::mutex> data_guard(temp_data_lock_);

--- a/src/cpp/rtps/flowcontrol/FlowControllerFactory.cpp
+++ b/src/cpp/rtps/flowcontrol/FlowControllerFactory.cpp
@@ -15,7 +15,7 @@ void FlowControllerFactory::init(
 
     const ThreadSettings& sender_thread_settings =
             (nullptr == participant_) ? ThreadSettings{}
-            : participant_->get_attributes().builtin_controllers_sender_thread;
+            : participant_->copy_attributes().builtin_controllers_sender_thread;
 
     // PureSyncFlowController -> used by volatile besteffort writers.
     flow_controllers_.insert(decltype(flow_controllers_)::value_type(

--- a/src/cpp/rtps/flowcontrol/FlowControllerFactory.cpp
+++ b/src/cpp/rtps/flowcontrol/FlowControllerFactory.cpp
@@ -15,7 +15,7 @@ void FlowControllerFactory::init(
 
     const ThreadSettings& sender_thread_settings =
             (nullptr == participant_) ? ThreadSettings{}
-            : participant_->copy_attributes().builtin_controllers_sender_thread;
+            : participant_->get_const_attributes().builtin_controllers_sender_thread;
 
     // PureSyncFlowController -> used by volatile besteffort writers.
     flow_controllers_.insert(decltype(flow_controllers_)::value_type(

--- a/src/cpp/rtps/flowcontrol/FlowControllerImpl.hpp
+++ b/src/cpp/rtps/flowcontrol/FlowControllerImpl.hpp
@@ -992,7 +992,7 @@ public:
     {
         if (nullptr != participant)
         {
-            participant_id_ = static_cast<uint32_t>(participant->get_attributes().participantID);
+            participant_id_ = static_cast<uint32_t>(participant->copy_attributes().participantID);
         }
 
         uint32_t limitation = get_max_payload();

--- a/src/cpp/rtps/flowcontrol/FlowControllerImpl.hpp
+++ b/src/cpp/rtps/flowcontrol/FlowControllerImpl.hpp
@@ -992,7 +992,7 @@ public:
     {
         if (nullptr != participant)
         {
-            participant_id_ = static_cast<uint32_t>(participant->copy_attributes().participantID);
+            participant_id_ = static_cast<uint32_t>(participant->get_const_attributes().participantID);
         }
 
         uint32_t limitation = get_max_payload();

--- a/src/cpp/rtps/participant/RTPSParticipant.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipant.cpp
@@ -135,7 +135,7 @@ std::vector<std::string> RTPSParticipant::getParticipantNames() const
     return mp_impl->getParticipantNames();
 }
 
-const RTPSParticipantAttributes& RTPSParticipant::get_attributes() const
+RTPSParticipantAttributes RTPSParticipant::get_attributes() const
 {
     return mp_impl->get_attributes();
 }

--- a/src/cpp/rtps/participant/RTPSParticipant.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipant.cpp
@@ -140,6 +140,11 @@ const RTPSParticipantAttributes& RTPSParticipant::get_attributes() const
     return mp_impl->get_attributes();
 }
 
+RTPSParticipantAttributes RTPSParticipant::copy_attributes() const
+{
+    return mp_impl->copy_attributes();
+}
+
 uint32_t RTPSParticipant::getMaxMessageSize() const
 {
     return mp_impl->getMaxMessageSize();
@@ -315,4 +320,3 @@ bool RTPSParticipant::fill_discovery_data_from_cdr_message(
 } /* namespace rtps */
 } /* namespace fastdds */
 } /* namespace eprosima */
-

--- a/src/cpp/rtps/participant/RTPSParticipant.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipant.cpp
@@ -140,6 +140,11 @@ const RTPSParticipantAttributes& RTPSParticipant::get_attributes() const
     return mp_impl->get_attributes();
 }
 
+const RTPSParticipantAttributes& RTPSParticipant::get_const_attributes() const
+{
+    return mp_impl->get_const_attributes();
+}
+
 RTPSParticipantAttributes RTPSParticipant::copy_attributes() const
 {
     return mp_impl->copy_attributes();

--- a/src/cpp/rtps/participant/RTPSParticipant.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipant.cpp
@@ -140,7 +140,7 @@ const RTPSParticipantAttributes& RTPSParticipant::get_attributes() const
     return mp_impl->get_attributes();
 }
 
-const RTPSParticipantAttributes& RTPSParticipant::get_const_attributes() const
+const RTPSParticipantConstantAttributes& RTPSParticipant::get_const_attributes() const
 {
     return mp_impl->get_const_attributes();
 }

--- a/src/cpp/rtps/participant/RTPSParticipant.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipant.cpp
@@ -145,6 +145,11 @@ const RTPSParticipantConstantAttributes& RTPSParticipant::get_const_attributes()
     return mp_impl->get_const_attributes();
 }
 
+const RTPSParticipantMutableAttributes RTPSParticipant::get_mutable_attributes() const
+{
+    return mp_impl->get_mutable_attributes();
+}
+
 RTPSParticipantAttributes RTPSParticipant::copy_attributes() const
 {
     return mp_impl->copy_attributes();

--- a/src/cpp/rtps/participant/RTPSParticipant.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipant.cpp
@@ -135,7 +135,7 @@ std::vector<std::string> RTPSParticipant::getParticipantNames() const
     return mp_impl->getParticipantNames();
 }
 
-RTPSParticipantAttributes RTPSParticipant::get_attributes() const
+const RTPSParticipantAttributes& RTPSParticipant::get_attributes() const
 {
     return mp_impl->get_attributes();
 }

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1690,6 +1690,7 @@ void RTPSParticipantImpl::update_mutable_attributes(
     m_att.defaultUnicastLocatorList = patt.defaultUnicastLocatorList;
     m_att.default_external_unicast_locators = patt.default_external_unicast_locators;
     m_att.builtin.discovery_config.m_DiscoveryServers = patt.builtin.discovery_config.m_DiscoveryServers;
+    m_att.builtin.metatraffic_external_unicast_locators = patt.builtin.metatraffic_external_unicast_locators;
 }
 
 bool RTPSParticipantImpl::update_writer(

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -282,7 +282,7 @@ RTPSParticipantImpl::RTPSParticipantImpl(
         RTPSParticipantListener* plisten)
     : domain_id_(domain_id)
     , m_att(PParam)
-    , const_m_att(PParam)
+    , m_const_att(PParam)
     , m_guid(guidP, c_EntityId_RTPSParticipant)
     , mp_builtinProtocols(nullptr)
     , IdCounter(0)
@@ -3451,9 +3451,9 @@ const RTPSParticipantAttributes& RTPSParticipantImpl::get_attributes() const
     return m_att;
 }
 
-const RTPSParticipantAttributes& RTPSParticipantImpl::get_const_attributes() const
+const RTPSParticipantConstantAttributes& RTPSParticipantImpl::get_const_attributes() const
 {
-    return const_m_att;
+    return m_const_att;
 }
 
 RTPSParticipantAttributes RTPSParticipantImpl::copy_attributes() const

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1686,12 +1686,12 @@ void RTPSParticipantImpl::update_mutable_attributes(
         const RTPSParticipantAttributes& patt)
 {
     // NTS
-    m_att.userData = patt.userData;
-    m_att.builtin.metatrafficUnicastLocatorList = patt.builtin.metatrafficUnicastLocatorList;
-    m_att.defaultUnicastLocatorList = patt.defaultUnicastLocatorList;
-    m_att.default_external_unicast_locators = patt.default_external_unicast_locators;
     m_att.builtin.discovery_config.m_DiscoveryServers = patt.builtin.discovery_config.m_DiscoveryServers;
     m_att.builtin.metatraffic_external_unicast_locators = patt.builtin.metatraffic_external_unicast_locators;
+    m_att.builtin.metatrafficUnicastLocatorList = patt.builtin.metatrafficUnicastLocatorList;
+    m_att.default_external_unicast_locators = patt.default_external_unicast_locators;
+    m_att.defaultUnicastLocatorList = patt.defaultUnicastLocatorList;
+    m_att.userData = patt.userData;
 }
 
 bool RTPSParticipantImpl::update_writer(
@@ -3454,6 +3454,11 @@ const RTPSParticipantAttributes& RTPSParticipantImpl::get_attributes() const
 const RTPSParticipantConstantAttributes& RTPSParticipantImpl::get_const_attributes() const
 {
     return m_const_att;
+}
+
+const RTPSParticipantMutableAttributes RTPSParticipantImpl::get_mutable_attributes() const
+{
+    return RTPSParticipantMutableAttributes(m_att);
 }
 
 RTPSParticipantAttributes RTPSParticipantImpl::copy_attributes() const

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -3444,7 +3444,12 @@ dds::utils::TypePropagation RTPSParticipantImpl::type_propagation() const
     return dds::utils::to_type_propagation(m_att.properties);
 }
 
-RTPSParticipantAttributes RTPSParticipantImpl::get_attributes() const
+const RTPSParticipantAttributes& RTPSParticipantImpl::get_attributes() const
+{
+    return m_att;
+}
+
+RTPSParticipantAttributes RTPSParticipantImpl::copy_attributes() const
 {
     std::lock_guard<std::mutex> _(mutex_);
     return m_att;

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -2889,8 +2889,8 @@ void RTPSParticipantImpl::environment_file_has_changed()
         patt = m_att;
     }
     // Only if it is a server/backup or a client override
-    if (DiscoveryProtocol::SERVER == m_att.builtin.discovery_config.discoveryProtocol ||
-            DiscoveryProtocol::BACKUP == m_att.builtin.discovery_config.discoveryProtocol ||
+    if (DiscoveryProtocol::SERVER == patt.builtin.discovery_config.discoveryProtocol ||
+            DiscoveryProtocol::BACKUP == patt.builtin.discovery_config.discoveryProtocol ||
             client_override_)
     {
         if (load_environment_server_info(patt.builtin.discovery_config.m_DiscoveryServers))
@@ -2911,8 +2911,8 @@ void RTPSParticipantImpl::get_default_metatraffic_locators(
 {
     uint32_t metatraffic_multicast_port = att.port.getMulticastPort(domain_id_);
 
-    if (m_att.builtin.discovery_config.discoveryProtocol != DiscoveryProtocol::CLIENT &&
-            m_att.builtin.discovery_config.discoveryProtocol != DiscoveryProtocol::SUPER_CLIENT)
+    if (att.builtin.discovery_config.discoveryProtocol != DiscoveryProtocol::CLIENT &&
+            att.builtin.discovery_config.discoveryProtocol != DiscoveryProtocol::SUPER_CLIENT)
     {
         m_network_Factory.getDefaultMetatrafficMulticastLocators(att.builtin.metatrafficMulticastLocatorList,
                 metatraffic_multicast_port);
@@ -3421,12 +3421,16 @@ void RTPSParticipantImpl::update_removed_participant(
 {
     if (!remote_participant_locators.empty())
     {
-        std::lock_guard<std::timed_mutex> guard(m_send_resources_mutex_);
-        LocatorList_t initial_peers_and_ds = m_att.builtin.discovery_config.m_DiscoveryServers;
-        for (const Locator_t& locator : m_att.builtin.initialPeersList)
+        LocatorList_t initial_peers_and_ds;
         {
-            initial_peers_and_ds.push_back(locator);
+            std::lock_guard<std::mutex> _(mutex_);
+            initial_peers_and_ds = m_att.builtin.discovery_config.m_DiscoveryServers;
+            for (const Locator_t& locator : m_att.builtin.initialPeersList)
+            {
+                initial_peers_and_ds.push_back(locator);
+            }
         }
+        std::lock_guard<std::timed_mutex> guard(m_send_resources_mutex_);
         m_network_Factory.remove_participant_associated_send_resources(
             send_resource_list_,
             remote_participant_locators,

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -3440,7 +3440,7 @@ dds::utils::TypePropagation RTPSParticipantImpl::type_propagation() const
     return dds::utils::to_type_propagation(m_att.properties);
 }
 
-const RTPSParticipantAttributes& RTPSParticipantImpl::get_attributes() const
+RTPSParticipantAttributes RTPSParticipantImpl::get_attributes() const
 {
     std::lock_guard<std::mutex> _(mutex_);
     return m_att;

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -3440,7 +3440,7 @@ dds::utils::TypePropagation RTPSParticipantImpl::type_propagation() const
     return dds::utils::to_type_propagation(m_att.properties);
 }
 
-RTPSParticipantAttributes RTPSParticipantImpl::get_attributes() const
+const RTPSParticipantAttributes& RTPSParticipantImpl::get_attributes() const
 {
     std::lock_guard<std::mutex> _(mutex_);
     return m_att;

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -282,7 +282,6 @@ RTPSParticipantImpl::RTPSParticipantImpl(
         RTPSParticipantListener* plisten)
     : domain_id_(domain_id)
     , m_att(PParam)
-    , m_const_att(PParam)
     , m_guid(guidP, c_EntityId_RTPSParticipant)
     , mp_builtinProtocols(nullptr)
     , IdCounter(0)
@@ -345,6 +344,9 @@ RTPSParticipantImpl::RTPSParticipantImpl(
     }
 #endif // if HAVE_SECURITY
 
+    // Store the constant attributes. Need to do it at this point to ensure we capture the constant attributes
+    // set at "setup_" methods, but before setup_builtin_protocols, which already access constant values.
+    m_const_att = m_att;
     // Initialize builtin protocols
     if (!setup_builtin_protocols())
     {

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -3458,6 +3458,7 @@ const RTPSParticipantConstantAttributes& RTPSParticipantImpl::get_const_attribut
 
 const RTPSParticipantMutableAttributes RTPSParticipantImpl::get_mutable_attributes() const
 {
+    std::lock_guard<std::mutex> _(mutex_);
     return RTPSParticipantMutableAttributes(m_att);
 }
 

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -1671,7 +1671,7 @@ void RTPSParticipantImpl::update_attributes(
     // Update the attributes data member
     {
         std::lock_guard<std::mutex> _(mutex_);
-        m_att = temp_atts;
+        update_mutable_attributes(temp_atts);
     }
 
     if (update_pdp)
@@ -1679,6 +1679,17 @@ void RTPSParticipantImpl::update_attributes(
         // Send DATA(P)
         pdp->announceParticipantState(true);
     }
+}
+
+void RTPSParticipantImpl::update_mutable_attributes(
+        const RTPSParticipantAttributes& patt)
+{
+    // NTS
+    m_att.userData = patt.userData;
+    m_att.builtin.metatrafficUnicastLocatorList = patt.builtin.metatrafficUnicastLocatorList;
+    m_att.defaultUnicastLocatorList = patt.defaultUnicastLocatorList;
+    m_att.default_external_unicast_locators = patt.default_external_unicast_locators;
+    m_att.builtin.discovery_config.m_DiscoveryServers = patt.builtin.discovery_config.m_DiscoveryServers;
 }
 
 bool RTPSParticipantImpl::update_writer(

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -282,6 +282,7 @@ RTPSParticipantImpl::RTPSParticipantImpl(
         RTPSParticipantListener* plisten)
     : domain_id_(domain_id)
     , m_att(PParam)
+    , m_const_att(PParam)
     , m_guid(guidP, c_EntityId_RTPSParticipant)
     , mp_builtinProtocols(nullptr)
     , IdCounter(0)
@@ -344,7 +345,7 @@ RTPSParticipantImpl::RTPSParticipantImpl(
     }
 #endif // if HAVE_SECURITY
 
-    // Store the constant attributes. Need to do it at this point to ensure we capture the constant attributes
+    // Update constant attributes. Need to do it at this point to ensure we capture the constant attributes
     // set at "setup_" methods, but before setup_builtin_protocols, which already access constant values.
     m_const_att = m_att;
     // Initialize builtin protocols

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -2872,7 +2872,11 @@ DurabilityKind_t RTPSParticipantImpl::get_persistence_durability_red_line(
 
 void RTPSParticipantImpl::environment_file_has_changed()
 {
-    RTPSParticipantAttributes patt = m_att;
+    RTPSParticipantAttributes patt;
+    {
+        std::lock_guard<std::mutex> _(mutex_);
+        patt = m_att;
+    }
     // Only if it is a server/backup or a client override
     if (DiscoveryProtocol::SERVER == m_att.builtin.discovery_config.discoveryProtocol ||
             DiscoveryProtocol::BACKUP == m_att.builtin.discovery_config.discoveryProtocol ||
@@ -3427,6 +3431,7 @@ dds::utils::TypePropagation RTPSParticipantImpl::type_propagation() const
 
 const RTPSParticipantAttributes& RTPSParticipantImpl::get_attributes() const
 {
+    std::lock_guard<std::mutex> _(mutex_);
     return m_att;
 }
 

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -282,6 +282,7 @@ RTPSParticipantImpl::RTPSParticipantImpl(
         RTPSParticipantListener* plisten)
     : domain_id_(domain_id)
     , m_att(PParam)
+    , const_m_att(PParam)
     , m_guid(guidP, c_EntityId_RTPSParticipant)
     , mp_builtinProtocols(nullptr)
     , IdCounter(0)
@@ -3448,6 +3449,11 @@ dds::utils::TypePropagation RTPSParticipantImpl::type_propagation() const
 const RTPSParticipantAttributes& RTPSParticipantImpl::get_attributes() const
 {
     return m_att;
+}
+
+const RTPSParticipantAttributes& RTPSParticipantImpl::get_const_attributes() const
+{
+    return const_m_att;
 }
 
 RTPSParticipantAttributes RTPSParticipantImpl::copy_attributes() const

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.cpp
@@ -291,7 +291,7 @@ RTPSParticipantImpl::RTPSParticipantImpl(
     , internal_metatraffic_locators_(false)
     , internal_default_locators_(false)
 #if HAVE_SECURITY
-    , m_security_manager(this, *this)
+    , m_security_manager(this, PParam, *this)
 #endif // if HAVE_SECURITY
     , mp_participantListener(plisten)
     , mp_userParticipant(par)

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.hpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.hpp
@@ -1053,6 +1053,9 @@ public:
     void update_attributes(
             const RTPSParticipantAttributes& patt);
 
+    void update_mutable_attributes(
+        const RTPSParticipantAttributes& patt);
+
     /**
      * Update local writer QoS
      * @param rtps_writer Writer to update.

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.hpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.hpp
@@ -614,6 +614,8 @@ protected:
     uint32_t domain_id_;
     //!Attributes of the RTPSParticipant
     RTPSParticipantAttributes m_att;
+    //!Constant copy of Attributes of the RTPSParticipant
+    const RTPSParticipantAttributes const_m_att;
     //! Metatraffic unicast port used by default on this participant
     uint32_t metatraffic_unicast_port_ = 0;
     //! Default unicast port used by default on this participant
@@ -898,13 +900,23 @@ public:
      * it is recommended to use copy_attributes() instead.
      * @return RTPSParticipantAttributes of this RTPSParticipantImpl.
      */
-    FASTDDS_TODO_BEFORE(4, 0, "Make this method return a copy and delete copy_attributes()");
+    FASTDDS_TODO_BEFORE(4, 0, "Refactor to differentiate mutable and constant objects and make getters thread safe");
     const RTPSParticipantAttributes& get_attributes() const;
+
+    /**
+     * @brief Get a const reference of the constant RTPSParticipantAttributes of this RTPSParticipantImpl.
+     * This method is thread safe because it returns a const reference to the internal attributes.
+     * @warning It must not be used to access mutable attributes as it could return outdated values.
+     * @return A const reference to the RTPSParticipantAttributes of this RTPSParticipantImpl.
+     */
+    FASTDDS_TODO_BEFORE(4, 0, "Refactor to differentiate mutable and constant objects and make getters thread safe");
+    const RTPSParticipantAttributes& get_const_attributes() const;
 
     /**
      * @brief Get a copy of the RTPSParticipantAttributes of this RTPSParticipantImpl in a thread safe manner.
      * @return A copy of the RTPSParticipantAttributes of this RTPSParticipantImpl.
      */
+    FASTDDS_TODO_BEFORE(4, 0, "Refactor to differentiate mutable and constant objects and make getters thread safe");
     RTPSParticipantAttributes copy_attributes() const;
 
     /**

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.hpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.hpp
@@ -908,8 +908,7 @@ public:
             "Make RTPSParticipantAttributes a composition of RTPSParticipantConstantAttributes and RTPSParticipantMutableAttributes");
     /**
      * @brief Get a const reference of RTPSParticipantConstantAttributes of this RTPSParticipantImpl.
-     * This method is thread safe because it returns a const reference to the internal attributes.
-     * @warning It must not be used to access mutable attributes as it could return outdated values. Use get_mutable_attributes instead.
+     * This method is thread safe because it returns a const reference to the internal constant attributes.
      * @return A const reference to the RTPSParticipantConstantAttributes of this RTPSParticipantImpl.
      */
     const RTPSParticipantConstantAttributes& get_const_attributes() const;
@@ -918,7 +917,7 @@ public:
             "Make RTPSParticipantAttributes a composition of RTPSParticipantConstantAttributes and RTPSParticipantMutableAttributes");
     /**
      * @brief Get a const copy of RTPSParticipantMutableAttributes of this RTPSParticipantImpl.
-     * This method is thread safe because it returns a const copy of the internal attributes.
+     * This method is thread safe because it returns a const copy of the internal mutable attributes.
      * @return A const copy of the RTPSParticipantMutableAttributes of this RTPSParticipantImpl.
      */
     const RTPSParticipantMutableAttributes get_mutable_attributes() const;

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.hpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.hpp
@@ -615,7 +615,7 @@ protected:
     //!Attributes of the RTPSParticipant
     RTPSParticipantAttributes m_att;
     //!Constant copy of Attributes of the RTPSParticipant
-    const RTPSParticipantConstantAttributes m_const_att;
+    RTPSParticipantConstantAttributes m_const_att;
     //! Metatraffic unicast port used by default on this participant
     uint32_t metatraffic_unicast_port_ = 0;
     //! Default unicast port used by default on this participant

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.hpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.hpp
@@ -893,7 +893,9 @@ private:
 
 public:
 
-    RTPSParticipantAttributes get_attributes() const;
+    const RTPSParticipantAttributes& get_attributes() const;
+
+    RTPSParticipantAttributes copy_attributes() const;
 
     /**
      * Create a Writer in this RTPSParticipant.

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.hpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.hpp
@@ -615,7 +615,7 @@ protected:
     //!Attributes of the RTPSParticipant
     RTPSParticipantAttributes m_att;
     //!Constant copy of Attributes of the RTPSParticipant
-    const RTPSParticipantAttributes const_m_att;
+    const RTPSParticipantConstantAttributes m_const_att;
     //! Metatraffic unicast port used by default on this participant
     uint32_t metatraffic_unicast_port_ = 0;
     //! Default unicast port used by default on this participant
@@ -900,7 +900,8 @@ public:
      * it is recommended to use copy_attributes() instead.
      * @return RTPSParticipantAttributes of this RTPSParticipantImpl.
      */
-    FASTDDS_TODO_BEFORE(4, 0, "Refactor to differentiate mutable and constant objects and make getters thread safe");
+    FASTDDS_TODO_BEFORE(4, 0,
+            "Make RTPSParticipantAttributes a composition of RTPSParticipantConstantAttributes and RTPSParticipantMutableAttributes");
     const RTPSParticipantAttributes& get_attributes() const;
 
     /**
@@ -909,14 +910,16 @@ public:
      * @warning It must not be used to access mutable attributes as it could return outdated values.
      * @return A const reference to the RTPSParticipantAttributes of this RTPSParticipantImpl.
      */
-    FASTDDS_TODO_BEFORE(4, 0, "Refactor to differentiate mutable and constant objects and make getters thread safe");
-    const RTPSParticipantAttributes& get_const_attributes() const;
+    FASTDDS_TODO_BEFORE(4, 0,
+            "Make RTPSParticipantAttributes a composition of RTPSParticipantConstantAttributes and RTPSParticipantMutableAttributes");
+    const RTPSParticipantConstantAttributes& get_const_attributes() const;
 
     /**
      * @brief Get a copy of the RTPSParticipantAttributes of this RTPSParticipantImpl in a thread safe manner.
      * @return A copy of the RTPSParticipantAttributes of this RTPSParticipantImpl.
      */
-    FASTDDS_TODO_BEFORE(4, 0, "Refactor to differentiate mutable and constant objects and make getters thread safe");
+    FASTDDS_TODO_BEFORE(4, 0,
+            "Make RTPSParticipantAttributes a composition of RTPSParticipantConstantAttributes and RTPSParticipantMutableAttributes");
     RTPSParticipantAttributes copy_attributes() const;
 
     /**

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.hpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.hpp
@@ -893,7 +893,7 @@ private:
 
 public:
 
-    const RTPSParticipantAttributes& get_attributes() const;
+    RTPSParticipantAttributes get_attributes() const;
 
     /**
      * Create a Writer in this RTPSParticipant.

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.hpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.hpp
@@ -1066,7 +1066,7 @@ public:
             const RTPSParticipantAttributes& patt);
 
     void update_mutable_attributes(
-        const RTPSParticipantAttributes& patt);
+            const RTPSParticipantAttributes& patt);
 
     /**
      * Update local writer QoS

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.hpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.hpp
@@ -895,31 +895,40 @@ private:
 
 public:
 
+    FASTDDS_TODO_BEFORE(4, 0,
+            "Make RTPSParticipantAttributes a composition of RTPSParticipantConstantAttributes and RTPSParticipantMutableAttributes");
     /**
      * @brief Get the RTPSParticipantAttributes of this RTPSParticipantImpl. This method is not thread safe,
      * it is recommended to use copy_attributes() instead.
      * @return RTPSParticipantAttributes of this RTPSParticipantImpl.
      */
-    FASTDDS_TODO_BEFORE(4, 0,
-            "Make RTPSParticipantAttributes a composition of RTPSParticipantConstantAttributes and RTPSParticipantMutableAttributes");
     const RTPSParticipantAttributes& get_attributes() const;
 
-    /**
-     * @brief Get a const reference of the constant RTPSParticipantAttributes of this RTPSParticipantImpl.
-     * This method is thread safe because it returns a const reference to the internal attributes.
-     * @warning It must not be used to access mutable attributes as it could return outdated values.
-     * @return A const reference to the RTPSParticipantAttributes of this RTPSParticipantImpl.
-     */
     FASTDDS_TODO_BEFORE(4, 0,
             "Make RTPSParticipantAttributes a composition of RTPSParticipantConstantAttributes and RTPSParticipantMutableAttributes");
+    /**
+     * @brief Get a const reference of RTPSParticipantConstantAttributes of this RTPSParticipantImpl.
+     * This method is thread safe because it returns a const reference to the internal attributes.
+     * @warning It must not be used to access mutable attributes as it could return outdated values. Use get_mutable_attributes instead.
+     * @return A const reference to the RTPSParticipantConstantAttributes of this RTPSParticipantImpl.
+     */
     const RTPSParticipantConstantAttributes& get_const_attributes() const;
 
+    FASTDDS_TODO_BEFORE(4, 0,
+            "Make RTPSParticipantAttributes a composition of RTPSParticipantConstantAttributes and RTPSParticipantMutableAttributes");
+    /**
+     * @brief Get a const copy of RTPSParticipantMutableAttributes of this RTPSParticipantImpl.
+     * This method is thread safe because it returns a const copy of the internal attributes.
+     * @return A const copy of the RTPSParticipantMutableAttributes of this RTPSParticipantImpl.
+     */
+    const RTPSParticipantMutableAttributes get_mutable_attributes() const;
+
+    FASTDDS_TODO_BEFORE(4, 0,
+            "Make RTPSParticipantAttributes a composition of RTPSParticipantConstantAttributes and RTPSParticipantMutableAttributes");
     /**
      * @brief Get a copy of the RTPSParticipantAttributes of this RTPSParticipantImpl in a thread safe manner.
      * @return A copy of the RTPSParticipantAttributes of this RTPSParticipantImpl.
      */
-    FASTDDS_TODO_BEFORE(4, 0,
-            "Make RTPSParticipantAttributes a composition of RTPSParticipantConstantAttributes and RTPSParticipantMutableAttributes");
     RTPSParticipantAttributes copy_attributes() const;
 
     /**
@@ -1080,6 +1089,10 @@ public:
     void update_attributes(
             const RTPSParticipantAttributes& patt);
 
+    /**
+     * Update only mutable participant attributes.
+     * @param patt New participant attributes.
+     */
     void update_mutable_attributes(
             const RTPSParticipantAttributes& patt);
 

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.hpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.hpp
@@ -893,7 +893,7 @@ private:
 
 public:
 
-    RTPSParticipantAttributes get_attributes() const;
+    const RTPSParticipantAttributes& get_attributes() const;
 
     /**
      * Create a Writer in this RTPSParticipant.

--- a/src/cpp/rtps/participant/RTPSParticipantImpl.hpp
+++ b/src/cpp/rtps/participant/RTPSParticipantImpl.hpp
@@ -893,8 +893,18 @@ private:
 
 public:
 
+    /**
+     * @brief Get the RTPSParticipantAttributes of this RTPSParticipantImpl. This method is not thread safe,
+     * it is recommended to use copy_attributes() instead.
+     * @return RTPSParticipantAttributes of this RTPSParticipantImpl.
+     */
+    FASTDDS_TODO_BEFORE(4, 0, "Make this method return a copy and delete copy_attributes()");
     const RTPSParticipantAttributes& get_attributes() const;
 
+    /**
+     * @brief Get a copy of the RTPSParticipantAttributes of this RTPSParticipantImpl in a thread safe manner.
+     * @return A copy of the RTPSParticipantAttributes of this RTPSParticipantImpl.
+     */
     RTPSParticipantAttributes copy_attributes() const;
 
     /**

--- a/src/cpp/rtps/reader/BaseReader.cpp
+++ b/src/cpp/rtps/reader/BaseReader.cpp
@@ -133,7 +133,7 @@ BaseReader::~BaseReader()
 bool BaseReader::matched_writer_add(
         const PublicationBuiltinTopicData& info)
 {
-    const auto& alloc = mp_RTPSParticipant->get_attributes().allocation;
+    auto alloc = mp_RTPSParticipant->get_attributes().allocation;
     WriterProxyData wdata(alloc.data_limits, info);
 
     return matched_writer_add_edp(wdata);

--- a/src/cpp/rtps/reader/BaseReader.cpp
+++ b/src/cpp/rtps/reader/BaseReader.cpp
@@ -133,7 +133,7 @@ BaseReader::~BaseReader()
 bool BaseReader::matched_writer_add(
         const PublicationBuiltinTopicData& info)
 {
-    auto alloc = mp_RTPSParticipant->copy_attributes().allocation;
+    auto alloc = mp_RTPSParticipant->get_const_attributes().allocation;
     WriterProxyData wdata(alloc.data_limits, info);
 
     return matched_writer_add_edp(wdata);

--- a/src/cpp/rtps/reader/BaseReader.cpp
+++ b/src/cpp/rtps/reader/BaseReader.cpp
@@ -133,7 +133,7 @@ BaseReader::~BaseReader()
 bool BaseReader::matched_writer_add(
         const PublicationBuiltinTopicData& info)
 {
-    auto alloc = mp_RTPSParticipant->get_const_attributes().allocation;
+    const auto& alloc = mp_RTPSParticipant->get_const_attributes().allocation;
     WriterProxyData wdata(alloc.data_limits, info);
 
     return matched_writer_add_edp(wdata);

--- a/src/cpp/rtps/reader/BaseReader.cpp
+++ b/src/cpp/rtps/reader/BaseReader.cpp
@@ -133,7 +133,7 @@ BaseReader::~BaseReader()
 bool BaseReader::matched_writer_add(
         const PublicationBuiltinTopicData& info)
 {
-    auto alloc = mp_RTPSParticipant->get_attributes().allocation;
+    auto alloc = mp_RTPSParticipant->copy_attributes().allocation;
     WriterProxyData wdata(alloc.data_limits, info);
 
     return matched_writer_add_edp(wdata);

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -190,7 +190,7 @@ void StatefulReader::init(
         RTPSParticipantImpl* pimpl,
         const ReaderAttributes& att)
 {
-    const RTPSParticipantAttributes& part_att = pimpl->get_attributes();
+    RTPSParticipantAttributes part_att = pimpl->get_attributes();
     for (size_t n = 0; n < att.matched_writers_allocation.initial; ++n)
     {
         matched_writers_pool_.push_back(new WriterProxy(this, part_att.allocation.locators, proxy_changes_config_));
@@ -264,7 +264,7 @@ bool StatefulReader::matched_writer_add_edp(
             size_t max_readers = matched_writers_pool_.max_size();
             if (getMatchedWritersSize() + matched_writers_pool_.size() < max_readers)
             {
-                const RTPSParticipantAttributes& part_att = mp_RTPSParticipant->get_attributes();
+                RTPSParticipantAttributes part_att = mp_RTPSParticipant->get_attributes();
                 wp = new WriterProxy(this, part_att.allocation.locators, proxy_changes_config_);
             }
             else

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -190,7 +190,7 @@ void StatefulReader::init(
         RTPSParticipantImpl* pimpl,
         const ReaderAttributes& att)
 {
-    RTPSParticipantAttributes part_att = pimpl->get_attributes();
+    RTPSParticipantAttributes part_att = pimpl->copy_attributes();
     for (size_t n = 0; n < att.matched_writers_allocation.initial; ++n)
     {
         matched_writers_pool_.push_back(new WriterProxy(this, part_att.allocation.locators, proxy_changes_config_));
@@ -264,7 +264,7 @@ bool StatefulReader::matched_writer_add_edp(
             size_t max_readers = matched_writers_pool_.max_size();
             if (getMatchedWritersSize() + matched_writers_pool_.size() < max_readers)
             {
-                RTPSParticipantAttributes part_att = mp_RTPSParticipant->get_attributes();
+                RTPSParticipantAttributes part_att = mp_RTPSParticipant->copy_attributes();
                 wp = new WriterProxy(this, part_att.allocation.locators, proxy_changes_config_);
             }
             else

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -190,10 +190,9 @@ void StatefulReader::init(
         RTPSParticipantImpl* pimpl,
         const ReaderAttributes& att)
 {
-    RTPSParticipantAttributes part_att = pimpl->copy_attributes();
     for (size_t n = 0; n < att.matched_writers_allocation.initial; ++n)
     {
-        matched_writers_pool_.push_back(new WriterProxy(this, part_att.allocation.locators, proxy_changes_config_));
+        matched_writers_pool_.push_back(new WriterProxy(this, pimpl->get_const_attributes().allocation.locators, proxy_changes_config_));
     }
 }
 
@@ -264,8 +263,7 @@ bool StatefulReader::matched_writer_add_edp(
             size_t max_readers = matched_writers_pool_.max_size();
             if (getMatchedWritersSize() + matched_writers_pool_.size() < max_readers)
             {
-                RTPSParticipantAttributes part_att = mp_RTPSParticipant->copy_attributes();
-                wp = new WriterProxy(this, part_att.allocation.locators, proxy_changes_config_);
+                wp = new WriterProxy(this, mp_RTPSParticipant->get_const_attributes().allocation.locators, proxy_changes_config_);
             }
             else
             {

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -192,7 +192,8 @@ void StatefulReader::init(
 {
     for (size_t n = 0; n < att.matched_writers_allocation.initial; ++n)
     {
-        matched_writers_pool_.push_back(new WriterProxy(this, pimpl->get_const_attributes().allocation.locators, proxy_changes_config_));
+        matched_writers_pool_.push_back(new WriterProxy(this, pimpl->get_const_attributes().allocation.locators,
+                proxy_changes_config_));
     }
 }
 
@@ -263,7 +264,8 @@ bool StatefulReader::matched_writer_add_edp(
             size_t max_readers = matched_writers_pool_.max_size();
             if (getMatchedWritersSize() + matched_writers_pool_.size() < max_readers)
             {
-                wp = new WriterProxy(this, mp_RTPSParticipant->get_const_attributes().allocation.locators, proxy_changes_config_);
+                wp = new WriterProxy(this, mp_RTPSParticipant->get_const_attributes().allocation.locators,
+                                proxy_changes_config_);
             }
             else
             {

--- a/src/cpp/rtps/security/SecurityManager.cpp
+++ b/src/cpp/rtps/security/SecurityManager.cpp
@@ -88,6 +88,7 @@ static CacheChange_t* create_change_for_message(
 
 SecurityManager::SecurityManager(
         RTPSParticipantImpl* participant,
+        const RTPSParticipantAttributes& pattr,
         ISecurityPluginFactory& plugin_factory)
     : participant_stateless_message_listener_(*this)
     , participant_volatile_message_secure_listener_(*this)
@@ -97,14 +98,14 @@ SecurityManager::SecurityManager(
     , auth_last_sequence_number_(1)
     , crypto_last_sequence_number_(1)
     , temp_reader_proxies_({
-                participant->get_attributes().allocation.locators.max_unicast_locators,
-                participant->get_attributes().allocation.locators.max_multicast_locators,
-                participant->get_attributes().allocation.data_limits,
-                participant->get_attributes().allocation.content_filter})
+                pattr.allocation.locators.max_unicast_locators,
+                pattr.allocation.locators.max_multicast_locators,
+                pattr.allocation.data_limits,
+                pattr.allocation.content_filter})
     , temp_writer_proxies_({
-                participant->get_attributes().allocation.locators.max_unicast_locators,
-                participant->get_attributes().allocation.locators.max_multicast_locators,
-                participant->get_attributes().allocation.data_limits})
+                pattr.allocation.locators.max_unicast_locators,
+                pattr.allocation.locators.max_multicast_locators,
+                pattr.allocation.data_limits})
 {
     assert(participant != nullptr);
 }

--- a/src/cpp/rtps/security/SecurityManager.cpp
+++ b/src/cpp/rtps/security/SecurityManager.cpp
@@ -1124,7 +1124,7 @@ bool SecurityManager::create_participant_stateless_message_writer()
         participant_stateless_message_writer_hattr_,
         participant_stateless_message_pool_);
 
-    const RTPSParticipantAttributes& pattr = participant_->get_attributes();
+    RTPSParticipantAttributes pattr = participant_->get_attributes();
 
     WriterAttributes watt;
     watt.endpoint.external_unicast_locators = pattr.builtin.metatraffic_external_unicast_locators;
@@ -1173,7 +1173,7 @@ bool SecurityManager::create_participant_stateless_message_reader()
 {
     participant_stateless_message_reader_history_ = new ReaderHistory(participant_stateless_message_reader_hattr_);
 
-    const RTPSParticipantAttributes& pattr = participant_->get_attributes();
+    RTPSParticipantAttributes pattr = participant_->get_attributes();
 
     ReaderAttributes ratt;
     ratt.endpoint.topicKind = NO_KEY;
@@ -1272,7 +1272,7 @@ bool SecurityManager::create_participant_volatile_message_secure_writer()
     participant_volatile_message_secure_writer_history_ =
             new WriterHistory(participant_volatile_message_secure_hattr_, participant_volatile_message_secure_pool_);
 
-    const RTPSParticipantAttributes& pattr = participant_->get_attributes();
+    RTPSParticipantAttributes pattr = participant_->get_attributes();
 
     WriterAttributes watt;
     watt.endpoint.endpointKind = WRITER;
@@ -1325,7 +1325,7 @@ bool SecurityManager::create_participant_volatile_message_secure_reader()
     participant_volatile_message_secure_reader_history_ =
             new ReaderHistory(participant_volatile_message_secure_hattr_);
 
-    const RTPSParticipantAttributes& pattr = participant_->get_attributes();
+    RTPSParticipantAttributes pattr = participant_->get_attributes();
 
     ReaderAttributes ratt;
     ratt.endpoint.topicKind = NO_KEY;

--- a/src/cpp/rtps/security/SecurityManager.cpp
+++ b/src/cpp/rtps/security/SecurityManager.cpp
@@ -123,9 +123,8 @@ bool SecurityManager::init(
     try
     {
         domain_id_ = participant_->get_domain_id();
-        auto part_attributes = participant_->copy_attributes();
         const PropertyPolicy log_properties = PropertyPolicyHelper::get_properties_with_prefix(
-            part_attributes.properties,
+            participant_->get_const_attributes().properties,
             "dds.sec.log.builtin.DDS_LogTopic.");
 
         // length(log_properties) == 0 considered as logging disable.
@@ -214,7 +213,7 @@ bool SecurityManager::init(
         {
             // retrieve authentication properties, if any
             const PropertyPolicy auth_handshake_properties = PropertyPolicyHelper::get_properties_with_prefix(
-                part_attributes.properties,
+                participant_->get_const_attributes().properties,
                 "dds.sec.auth.builtin.PKI-DH.");
 
             // if auth_handshake_properties is empty, the default values are used
@@ -234,7 +233,7 @@ bool SecurityManager::init(
                 ret = authentication_plugin_->validate_local_identity(&local_identity_handle_,
                                 adjusted_participant_key,
                                 domain_id_,
-                                part_attributes,
+                                participant_->get_const_attributes().properties,
                                 participant_->getGuid(),
                                 exception);
             }
@@ -257,7 +256,7 @@ bool SecurityManager::init(
                     local_permissions_handle_ = access_plugin_->validate_local_permissions(
                         *authentication_plugin_, *local_identity_handle_,
                         domain_id_,
-                        part_attributes,
+                        participant_->get_const_attributes().properties,
                         exception);
 
                     if (local_permissions_handle_ != nullptr)
@@ -265,8 +264,7 @@ bool SecurityManager::init(
                         if (!local_permissions_handle_->nil())
                         {
                             if (access_plugin_->check_create_participant(*local_permissions_handle_,
-                                    domain_id_,
-                                    part_attributes, exception))
+                                    domain_id_, exception))
                             {
                                 // Set credentials.
                                 PermissionsCredentialToken* token = nullptr;

--- a/src/cpp/rtps/security/SecurityManager.cpp
+++ b/src/cpp/rtps/security/SecurityManager.cpp
@@ -123,7 +123,7 @@ bool SecurityManager::init(
     try
     {
         domain_id_ = participant_->get_domain_id();
-        auto part_attributes = participant_->get_attributes();
+        auto part_attributes = participant_->copy_attributes();
         const PropertyPolicy log_properties = PropertyPolicyHelper::get_properties_with_prefix(
             part_attributes.properties,
             "dds.sec.log.builtin.DDS_LogTopic.");
@@ -1124,7 +1124,7 @@ bool SecurityManager::create_participant_stateless_message_writer()
         participant_stateless_message_writer_hattr_,
         participant_stateless_message_pool_);
 
-    RTPSParticipantAttributes pattr = participant_->get_attributes();
+    RTPSParticipantAttributes pattr = participant_->copy_attributes();
 
     WriterAttributes watt;
     watt.endpoint.external_unicast_locators = pattr.builtin.metatraffic_external_unicast_locators;
@@ -1173,7 +1173,7 @@ bool SecurityManager::create_participant_stateless_message_reader()
 {
     participant_stateless_message_reader_history_ = new ReaderHistory(participant_stateless_message_reader_hattr_);
 
-    RTPSParticipantAttributes pattr = participant_->get_attributes();
+    RTPSParticipantAttributes pattr = participant_->copy_attributes();
 
     ReaderAttributes ratt;
     ratt.endpoint.topicKind = NO_KEY;
@@ -1272,7 +1272,7 @@ bool SecurityManager::create_participant_volatile_message_secure_writer()
     participant_volatile_message_secure_writer_history_ =
             new WriterHistory(participant_volatile_message_secure_hattr_, participant_volatile_message_secure_pool_);
 
-    RTPSParticipantAttributes pattr = participant_->get_attributes();
+    RTPSParticipantAttributes pattr = participant_->copy_attributes();
 
     WriterAttributes watt;
     watt.endpoint.endpointKind = WRITER;
@@ -1325,7 +1325,7 @@ bool SecurityManager::create_participant_volatile_message_secure_reader()
     participant_volatile_message_secure_reader_history_ =
             new ReaderHistory(participant_volatile_message_secure_hattr_);
 
-    RTPSParticipantAttributes pattr = participant_->get_attributes();
+    RTPSParticipantAttributes pattr = participant_->copy_attributes();
 
     ReaderAttributes ratt;
     ratt.endpoint.topicKind = NO_KEY;

--- a/src/cpp/rtps/security/SecurityManager.h
+++ b/src/cpp/rtps/security/SecurityManager.h
@@ -82,6 +82,7 @@ public:
      */
     SecurityManager(
             RTPSParticipantImpl* participant,
+            const RTPSParticipantAttributes& pattr,
             ISecurityPluginFactory& plugin_factory);
 
     // @brief Destructor

--- a/src/cpp/rtps/security/accesscontrol/AccessControl.h
+++ b/src/cpp/rtps/security/accesscontrol/AccessControl.h
@@ -48,7 +48,7 @@ public:
             Authentication& auth_plugin,
             const IdentityHandle& identity,
             const uint32_t domain_id,
-            const RTPSParticipantAttributes& participant_attr,
+            const PropertyPolicy& part_props,
             SecurityException& exception) = 0;
 
     virtual bool get_permissions_token(
@@ -88,7 +88,6 @@ public:
     virtual bool check_create_participant(
             const PermissionsHandle& local_handle,
             const uint32_t domain_id,
-            const RTPSParticipantAttributes& qos,
             SecurityException& exception) = 0;
 
     virtual bool check_remote_participant(

--- a/src/cpp/rtps/security/authentication/Authentication.h
+++ b/src/cpp/rtps/security/authentication/Authentication.h
@@ -80,7 +80,7 @@ public:
             IdentityHandle** local_identity_handle,
             GUID_t& adjusted_participant_key,
             const uint32_t domain_id,
-            const RTPSParticipantAttributes& participant_attr,
+            const PropertyPolicy& part_props,
             const GUID_t& candidate_participant_key,
             SecurityException& exception) = 0;
 

--- a/src/cpp/rtps/writer/BaseWriter.cpp
+++ b/src/cpp/rtps/writer/BaseWriter.cpp
@@ -117,7 +117,7 @@ BaseWriter::~BaseWriter()
 bool BaseWriter::matched_reader_add(
         const SubscriptionBuiltinTopicData& rqos)
 {
-    const auto& alloc = mp_RTPSParticipant->get_attributes().allocation;
+    auto alloc = mp_RTPSParticipant->get_attributes().allocation;
     ReaderProxyData rdata(alloc.data_limits, rqos);
 
     return matched_reader_add_edp(rdata);

--- a/src/cpp/rtps/writer/BaseWriter.cpp
+++ b/src/cpp/rtps/writer/BaseWriter.cpp
@@ -117,7 +117,7 @@ BaseWriter::~BaseWriter()
 bool BaseWriter::matched_reader_add(
         const SubscriptionBuiltinTopicData& rqos)
 {
-    auto alloc = mp_RTPSParticipant->get_attributes().allocation;
+    auto alloc = mp_RTPSParticipant->copy_attributes().allocation;
     ReaderProxyData rdata(alloc.data_limits, rqos);
 
     return matched_reader_add_edp(rdata);

--- a/src/cpp/rtps/writer/BaseWriter.cpp
+++ b/src/cpp/rtps/writer/BaseWriter.cpp
@@ -117,7 +117,7 @@ BaseWriter::~BaseWriter()
 bool BaseWriter::matched_reader_add(
         const SubscriptionBuiltinTopicData& rqos)
 {
-    auto alloc = mp_RTPSParticipant->copy_attributes().allocation;
+    const auto& alloc = mp_RTPSParticipant->get_attributes().allocation;
     ReaderProxyData rdata(alloc.data_limits, rqos);
 
     return matched_reader_add_edp(rdata);

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -210,7 +210,7 @@ void StatefulWriter::init(
         RTPSParticipantImpl* pimpl,
         const WriterAttributes& att)
 {
-    RTPSParticipantAttributes part_att = pimpl->get_attributes();
+    RTPSParticipantAttributes part_att = pimpl->copy_attributes();
 
     auto push_mode = PropertyPolicyHelper::find_property(att.endpoint.properties, "fastdds.push_mode");
     push_mode_ = !((nullptr != push_mode) && ("false" == *push_mode));
@@ -1038,7 +1038,7 @@ bool StatefulWriter::matched_reader_add_edp(
         size_t max_readers = matched_readers_pool_.max_size();
         if (get_matched_readers_size() + matched_readers_pool_.size() < max_readers)
         {
-            RTPSParticipantAttributes part_att = mp_RTPSParticipant->get_attributes();
+            RTPSParticipantAttributes part_att = mp_RTPSParticipant->copy_attributes();
             rp = new ReaderProxy(times_, part_att.allocation.locators, this, stateful_writer_listener_);
         }
         else

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -210,7 +210,7 @@ void StatefulWriter::init(
         RTPSParticipantImpl* pimpl,
         const WriterAttributes& att)
 {
-    const RTPSParticipantAttributes& part_att = pimpl->get_attributes();
+    RTPSParticipantAttributes part_att = pimpl->get_attributes();
 
     auto push_mode = PropertyPolicyHelper::find_property(att.endpoint.properties, "fastdds.push_mode");
     push_mode_ = !((nullptr != push_mode) && ("false" == *push_mode));
@@ -1038,7 +1038,7 @@ bool StatefulWriter::matched_reader_add_edp(
         size_t max_readers = matched_readers_pool_.max_size();
         if (get_matched_readers_size() + matched_readers_pool_.size() < max_readers)
         {
-            const RTPSParticipantAttributes& part_att = mp_RTPSParticipant->get_attributes();
+            RTPSParticipantAttributes part_att = mp_RTPSParticipant->get_attributes();
             rp = new ReaderProxy(times_, part_att.allocation.locators, this, stateful_writer_listener_);
         }
         else

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -210,7 +210,7 @@ void StatefulWriter::init(
         RTPSParticipantImpl* pimpl,
         const WriterAttributes& att)
 {
-    RTPSParticipantAttributes part_att = pimpl->copy_attributes();
+    const RTPSParticipantAttributes& part_att = pimpl->get_attributes();
 
     auto push_mode = PropertyPolicyHelper::find_property(att.endpoint.properties, "fastdds.push_mode");
     push_mode_ = !((nullptr != push_mode) && ("false" == *push_mode));
@@ -1038,7 +1038,7 @@ bool StatefulWriter::matched_reader_add_edp(
         size_t max_readers = matched_readers_pool_.max_size();
         if (get_matched_readers_size() + matched_readers_pool_.size() < max_readers)
         {
-            RTPSParticipantAttributes part_att = mp_RTPSParticipant->copy_attributes();
+            const RTPSParticipantAttributes& part_att = mp_RTPSParticipant->get_attributes();
             rp = new ReaderProxy(times_, part_att.allocation.locators, this, stateful_writer_listener_);
         }
         else

--- a/src/cpp/rtps/writer/StatelessWriter.cpp
+++ b/src/cpp/rtps/writer/StatelessWriter.cpp
@@ -170,7 +170,7 @@ void StatelessWriter::init(
 {
     get_builtin_guid();
 
-    const RemoteLocatorsAllocationAttributes& loc_alloc =
+    RemoteLocatorsAllocationAttributes loc_alloc =
             participant->get_attributes().allocation.locators;
 
     for (size_t i = 0; i < attributes.matched_readers_allocation.initial; ++i)
@@ -511,7 +511,7 @@ bool StatelessWriter::matched_reader_add_edp(
         size_t max_readers = matched_readers_pool_.max_size();
         if (get_matched_readers_size() + matched_readers_pool_.size() < max_readers)
         {
-            const RemoteLocatorsAllocationAttributes& loc_alloc =
+            RemoteLocatorsAllocationAttributes loc_alloc =
                     mp_RTPSParticipant->get_attributes().allocation.locators;
 
             new_reader.reset(new ReaderLocator(

--- a/src/cpp/rtps/writer/StatelessWriter.cpp
+++ b/src/cpp/rtps/writer/StatelessWriter.cpp
@@ -170,8 +170,8 @@ void StatelessWriter::init(
 {
     get_builtin_guid();
 
-    RemoteLocatorsAllocationAttributes loc_alloc =
-            participant->copy_attributes().allocation.locators;
+    const RemoteLocatorsAllocationAttributes& loc_alloc =
+            participant->get_attributes().allocation.locators;
 
     for (size_t i = 0; i < attributes.matched_readers_allocation.initial; ++i)
     {
@@ -511,8 +511,8 @@ bool StatelessWriter::matched_reader_add_edp(
         size_t max_readers = matched_readers_pool_.max_size();
         if (get_matched_readers_size() + matched_readers_pool_.size() < max_readers)
         {
-            RemoteLocatorsAllocationAttributes loc_alloc =
-                    mp_RTPSParticipant->copy_attributes().allocation.locators;
+            const RemoteLocatorsAllocationAttributes& loc_alloc =
+                    mp_RTPSParticipant->get_attributes().allocation.locators;
 
             new_reader.reset(new ReaderLocator(
                         this,

--- a/src/cpp/rtps/writer/StatelessWriter.cpp
+++ b/src/cpp/rtps/writer/StatelessWriter.cpp
@@ -171,7 +171,7 @@ void StatelessWriter::init(
     get_builtin_guid();
 
     RemoteLocatorsAllocationAttributes loc_alloc =
-            participant->get_attributes().allocation.locators;
+            participant->copy_attributes().allocation.locators;
 
     for (size_t i = 0; i < attributes.matched_readers_allocation.initial; ++i)
     {
@@ -512,7 +512,7 @@ bool StatelessWriter::matched_reader_add_edp(
         if (get_matched_readers_size() + matched_readers_pool_.size() < max_readers)
         {
             RemoteLocatorsAllocationAttributes loc_alloc =
-                    mp_RTPSParticipant->get_attributes().allocation.locators;
+                    mp_RTPSParticipant->copy_attributes().allocation.locators;
 
             new_reader.reset(new ReaderLocator(
                         this,

--- a/src/cpp/security/accesscontrol/Permissions.cpp
+++ b/src/cpp/security/accesscontrol/Permissions.cpp
@@ -818,10 +818,10 @@ PermissionsHandle* Permissions::validate_local_permissions(
         Authentication&,
         const IdentityHandle& identity,
         const uint32_t domain_id,
-        const RTPSParticipantAttributes& participant_attr,
+        const PropertyPolicy& part_props,
         SecurityException& exception)
 {
-    PropertyPolicy access_properties = PropertyPolicyHelper::get_properties_with_prefix(participant_attr.properties,
+    PropertyPolicy access_properties = PropertyPolicyHelper::get_properties_with_prefix(part_props,
                     "dds.sec.access.builtin.Access-Permissions.");
 
     if (PropertyPolicyHelper::length(access_properties) == 0)
@@ -1071,7 +1071,6 @@ PermissionsHandle* Permissions::validate_remote_permissions(
 bool Permissions::check_create_participant(
         const PermissionsHandle& local_handle,
         const uint32_t /*domain_id*/,
-        const RTPSParticipantAttributes&,
         SecurityException& exception)
 {
     bool returned_value = false;

--- a/src/cpp/security/accesscontrol/Permissions.h
+++ b/src/cpp/security/accesscontrol/Permissions.h
@@ -37,7 +37,7 @@ public:
             Authentication& auth_plugin,
             const IdentityHandle& identity,
             const uint32_t domain_id,
-            const RTPSParticipantAttributes& participant_attr,
+            const PropertyPolicy& part_props,
             SecurityException& exception) override;
 
     bool get_permissions_token(
@@ -77,7 +77,6 @@ public:
     bool check_create_participant(
             const PermissionsHandle& local_handle,
             const uint32_t domain_id,
-            const RTPSParticipantAttributes& qos,
             SecurityException& exception) override;
 
     bool check_remote_participant(

--- a/src/cpp/security/authentication/PKIDH.cpp
+++ b/src/cpp/security/authentication/PKIDH.cpp
@@ -1065,13 +1065,13 @@ ValidationResult_t PKIDH::validate_local_identity(
         IdentityHandle** local_identity_handle,
         GUID_t& adjusted_participant_key,
         const uint32_t /*domain_id*/,
-        const RTPSParticipantAttributes& participant_attr,
+        const PropertyPolicy& part_props,
         const GUID_t& candidate_participant_key,
         SecurityException& exception)
 {
     assert(local_identity_handle);
 
-    PropertyPolicy auth_properties = PropertyPolicyHelper::get_properties_with_prefix(participant_attr.properties,
+    PropertyPolicy auth_properties = PropertyPolicyHelper::get_properties_with_prefix(part_props,
                     "dds.sec.auth.builtin.PKI-DH.");
 
     if (PropertyPolicyHelper::length(auth_properties) == 0)

--- a/src/cpp/security/authentication/PKIDH.h
+++ b/src/cpp/security/authentication/PKIDH.h
@@ -37,7 +37,7 @@ public:
             IdentityHandle** local_identity_handle,
             GUID_t& adjusted_participant_key,
             const uint32_t domain_id,
-            const RTPSParticipantAttributes& participant_attr,
+            const PropertyPolicy& part_props,
             const GUID_t& candidate_participant_key,
             SecurityException& exception) override;
 

--- a/test/mock/rtps/RTPSParticipant/fastdds/rtps/participant/RTPSParticipant.hpp
+++ b/test/mock/rtps/RTPSParticipant/fastdds/rtps/participant/RTPSParticipant.hpp
@@ -237,6 +237,11 @@ public:
         return const_attributes_;
     }
 
+    const RTPSParticipantMutableAttributes get_mutable_attributes() const
+    {
+        return RTPSParticipantMutableAttributes{attributes_};
+    }
+
     RTPSParticipantAttributes copy_attributes() const
     {
         return attributes_;

--- a/test/mock/rtps/RTPSParticipant/fastdds/rtps/participant/RTPSParticipant.hpp
+++ b/test/mock/rtps/RTPSParticipant/fastdds/rtps/participant/RTPSParticipant.hpp
@@ -232,9 +232,9 @@ public:
         return attributes_;
     }
 
-    const RTPSParticipantAttributes& get_const_attributes() const
+    const RTPSParticipantConstantAttributes& get_const_attributes() const
     {
-        return attributes_;
+        return const_attributes_;
     }
 
     RTPSParticipantAttributes copy_attributes() const
@@ -271,6 +271,7 @@ public:
     const GUID_t m_guid;
     mutable ResourceEvent mp_event_thr;
     RTPSParticipantAttributes attributes_;
+    RTPSParticipantConstantAttributes const_attributes_;
     RTPSParticipantImpl* mp_impl;
 };
 

--- a/test/mock/rtps/RTPSParticipant/fastdds/rtps/participant/RTPSParticipant.hpp
+++ b/test/mock/rtps/RTPSParticipant/fastdds/rtps/participant/RTPSParticipant.hpp
@@ -232,6 +232,11 @@ public:
         return attributes_;
     }
 
+    RTPSParticipantAttributes copy_attributes() const
+    {
+        return attributes_;
+    }
+
     MOCK_METHOD(bool, get_publication_info,
             (fastdds::rtps::PublicationBuiltinTopicData&,
             const GUID_t&), (const));

--- a/test/mock/rtps/RTPSParticipant/fastdds/rtps/participant/RTPSParticipant.hpp
+++ b/test/mock/rtps/RTPSParticipant/fastdds/rtps/participant/RTPSParticipant.hpp
@@ -232,6 +232,11 @@ public:
         return attributes_;
     }
 
+    const RTPSParticipantAttributes& get_const_attributes() const
+    {
+        return attributes_;
+    }
+
     RTPSParticipantAttributes copy_attributes() const
     {
         return attributes_;

--- a/test/mock/rtps/RTPSParticipantAttributes/fastdds/rtps/attributes/RTPSParticipantAttributes.hpp
+++ b/test/mock/rtps/RTPSParticipantAttributes/fastdds/rtps/attributes/RTPSParticipantAttributes.hpp
@@ -333,6 +333,37 @@ private:
 };
 
 /**
+ * Class MutableDiscoverySettings, to define the mutable attributes of the several discovery protocols available
+ * @ingroup RTPS_ATTRIBUTES_MODULE
+ */
+class MutableDiscoverySettings
+{
+public:
+
+    //! Discovery Server initial connections, needed if `discoveryProtocol` = CLIENT | SUPER_CLIENT | SERVER | BACKUP
+    eprosima::fastdds::rtps::LocatorList m_DiscoveryServers;
+
+    MutableDiscoverySettings() = default;
+
+    MutableDiscoverySettings(
+            const DiscoverySettings& discovery_settings)
+        : m_DiscoveryServers(discovery_settings.m_DiscoveryServers)
+    {
+    }
+
+    bool operator ==(
+            const MutableDiscoverySettings& b) const
+    {
+        return (this->m_DiscoveryServers == b.m_DiscoveryServers);
+    }
+
+};
+
+// Forward declaration to allow assignment from Constant and Mutable attributes.
+class BuiltinConstantAttributes;
+class BuiltinMutableAttributes;
+
+/**
  * Class BuiltinAttributes, to define the behavior of the RTPSParticipant builtin protocols.
  * @ingroup RTPS_ATTRIBUTES_MODULE
  */
@@ -388,6 +419,17 @@ public:
 
     virtual ~BuiltinAttributes() = default;
 
+    /**
+     * Composes this object from a BuiltinConstantAttributes and a BuiltinMutableAttributes.
+     * Every field is assigned: constant fields are taken from @c builtin_const, mutable fields
+     * are taken from @c builtin_mutable.
+     * @param builtin_const Constant builtin attributes to copy from.
+     * @param builtin_mutable Mutable builtin attributes to copy from.
+     */
+    void compose(
+            const BuiltinConstantAttributes& builtin_const,
+            const BuiltinMutableAttributes& builtin_mutable);
+
     bool operator ==(
             const BuiltinAttributes& b) const
     {
@@ -418,11 +460,11 @@ class BuiltinMutableAttributes
 {
 public:
 
+    //! Discovery protocol related attributes
+    MutableDiscoverySettings discovery_config;
+
     //! Metatraffic Unicast Locator List
     LocatorList_t metatrafficUnicastLocatorList;
-
-    //! Metatraffic Multicast Locator List.
-    LocatorList_t metatrafficMulticastLocatorList;
 
     //! The collection of external locators to use for communication on metatraffic topics.
     fastdds::rtps::ExternalLocators metatraffic_external_unicast_locators;
@@ -431,8 +473,8 @@ public:
 
     BuiltinMutableAttributes(
             const BuiltinAttributes& builtin)
-        : metatrafficUnicastLocatorList(builtin.metatrafficUnicastLocatorList)
-        , metatrafficMulticastLocatorList(builtin.metatrafficMulticastLocatorList)
+        : discovery_config(builtin.discovery_config)
+        , metatrafficUnicastLocatorList(builtin.metatrafficUnicastLocatorList)
         , metatraffic_external_unicast_locators(builtin.metatraffic_external_unicast_locators)
     {
     }
@@ -442,8 +484,8 @@ public:
     bool operator ==(
             const BuiltinMutableAttributes& b) const
     {
-        return (this->metatrafficUnicastLocatorList == b.metatrafficUnicastLocatorList) &&
-               (this->metatrafficMulticastLocatorList == b.metatrafficMulticastLocatorList) &&
+        return (this->discovery_config == b.discovery_config) &&
+               (this->metatrafficUnicastLocatorList == b.metatrafficUnicastLocatorList) &&
                (this->metatraffic_external_unicast_locators == b.metatraffic_external_unicast_locators);
     }
 
@@ -458,7 +500,10 @@ class BuiltinConstantAttributes
 {
 public:
 
-    //! Discovery protocol related attributes
+    /**
+     * Discovery protocol related attributes. Only the discovery server list is mutable, which must be
+     * accessed through the BuiltinMutableAttributes class. Its value in this class is only used as initial value.
+     */
     DiscoverySettings discovery_config;
 
     //! Indicates to use the WriterLiveliness protocol.
@@ -466,6 +511,9 @@ public:
 
     //! Network Configuration
     NetworkConfigSet_t network_configuration = 0;
+
+    //! Metatraffic Multicast Locator List
+    LocatorList_t metatrafficMulticastLocatorList;
 
     //! Initial peers.
     LocatorList_t initialPeersList;
@@ -500,6 +548,7 @@ public:
         : discovery_config(builtin.discovery_config)
         , use_WriterLivelinessProtocol(builtin.use_WriterLivelinessProtocol)
         , network_configuration(builtin.network_configuration)
+        , metatrafficMulticastLocatorList(builtin.metatrafficMulticastLocatorList)
         , initialPeersList(builtin.initialPeersList)
         , readerHistoryMemoryPolicy(builtin.readerHistoryMemoryPolicy)
         , readerPayloadSize(builtin.readerPayloadSize)
@@ -519,6 +568,7 @@ public:
         return (this->discovery_config == b.discovery_config) &&
                (this->use_WriterLivelinessProtocol == b.use_WriterLivelinessProtocol) &&
                (this->network_configuration == b.network_configuration) &&
+               (this->metatrafficMulticastLocatorList == b.metatrafficMulticastLocatorList) &&
                (this->initialPeersList == b.initialPeersList) &&
                (this->readerHistoryMemoryPolicy == b.readerHistoryMemoryPolicy) &&
                (this->readerPayloadSize == b.readerPayloadSize) &&
@@ -530,6 +580,26 @@ public:
     }
 
 };
+inline void BuiltinAttributes::compose(
+        const BuiltinConstantAttributes& builtin_const,
+        const BuiltinMutableAttributes& builtin_mutable)
+{
+    discovery_config = builtin_const.discovery_config;
+    discovery_config.m_DiscoveryServers = builtin_mutable.discovery_config.m_DiscoveryServers;
+    use_WriterLivelinessProtocol = builtin_const.use_WriterLivelinessProtocol;
+    network_configuration = builtin_const.network_configuration;
+    metatrafficUnicastLocatorList = builtin_mutable.metatrafficUnicastLocatorList;
+    metatrafficMulticastLocatorList = builtin_const.metatrafficMulticastLocatorList;
+    metatraffic_external_unicast_locators = builtin_mutable.metatraffic_external_unicast_locators;
+    initialPeersList = builtin_const.initialPeersList;
+    readerHistoryMemoryPolicy = builtin_const.readerHistoryMemoryPolicy;
+    readerPayloadSize = builtin_const.readerPayloadSize;
+    writerHistoryMemoryPolicy = builtin_const.writerHistoryMemoryPolicy;
+    writerPayloadSize = builtin_const.writerPayloadSize;
+    mutation_tries = builtin_const.mutation_tries;
+    avoid_builtin_multicast = builtin_const.avoid_builtin_multicast;
+    flow_controller_name = builtin_const.flow_controller_name;
+}
 
 /**
  * Class RTPSParticipantAttributes used to define different aspects of a RTPSParticipant.
@@ -745,7 +815,7 @@ private:
 };
 
 /**
- * Class RTPSMutablePartAttributes used to define mutable aspects of a RTPSParticipant.
+ * Class RTPSParticipantMutableAttributes used to define mutable aspects of a RTPSParticipant.
  * @ingroup RTPS_ATTRIBUTES_MODULE
  */
 class RTPSParticipantMutableAttributes

--- a/test/mock/rtps/RTPSParticipantAttributes/fastdds/rtps/attributes/RTPSParticipantAttributes.hpp
+++ b/test/mock/rtps/RTPSParticipantAttributes/fastdds/rtps/attributes/RTPSParticipantAttributes.hpp
@@ -410,6 +410,128 @@ public:
 };
 
 /**
+ * Class BuiltinMutableAttributes, to define the behavior of the mutable RTPSParticipant builtin protocols.
+ * This class is a subset of BuiltinAttributes. It is separated to keep the logic of constant and mutable attributes separated.
+ * @ingroup RTPS_ATTRIBUTES_MODULE
+ */
+class BuiltinMutableAttributes
+{
+public:
+
+    //! Metatraffic Unicast Locator List
+    LocatorList_t metatrafficUnicastLocatorList;
+
+    //! Metatraffic Multicast Locator List.
+    LocatorList_t metatrafficMulticastLocatorList;
+
+    //! The collection of external locators to use for communication on metatraffic topics.
+    fastdds::rtps::ExternalLocators metatraffic_external_unicast_locators;
+
+    BuiltinMutableAttributes() = default;
+
+    BuiltinMutableAttributes(
+            const BuiltinAttributes& builtin)
+        : metatrafficUnicastLocatorList(builtin.metatrafficUnicastLocatorList)
+        , metatrafficMulticastLocatorList(builtin.metatrafficMulticastLocatorList)
+        , metatraffic_external_unicast_locators(builtin.metatraffic_external_unicast_locators)
+    {
+    }
+
+    ~BuiltinMutableAttributes() = default;
+
+    bool operator ==(
+            const BuiltinMutableAttributes& b) const
+    {
+        return (this->metatrafficUnicastLocatorList == b.metatrafficUnicastLocatorList) &&
+               (this->metatrafficMulticastLocatorList == b.metatrafficMulticastLocatorList) &&
+               (this->metatraffic_external_unicast_locators == b.metatraffic_external_unicast_locators);
+    }
+
+};
+
+/**
+ * Class BuiltinConstantAttributes, to define the behavior of the constant RTPSParticipant builtin protocols.
+ * This class is a subset of BuiltinAttributes. It is separated to keep the logic of constant and mutable attributes separated.
+ * @ingroup RTPS_ATTRIBUTES_MODULE
+ */
+class BuiltinConstantAttributes
+{
+public:
+
+    //! Discovery protocol related attributes
+    DiscoverySettings discovery_config;
+
+    //! Indicates to use the WriterLiveliness protocol.
+    bool use_WriterLivelinessProtocol = true;
+
+    //! Network Configuration
+    NetworkConfigSet_t network_configuration = 0;
+
+    //! Initial peers.
+    LocatorList_t initialPeersList;
+
+    //! Memory policy for builtin readers
+    MemoryManagementPolicy_t readerHistoryMemoryPolicy =
+            MemoryManagementPolicy_t::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+
+    //! Maximum payload size for builtin readers
+    uint32_t readerPayloadSize = BUILTIN_DATA_MAX_SIZE;
+
+    //! Memory policy for builtin writers
+    MemoryManagementPolicy_t writerHistoryMemoryPolicy =
+            MemoryManagementPolicy_t::PREALLOCATED_WITH_REALLOC_MEMORY_MODE;
+
+    //! Maximum payload size for builtin writers
+    uint32_t writerPayloadSize = BUILTIN_DATA_MAX_SIZE;
+
+    //! Mutation tries if the port is being used.
+    uint32_t mutation_tries = 100u;
+
+    //! Set to true to avoid multicast traffic on builtin endpoints
+    bool avoid_builtin_multicast = true;
+
+    //! Flow controller name to use for the builtin writers
+    std::string flow_controller_name = "";
+
+    BuiltinConstantAttributes() = default;
+
+    BuiltinConstantAttributes(
+            const BuiltinAttributes& builtin)
+        : discovery_config(builtin.discovery_config)
+        , use_WriterLivelinessProtocol(builtin.use_WriterLivelinessProtocol)
+        , network_configuration(builtin.network_configuration)
+        , initialPeersList(builtin.initialPeersList)
+        , readerHistoryMemoryPolicy(builtin.readerHistoryMemoryPolicy)
+        , readerPayloadSize(builtin.readerPayloadSize)
+        , writerHistoryMemoryPolicy(builtin.writerHistoryMemoryPolicy)
+        , writerPayloadSize(builtin.writerPayloadSize)
+        , mutation_tries(builtin.mutation_tries)
+        , avoid_builtin_multicast(builtin.avoid_builtin_multicast)
+        , flow_controller_name(builtin.flow_controller_name)
+    {
+    }
+
+    ~BuiltinConstantAttributes() = default;
+
+    bool operator ==(
+            const BuiltinConstantAttributes& b) const
+    {
+        return (this->discovery_config == b.discovery_config) &&
+               (this->use_WriterLivelinessProtocol == b.use_WriterLivelinessProtocol) &&
+               (this->network_configuration == b.network_configuration) &&
+               (this->initialPeersList == b.initialPeersList) &&
+               (this->readerHistoryMemoryPolicy == b.readerHistoryMemoryPolicy) &&
+               (this->readerPayloadSize == b.readerPayloadSize) &&
+               (this->writerHistoryMemoryPolicy == b.writerHistoryMemoryPolicy) &&
+               (this->writerPayloadSize == b.writerPayloadSize) &&
+               (this->mutation_tries == b.mutation_tries) &&
+               (this->flow_controller_name == b.flow_controller_name) &&
+               (this->avoid_builtin_multicast == b.avoid_builtin_multicast);
+    }
+
+};
+
+/**
  * Class RTPSParticipantAttributes used to define different aspects of a RTPSParticipant.
  * @ingroup RTPS_ATTRIBUTES_MODULE
  */
@@ -620,6 +742,232 @@ private:
 
     //! Name of the participant.
     fastcdr::string_255 name{"RTPSParticipant"};
+};
+
+/**
+ * Class RTPSMutablePartAttributes used to define mutable aspects of a RTPSParticipant.
+ * @ingroup RTPS_ATTRIBUTES_MODULE
+ */
+class RTPSParticipantMutableAttributes
+{
+public:
+
+    RTPSParticipantMutableAttributes() = default;
+
+    RTPSParticipantMutableAttributes(
+            const RTPSParticipantAttributes& attrs)
+        : defaultUnicastLocatorList(attrs.defaultUnicastLocatorList)
+        , default_external_unicast_locators(attrs.default_external_unicast_locators)
+        , userData(attrs.userData)
+        , builtin(attrs.builtin)
+    {
+    }
+
+    ~RTPSParticipantMutableAttributes() = default;
+
+    bool operator ==(
+            const RTPSParticipantMutableAttributes& b) const
+    {
+        return (this->defaultUnicastLocatorList == b.defaultUnicastLocatorList) &&
+               (this->default_external_unicast_locators == b.default_external_unicast_locators) &&
+               (this->userData == b.userData) &&
+               (this->builtin == b.builtin);
+    }
+
+    /**
+     * Default list of Unicast Locators to be used for any Endpoint defined inside this RTPSParticipant in the case
+     * that it was defined with NO UnicastLocators. At least ONE locator should be included in this list.
+     */
+    LocatorList_t defaultUnicastLocatorList;
+
+    /**
+     * The collection of external locators to use for communication on user created topics.
+     */
+    fastdds::rtps::ExternalLocators default_external_unicast_locators;
+
+    //! User Data of the participant
+    std::vector<octet> userData;
+
+    //! Builtin parameters.
+    BuiltinMutableAttributes builtin;
+};
+
+/**
+ * Class RTPSParticipantConstantAttributes used to define constant aspects of a RTPSParticipant.
+ * @ingroup RTPS_ATTRIBUTES_MODULE
+ */
+class RTPSParticipantConstantAttributes
+{
+    using FlowControllerDescriptorList = std::vector<std::shared_ptr<fastdds::rtps::FlowControllerDescriptor>>;
+
+public:
+
+    RTPSParticipantConstantAttributes() = default;
+
+    RTPSParticipantConstantAttributes(
+            const RTPSParticipantAttributes& attrs)
+        : defaultMulticastLocatorList(attrs.defaultMulticastLocatorList)
+        , ignore_non_matching_locators(attrs.ignore_non_matching_locators)
+        , sendSocketBufferSize(attrs.sendSocketBufferSize)
+        , listenSocketBufferSize(attrs.listenSocketBufferSize)
+        , netmaskFilter(attrs.netmaskFilter)
+        , prefix(attrs.prefix)
+        , builtin(attrs.builtin)
+        , port(attrs.port)
+        , participantID(attrs.participantID)
+        , easy_mode_ip(attrs.easy_mode_ip)
+        , userTransports(attrs.userTransports)
+        , useBuiltinTransports(attrs.useBuiltinTransports)
+        , allocation(attrs.allocation)
+        , properties(attrs.properties)
+        , flow_controllers(attrs.flow_controllers)
+        , builtin_controllers_sender_thread(attrs.builtin_controllers_sender_thread)
+        , timed_events_thread(attrs.timed_events_thread)
+        , discovery_server_thread(attrs.discovery_server_thread)
+        , typelookup_service_thread(attrs.typelookup_service_thread)
+        , builtin_transports_reception_threads(attrs.builtin_transports_reception_threads)
+#if HAVE_SECURITY
+        , security_log_thread(attrs.security_log_thread)
+#endif // if HAVE_SECURITY
+        , max_msg_size_no_frag(attrs.max_msg_size_no_frag)
+        , name(attrs.getName())
+    {
+    }
+
+    ~RTPSParticipantConstantAttributes() = default;
+
+    bool operator ==(
+            const RTPSParticipantConstantAttributes& b) const
+    {
+        return (this->defaultMulticastLocatorList == b.defaultMulticastLocatorList) &&
+               (this->ignore_non_matching_locators == b.ignore_non_matching_locators) &&
+               (this->sendSocketBufferSize == b.sendSocketBufferSize) &&
+               (this->listenSocketBufferSize == b.listenSocketBufferSize) &&
+               (this->netmaskFilter == b.netmaskFilter) &&
+               (this->builtin == b.builtin) &&
+               (this->port == b.port) &&
+               (this->participantID == b.participantID) &&
+               (this->easy_mode_ip == b.easy_mode_ip) &&
+               (this->useBuiltinTransports == b.useBuiltinTransports) &&
+               (this->allocation == b.allocation) &&
+               (this->properties == b.properties) &&
+               (this->prefix == b.prefix) &&
+               (this->flow_controllers == b.flow_controllers) &&
+               (this->builtin_controllers_sender_thread == b.builtin_controllers_sender_thread) &&
+               (this->timed_events_thread == b.timed_events_thread) &&
+#if HAVE_SECURITY
+               (this->security_log_thread == b.security_log_thread) &&
+#endif // if HAVE_SECURITY
+               (this->discovery_server_thread == b.discovery_server_thread) &&
+               (this->typelookup_service_thread == b.typelookup_service_thread) &&
+               (this->builtin_transports_reception_threads == b.builtin_transports_reception_threads);
+    }
+
+    /**
+     * Default list of Multicast Locators to be used for any Endpoint defined inside this RTPSParticipant in the
+     * case that it was defined with NO MulticastLocators. This is usually left empty.
+     */
+    LocatorList_t defaultMulticastLocatorList;
+
+    /**
+     * Whether locators that don't match with the announced locators should be kept.
+     */
+    bool ignore_non_matching_locators = false;
+
+    /*!
+     * @brief Send socket buffer size for the send resource. Zero value indicates to use default system buffer size.
+     * Default value: 0.
+     */
+    uint32_t sendSocketBufferSize = 0;
+
+    /*! Listen socket buffer for all listen resources. Zero value indicates to use default system buffer size.
+     * Default value: 0.
+     */
+    uint32_t listenSocketBufferSize = 0;
+
+    //! Netmask filter configuration
+    fastdds::rtps::NetmaskFilterKind netmaskFilter = fastdds::rtps::NetmaskFilterKind::AUTO;
+
+    //! Optionally allows user to define the GuidPrefix_t
+    GuidPrefix_t prefix;
+
+    inline bool ReadguidPrefix(
+            const char* pfx)
+    {
+        return bool(std::istringstream(pfx) >> prefix);
+    }
+
+    //! Builtin parameters.
+    BuiltinConstantAttributes builtin;
+
+    //! Port Parameters
+    PortParameters port;
+
+    //! Participant ID
+    int32_t participantID = -1;
+
+    //! IP of the Host where master Server is located (EASY_MODE context)
+    std::string easy_mode_ip = "";
+
+    //! User defined transports to use alongside or in place of builtins.
+    std::vector<std::shared_ptr<fastdds::rtps::TransportDescriptorInterface>> userTransports;
+
+    //! Set as false to disable the creation of the default transports.
+    bool useBuiltinTransports = true;
+
+    //! Holds allocation limits affecting collections managed by a participant.
+    RTPSParticipantAllocationAttributes allocation;
+
+    //! Property policies
+    PropertyPolicy properties;
+
+    //! Set the name of the participant.
+    inline void setName(
+            const char* nam)
+    {
+        name = nam;
+    }
+
+    //! Get the name of the participant.
+    inline const char* getName() const
+    {
+        return name.c_str();
+    }
+
+    //! Flow controllers.
+    FlowControllerDescriptorList flow_controllers;
+
+    //! Thread settings for the builtin flow controllers sender threads
+    fastdds::rtps::ThreadSettings builtin_controllers_sender_thread;
+
+    //! Thread settings for the timed events thread
+    fastdds::rtps::ThreadSettings timed_events_thread;
+
+    //! Thread settings for the discovery server thread
+    fastdds::rtps::ThreadSettings discovery_server_thread;
+
+    //! Thread settings for the builtin TypeLookup service requests and replies threads
+    fastdds::rtps::ThreadSettings typelookup_service_thread;
+
+    //! Thread settings for the builtin transports reception threads
+    fastdds::rtps::ThreadSettings builtin_transports_reception_threads;
+
+#if HAVE_SECURITY
+    //! Thread settings for the security log thread
+    fastdds::rtps::ThreadSettings security_log_thread;
+#endif // if HAVE_SECURITY
+
+    /*! Maximum message size used to avoid fragmentation, set ONLY in LARGE_DATA. If this value is
+     * not zero, the network factory will allow the initialization of UDP transports with maxMessageSize
+     * higher than 65500K.
+     */
+    uint32_t max_msg_size_no_frag = 0;
+
+private:
+
+    //! Name of the participant.
+    fastcdr::string_255 name{"RTPSParticipant"};
+
 };
 
 }  // namespace rtps

--- a/test/mock/rtps/RTPSParticipantAttributes/fastdds/rtps/attributes/RTPSParticipantAttributes.hpp
+++ b/test/mock/rtps/RTPSParticipantAttributes/fastdds/rtps/attributes/RTPSParticipantAttributes.hpp
@@ -711,9 +711,9 @@ inline void BuiltinAttributes::compose(
  */
 class RTPSParticipantAttributes
 {
-    using FlowControllerDescriptorList = std::vector<std::shared_ptr<fastdds::rtps::FlowControllerDescriptor>>;
-
 public:
+
+    using FlowControllerDescriptorList = std::vector<std::shared_ptr<fastdds::rtps::FlowControllerDescriptor>>;
 
     RTPSParticipantAttributes() = default;
 
@@ -972,9 +972,9 @@ public:
  */
 class RTPSParticipantConstantAttributes
 {
-    using FlowControllerDescriptorList = std::vector<std::shared_ptr<fastdds::rtps::FlowControllerDescriptor>>;
-
 public:
+
+    using FlowControllerDescriptorList = std::vector<std::shared_ptr<fastdds::rtps::FlowControllerDescriptor>>;
 
     RTPSParticipantConstantAttributes() = default;
 

--- a/test/mock/rtps/RTPSParticipantAttributes/fastdds/rtps/attributes/RTPSParticipantAttributes.hpp
+++ b/test/mock/rtps/RTPSParticipantAttributes/fastdds/rtps/attributes/RTPSParticipantAttributes.hpp
@@ -359,6 +359,110 @@ public:
 
 };
 
+/**
+ * Class ConstantDiscoverySettings, to define the constant attributes of the several discovery protocols available
+ * @ingroup RTPS_ATTRIBUTES_MODULE
+ */
+class ConstantDiscoverySettings
+{
+public:
+
+    //! Chosen discovery protocol
+    DiscoveryProtocol discoveryProtocol = DiscoveryProtocol::SIMPLE;
+
+    /**
+     * If set to true, SimpleEDP would be used.
+     */
+    bool use_SIMPLE_EndpointDiscoveryProtocol = true;
+
+    /**
+     * If set to true, StaticEDP based on an XML file would be implemented.
+     * The XML filename must be provided.
+     */
+    bool use_STATIC_EndpointDiscoveryProtocol = false;
+
+    /**
+     * Lease Duration of the RTPSParticipant,
+     * indicating how much time remote RTPSParticipants should consider this RTPSParticipant alive.
+     */
+    dds::Duration_t leaseDuration = { 20, 0 };
+
+    /**
+     * The period for the RTPSParticipant to send its Discovery Message to all other discovered RTPSParticipants
+     * as well as to all Multicast ports.
+     */
+    dds::Duration_t leaseDuration_announcementperiod = { 3, 0 };
+
+    //!Initial announcements configuration
+    InitialAnnouncementConfig initial_announcements;
+
+    //!Attributes of the SimpleEDP protocol
+    SimpleEDPAttributes m_simpleEDP;
+
+    //! function that returns a PDP object (only if EXTERNAL selected)
+    PDPFactory m_PDPfactory{};
+    /**
+     * The period for the RTPSParticipant to:
+     *  send its Discovery Message to its servers
+     *  check for EDP endpoints matching
+     */
+    dds::Duration_t discoveryServer_client_syncperiod = { 0, 450 * 1000000}; // 450 milliseconds
+
+    //! Filtering participants out depending on location
+    ParticipantFilteringFlags ignoreParticipantFlags = ParticipantFilteringFlags::NO_FILTER;
+
+    ConstantDiscoverySettings() = default;
+
+    ConstantDiscoverySettings(
+            const DiscoverySettings& discovery_settings)
+        : discoveryProtocol(discovery_settings.discoveryProtocol)
+        , use_SIMPLE_EndpointDiscoveryProtocol(discovery_settings.use_SIMPLE_EndpointDiscoveryProtocol)
+        , use_STATIC_EndpointDiscoveryProtocol(discovery_settings.use_STATIC_EndpointDiscoveryProtocol)
+        , leaseDuration(discovery_settings.leaseDuration)
+        , leaseDuration_announcementperiod(discovery_settings.leaseDuration_announcementperiod)
+        , initial_announcements(discovery_settings.initial_announcements)
+        , m_simpleEDP(discovery_settings.m_simpleEDP)
+        , m_PDPfactory(discovery_settings.m_PDPfactory)
+        , discoveryServer_client_syncperiod(discovery_settings.discoveryServer_client_syncperiod)
+        , ignoreParticipantFlags(discovery_settings.ignoreParticipantFlags)
+        , static_edp_xml_config_(discovery_settings.static_edp_xml_config())
+    {
+    }
+
+    bool operator ==(
+            const ConstantDiscoverySettings& b) const
+    {
+        return (this->discoveryProtocol == b.discoveryProtocol) &&
+               (this->use_SIMPLE_EndpointDiscoveryProtocol == b.use_SIMPLE_EndpointDiscoveryProtocol) &&
+               (this->use_STATIC_EndpointDiscoveryProtocol == b.use_STATIC_EndpointDiscoveryProtocol) &&
+               (this->discoveryServer_client_syncperiod == b.discoveryServer_client_syncperiod) &&
+               (this->m_PDPfactory == b.m_PDPfactory) &&
+               (this->leaseDuration == b.leaseDuration) &&
+               (this->leaseDuration_announcementperiod == b.leaseDuration_announcementperiod) &&
+               (this->initial_announcements == b.initial_announcements) &&
+               (this->m_simpleEDP == b.m_simpleEDP) &&
+               (this->static_edp_xml_config_ == b.static_edp_xml_config_) &&
+               (this->ignoreParticipantFlags == b.ignoreParticipantFlags);
+    }
+
+    /**
+     * Get the static endpoint XML configuration.
+     * @return URI specifying the static endpoint XML configuration.
+     * The string could contain a filename (file://) or the XML content directly (data://).
+     */
+    const char* static_edp_xml_config() const
+    {
+        return static_edp_xml_config_.c_str();
+    }
+
+private:
+
+    //! URI specifying the static EDP XML configuration, only necessary if use_STATIC_EndpointDiscoveryProtocol=true
+    //! This string could contain a filename or the XML content directly.
+    std::string static_edp_xml_config_ = "";
+
+};
+
 // Forward declaration to allow assignment from Constant and Mutable attributes.
 class BuiltinConstantAttributes;
 class BuiltinMutableAttributes;

--- a/test/mock/rtps/RTPSParticipantImpl/rtps/participant/RTPSParticipantImpl.hpp
+++ b/test/mock/rtps/RTPSParticipantImpl/rtps/participant/RTPSParticipantImpl.hpp
@@ -332,6 +332,11 @@ public:
         return attr_;
     }
 
+    const RTPSParticipantAttributes& get_const_attributes() const
+    {
+        return attr_;
+    }
+
     RTPSParticipantAttributes copy_attributes() const
     {
         return attr_;

--- a/test/mock/rtps/RTPSParticipantImpl/rtps/participant/RTPSParticipantImpl.hpp
+++ b/test/mock/rtps/RTPSParticipantImpl/rtps/participant/RTPSParticipantImpl.hpp
@@ -337,6 +337,11 @@ public:
         return const_attr_;
     }
 
+    const RTPSParticipantMutableAttributes get_mutable_attributes() const
+    {
+        return RTPSParticipantMutableAttributes{attr_};
+    }
+
     RTPSParticipantAttributes copy_attributes() const
     {
         return attr_;

--- a/test/mock/rtps/RTPSParticipantImpl/rtps/participant/RTPSParticipantImpl.hpp
+++ b/test/mock/rtps/RTPSParticipantImpl/rtps/participant/RTPSParticipantImpl.hpp
@@ -332,6 +332,11 @@ public:
         return attr_;
     }
 
+    RTPSParticipantAttributes copy_attributes() const
+    {
+        return attr_;
+    }
+
     void get_sending_locators(
             rtps::LocatorList_t& /*locators*/) const
     {

--- a/test/mock/rtps/RTPSParticipantImpl/rtps/participant/RTPSParticipantImpl.hpp
+++ b/test/mock/rtps/RTPSParticipantImpl/rtps/participant/RTPSParticipantImpl.hpp
@@ -332,9 +332,9 @@ public:
         return attr_;
     }
 
-    const RTPSParticipantAttributes& get_const_attributes() const
+    const RTPSParticipantConstantAttributes& get_const_attributes() const
     {
-        return attr_;
+        return const_attr_;
     }
 
     RTPSParticipantAttributes copy_attributes() const
@@ -470,6 +470,7 @@ private:
     MockParticipantListener listener_;
 
     RTPSParticipantAttributes attr_;
+    RTPSParticipantConstantAttributes const_attr_;
 
     NetworkFactory network_factory_ {attr_};
 

--- a/test/mock/rtps/SecurityPluginFactory/rtps/security/MockAccessControlPlugin.h
+++ b/test/mock/rtps/SecurityPluginFactory/rtps/security/MockAccessControlPlugin.h
@@ -41,7 +41,7 @@ public:
                 Authentication & auth_plugin,
                 const IdentityHandle& identity,
                 const uint32_t domain_id,
-                const RTPSParticipantAttributes& participant_attr,
+                const PropertyPolicy& part_props,
                 SecurityException & exception), (override));
 
     MOCK_METHOD(bool, get_permissions_token, (
@@ -74,7 +74,6 @@ public:
     MOCK_METHOD(bool, check_create_participant, (
                 const PermissionsHandle& local_handle,
                 const uint32_t domain_id,
-                const RTPSParticipantAttributes& qos,
                 SecurityException & exception), (override));
 
     MOCK_METHOD(bool, check_remote_participant, (

--- a/test/mock/rtps/SecurityPluginFactory/rtps/security/MockAuthenticationPlugin.h
+++ b/test/mock/rtps/SecurityPluginFactory/rtps/security/MockAuthenticationPlugin.h
@@ -45,7 +45,7 @@ public:
     MOCK_METHOD(ValidationResult_t, validate_local_identity, (IdentityHandle * *local_identity_handle,
             GUID_t & adjusted_participant_key,
             const uint32_t domain_id,
-            const RTPSParticipantAttributes& participant_attr,
+            const PropertyPolicy& part_props,
             const GUID_t& candidate_participant_key,
             SecurityException & exception), (override));
 

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -1002,15 +1002,22 @@ public:
 
 };
 
-void get_rtps_attributes(
-        const DomainParticipant* participant,
-        fastdds::rtps::RTPSParticipantAttributes& att)
+fastdds::rtps::RTPSParticipantAttributes get_rtps_attributes(
+        const DomainParticipant* participant)
 {
     const DomainParticipantTest* participant_test = static_cast<const DomainParticipantTest*>(participant);
-    ASSERT_NE(nullptr, participant_test);
+    EXPECT_NE(nullptr, participant_test);
+    if (participant_test == nullptr)
+    {
+        return {};
+    }
     const DomainParticipantImpl* participant_impl = participant_test->get_impl();
-    ASSERT_NE(nullptr, participant_impl);
-    att = participant_impl->get_rtps_participant()->get_attributes();
+    EXPECT_NE(nullptr, participant_impl);
+    if (participant_impl == nullptr)
+    {
+        return {};
+    }
+    return participant_impl->get_rtps_participant()->copy_attributes();
 }
 
 void helper_wait_for_at_least_entries(
@@ -1156,8 +1163,7 @@ void set_and_check_with_environment_file(
     // Wait for the file watch callback
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
 
-    fastdds::rtps::RTPSParticipantAttributes attributes;
-    get_rtps_attributes(participant, attributes);
+    fastdds::rtps::RTPSParticipantAttributes attributes = get_rtps_attributes(participant);
     EXPECT_EQ(attributes.builtin.discovery_config.discoveryProtocol, fastdds::rtps::DiscoveryProtocol::SERVER);
     EXPECT_EQ(attributes.builtin.discovery_config.m_DiscoveryServers, output);
 }
@@ -1181,8 +1187,7 @@ TEST(ParticipantTests, SimpleParticipantRemoteServerListConfiguration)
         (uint32_t)GET_PID() % 230, qos);
     ASSERT_NE(nullptr, participant);
 
-    fastdds::rtps::RTPSParticipantAttributes attributes;
-    get_rtps_attributes(participant, attributes);
+    fastdds::rtps::RTPSParticipantAttributes attributes = get_rtps_attributes(participant);
     EXPECT_EQ(attributes.builtin.discovery_config.discoveryProtocol, fastdds::rtps::DiscoveryProtocol::CLIENT);
     EXPECT_EQ(attributes.builtin.discovery_config.m_DiscoveryServers, output);
 
@@ -1219,8 +1224,7 @@ TEST(ParticipantTests, NoBuiltinMetatrafficMulticastForClients)
         (uint32_t)GET_PID() % 230, qos);
     ASSERT_NE(nullptr, participant);
 
-    fastdds::rtps::RTPSParticipantAttributes attributes;
-    get_rtps_attributes(participant, attributes);
+    fastdds::rtps::RTPSParticipantAttributes attributes = get_rtps_attributes(participant);
     EXPECT_EQ(attributes.builtin.discovery_config.discoveryProtocol, fastdds::rtps::DiscoveryProtocol::CLIENT);
     EXPECT_EQ(attributes.builtin.metatrafficMulticastLocatorList.size(), 0);
 
@@ -1256,8 +1260,7 @@ TEST(ParticipantTests, TransformSimpleParticipantToSuperclientByEnvVariable)
         (uint32_t)GET_PID() % 230, qos);
     ASSERT_NE(nullptr, participant);
 
-    fastdds::rtps::RTPSParticipantAttributes attributes;
-    get_rtps_attributes(participant, attributes);
+    fastdds::rtps::RTPSParticipantAttributes attributes = get_rtps_attributes(participant);
     EXPECT_EQ(attributes.builtin.discovery_config.discoveryProtocol, fastdds::rtps::DiscoveryProtocol::CLIENT);
     EXPECT_EQ(attributes.builtin.discovery_config.m_DiscoveryServers, output);
 
@@ -1271,8 +1274,7 @@ TEST(ParticipantTests, TransformSimpleParticipantToSuperclientByEnvVariable)
         (uint32_t)GET_PID() % 230, qos);
     ASSERT_NE(nullptr, participant_2);
 
-    fastdds::rtps::RTPSParticipantAttributes attributes_2;
-    get_rtps_attributes(participant_2, attributes_2);
+    fastdds::rtps::RTPSParticipantAttributes attributes_2 = get_rtps_attributes(participant_2);
     EXPECT_EQ(attributes_2.builtin.discovery_config.discoveryProtocol, fastdds::rtps::DiscoveryProtocol::SUPER_CLIENT);
     EXPECT_EQ(attributes_2.builtin.discovery_config.m_DiscoveryServers, output);
 
@@ -1345,8 +1347,7 @@ TEST(ParticipantTests, SimpleParticipantRemoteServerListConfigurationDNS)
                     PARTICIPANT_QOS_DEFAULT);
     ASSERT_NE(nullptr, participant);
 
-    fastdds::rtps::RTPSParticipantAttributes attributes;
-    get_rtps_attributes(participant, attributes);
+    fastdds::rtps::RTPSParticipantAttributes attributes = get_rtps_attributes(participant);
     EXPECT_EQ(attributes.builtin.discovery_config.discoveryProtocol, fastdds::rtps::DiscoveryProtocol::CLIENT);
     EXPECT_EQ(attributes.builtin.discovery_config.m_DiscoveryServers, output);
 
@@ -1388,8 +1389,7 @@ TEST(ParticipantTests, SimpleParticipantDynamicAdditionRemoteServers)
     DomainParticipant* participant = DomainParticipantFactory::get_instance()->create_participant(
         (uint32_t)GET_PID() % 230, qos);
     ASSERT_NE(nullptr, participant);
-    fastdds::rtps::RTPSParticipantAttributes attributes;
-    get_rtps_attributes(participant, attributes);
+    fastdds::rtps::RTPSParticipantAttributes attributes = get_rtps_attributes(participant);
 
     // As the environment file does not have the ROS_DISCOVERY_SERVER variable set, this variable has been loaded from
     // the environment
@@ -1404,7 +1404,7 @@ TEST(ParticipantTests, SimpleParticipantDynamicAdditionRemoteServers)
 
     // Wait long enough for the file watch callback
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    get_rtps_attributes(participant, attributes);
+    attributes = get_rtps_attributes(participant);
 
     fastdds::rtps::Locator_t locator;
     fastdds::rtps::IPLocator::setIPv4(locator, "192.168.1.133");
@@ -1434,8 +1434,7 @@ TEST(ParticipantTests, ClientParticipantRemoteServerListConfiguration)
     DomainParticipant* participant = DomainParticipantFactory::get_instance()->create_participant(
         (uint32_t)GET_PID() % 230, qos);
     ASSERT_NE(nullptr, participant);
-    fastdds::rtps::RTPSParticipantAttributes attributes;
-    get_rtps_attributes(participant, attributes);
+    fastdds::rtps::RTPSParticipantAttributes attributes = get_rtps_attributes(participant);
     EXPECT_EQ(attributes.builtin.discovery_config.discoveryProtocol, fastdds::rtps::DiscoveryProtocol::CLIENT);
     EXPECT_EQ(attributes.builtin.discovery_config.m_DiscoveryServers, qos_output);
     DomainParticipantQos result_qos = participant->get_qos();
@@ -1463,8 +1462,7 @@ TEST(ParticipantTests, ServerParticipantEnvironmentConfiguration)
     DomainParticipant* participant = DomainParticipantFactory::get_instance()->create_participant(
         (uint32_t)GET_PID() % 230, server_qos);
     ASSERT_NE(nullptr, participant);
-    fastdds::rtps::RTPSParticipantAttributes attributes;
-    get_rtps_attributes(participant, attributes);
+    fastdds::rtps::RTPSParticipantAttributes attributes = get_rtps_attributes(participant);
     EXPECT_EQ(attributes.builtin.discovery_config.discoveryProtocol, fastdds::rtps::DiscoveryProtocol::SERVER);
     EXPECT_TRUE(attributes.builtin.discovery_config.m_DiscoveryServers.empty());
     DomainParticipantQos result_qos = participant->get_qos();
@@ -1493,8 +1491,7 @@ TEST(ParticipantTests, ServerParticipantRemoteServerListConfiguration)
     DomainParticipant* participant = DomainParticipantFactory::get_instance()->create_participant(
         (uint32_t)GET_PID() % 230, qos);
     ASSERT_NE(nullptr, participant);
-    fastdds::rtps::RTPSParticipantAttributes attributes;
-    get_rtps_attributes(participant, attributes);
+    fastdds::rtps::RTPSParticipantAttributes attributes = get_rtps_attributes(participant);
     EXPECT_EQ(attributes.builtin.discovery_config.discoveryProtocol, fastdds::rtps::DiscoveryProtocol::SERVER);
     EXPECT_EQ(attributes.builtin.discovery_config.m_DiscoveryServers, qos_output);
     DomainParticipantQos result_qos = participant->get_qos();
@@ -1585,8 +1582,7 @@ TEST(ParticipantTests, EasyModeParticipantCheckConfigurationPriority)
 
     // Verify that the localhost Discovery Server is created and the configured remote IP
     // is the one set by the QoS (i.e., ROS2_EASY_MODE environment variable is ignored).
-    rtps::RTPSParticipantAttributes rtps_attr;
-    get_rtps_attributes(participant, rtps_attr);
+    rtps::RTPSParticipantAttributes rtps_attr = get_rtps_attributes(participant);
     ASSERT_EQ(rtps_attr.builtin.discovery_config.m_DiscoveryServers.size(), 1);
 
     rtps::Locator_t expected_locator;
@@ -1621,8 +1617,7 @@ TEST(ParticipantTests, EasyModeIPConfigFromXML)
 
     // Verify that the localhost Discovery Server is created and the configured remote IP
     // is the one set by the QoS
-    rtps::RTPSParticipantAttributes rtps_attr;
-    get_rtps_attributes(participant, rtps_attr);
+    rtps::RTPSParticipantAttributes rtps_attr = get_rtps_attributes(participant);
     ASSERT_EQ(rtps_attr.builtin.discovery_config.m_DiscoveryServers.size(), 1);
 
     rtps::Locator_t expected_locator;
@@ -1675,8 +1670,7 @@ TEST(ParticipantTests, ServerParticipantReplaceRemoteServerListConfiguration)
         (uint32_t)GET_PID() % 230, qos);
     ASSERT_NE(nullptr, participant);
 #ifndef __APPLE__
-    fastdds::rtps::RTPSParticipantAttributes attributes;
-    get_rtps_attributes(participant, attributes);
+    fastdds::rtps::RTPSParticipantAttributes attributes = get_rtps_attributes(participant);
     EXPECT_EQ(attributes.builtin.discovery_config.discoveryProtocol, fastdds::rtps::DiscoveryProtocol::SERVER);
     EXPECT_EQ(attributes.builtin.discovery_config.m_DiscoveryServers, qos_output);
 
@@ -1691,7 +1685,7 @@ TEST(ParticipantTests, ServerParticipantReplaceRemoteServerListConfiguration)
     qos_output.push_back(locator);
 
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    get_rtps_attributes(participant, attributes);
+    attributes = get_rtps_attributes(participant);
     EXPECT_EQ(attributes.builtin.discovery_config.m_DiscoveryServers, qos_output);
 #endif // APPLE
     DomainParticipantQos result_qos = participant->get_qos();
@@ -1733,8 +1727,7 @@ TEST(ParticipantTests, ServerParticipantInconsistentLocatorsRemoteServerListConf
     file << "{\"ROS_DISCOVERY_SERVER\": \"172.17.0.5:4321;192.168.1.133:64863\"}";
     file.close();
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
-    fastdds::rtps::RTPSParticipantAttributes attributes;
-    get_rtps_attributes(participant, attributes);
+    fastdds::rtps::RTPSParticipantAttributes attributes = get_rtps_attributes(participant);
     EXPECT_EQ(attributes.builtin.discovery_config.m_DiscoveryServers, output);
 #endif // APPLE
     DomainParticipantQos result_qos = participant->get_qos();
@@ -1796,8 +1789,7 @@ TEST(ParticipantTests, ServerParticipantCorrectRemoteServerListConfiguration)
         (uint32_t)GET_PID() % 230, qos);
     ASSERT_NE(nullptr, participant);
 #ifndef __APPLE__
-    fastdds::rtps::RTPSParticipantAttributes attributes;
-    get_rtps_attributes(participant, attributes);
+    fastdds::rtps::RTPSParticipantAttributes attributes = get_rtps_attributes(participant);
     EXPECT_EQ(attributes.builtin.discovery_config.m_DiscoveryServers, output);
     // Add new server through environment file
     // Even though the server added previously through the environment file is being pinged, it is not really being
@@ -1814,7 +1806,7 @@ TEST(ParticipantTests, ServerParticipantCorrectRemoteServerListConfiguration)
     fastdds::rtps::IPLocator::setIPv4(locator, "192.168.1.133");
     locator.port = 64863;
     output.push_back(locator);
-    get_rtps_attributes(participant, attributes);
+    attributes = get_rtps_attributes(participant);
     EXPECT_EQ(attributes.builtin.discovery_config.m_DiscoveryServers, output);
     // Try to be consistent: add already known server
     std::this_thread::sleep_for(std::chrono::milliseconds(100));
@@ -1825,7 +1817,7 @@ TEST(ParticipantTests, ServerParticipantCorrectRemoteServerListConfiguration)
     fastdds::rtps::IPLocator::setIPv4(locator, "127.0.0.1");
     locator.port = 1234;
     output.push_back(locator);
-    get_rtps_attributes(participant, attributes);
+    attributes = get_rtps_attributes(participant);
     EXPECT_EQ(attributes.builtin.discovery_config.m_DiscoveryServers, output);
     result_qos = participant->get_qos();
     EXPECT_EQ(RETCODE_OK, participant->set_qos(result_qos));
@@ -1841,7 +1833,7 @@ TEST(ParticipantTests, ServerParticipantCorrectRemoteServerListConfiguration)
     result_qos.wire_protocol().builtin.discovery_config.m_DiscoveryServers.push_back(locator);
     EXPECT_EQ(RETCODE_OK, participant->set_qos(result_qos));
     output.push_back(locator);
-    get_rtps_attributes(participant, attributes);
+    attributes = get_rtps_attributes(participant);
     EXPECT_EQ(attributes.builtin.discovery_config.m_DiscoveryServers, output);
 #endif // APPLE
     result_qos = participant->get_qos();
@@ -4669,14 +4661,13 @@ TEST(ParticipantTests, ParticipantCreationWithBuiltinTransport)
 {
     {
         DomainParticipantQos qos;
-        fastdds::rtps::RTPSParticipantAttributes attributes_;
         qos.setup_transports(rtps::BuiltinTransports::DEFAULT);
 
         DomainParticipant* participant_ = DomainParticipantFactory::get_instance()->create_participant(
             (uint32_t)GET_PID() % 230, qos);
         ASSERT_NE(nullptr, participant_);
 
-        get_rtps_attributes(participant_, attributes_);
+        fastdds::rtps::RTPSParticipantAttributes attributes_ = get_rtps_attributes(participant_);
 
         auto transport_check = [](fastdds::rtps::RTPSParticipantAttributes& attributes_) -> bool
                 {
@@ -4697,14 +4688,13 @@ TEST(ParticipantTests, ParticipantCreationWithBuiltinTransport)
 
     {
         DomainParticipantQos qos;
-        fastdds::rtps::RTPSParticipantAttributes attributes_;
         qos.setup_transports(rtps::BuiltinTransports::DEFAULTv6);
 
         DomainParticipant* participant_ = DomainParticipantFactory::get_instance()->create_participant(
             (uint32_t)GET_PID() % 230, qos);
         ASSERT_NE(nullptr, participant_);
 
-        get_rtps_attributes(participant_, attributes_);
+        fastdds::rtps::RTPSParticipantAttributes attributes_ = get_rtps_attributes(participant_);
 
         auto transport_check = [](fastdds::rtps::RTPSParticipantAttributes& attributes_) -> bool
                 {
@@ -4725,14 +4715,13 @@ TEST(ParticipantTests, ParticipantCreationWithBuiltinTransport)
 
     {
         DomainParticipantQos qos;
-        fastdds::rtps::RTPSParticipantAttributes attributes_;
         qos.setup_transports(rtps::BuiltinTransports::SHM);
 
         DomainParticipant* participant_ = DomainParticipantFactory::get_instance()->create_participant(
             (uint32_t)GET_PID() % 230, qos);
         ASSERT_NE(nullptr, participant_);
 
-        get_rtps_attributes(participant_, attributes_);
+        fastdds::rtps::RTPSParticipantAttributes attributes_ = get_rtps_attributes(participant_);
 
         auto transport_check = [](fastdds::rtps::RTPSParticipantAttributes& attributes_) -> bool
                 {
@@ -4753,14 +4742,13 @@ TEST(ParticipantTests, ParticipantCreationWithBuiltinTransport)
 
     {
         DomainParticipantQos qos;
-        fastdds::rtps::RTPSParticipantAttributes attributes_;
         qos.setup_transports(rtps::BuiltinTransports::UDPv4);
 
         DomainParticipant* participant_ = DomainParticipantFactory::get_instance()->create_participant(
             (uint32_t)GET_PID() % 230, qos);
         ASSERT_NE(nullptr, participant_);
 
-        get_rtps_attributes(participant_, attributes_);
+        fastdds::rtps::RTPSParticipantAttributes attributes_ = get_rtps_attributes(participant_);
 
         auto transport_check = [](fastdds::rtps::RTPSParticipantAttributes& attributes_) -> bool
                 {
@@ -4781,14 +4769,13 @@ TEST(ParticipantTests, ParticipantCreationWithBuiltinTransport)
 
     {
         DomainParticipantQos qos;
-        fastdds::rtps::RTPSParticipantAttributes attributes_;
         qos.setup_transports(rtps::BuiltinTransports::UDPv6);
 
         DomainParticipant* participant_ = DomainParticipantFactory::get_instance()->create_participant(
             (uint32_t)GET_PID() % 230, qos);
         ASSERT_NE(nullptr, participant_);
 
-        get_rtps_attributes(participant_, attributes_);
+        fastdds::rtps::RTPSParticipantAttributes attributes_ = get_rtps_attributes(participant_);
 
         auto transport_check = [](fastdds::rtps::RTPSParticipantAttributes& attributes_) -> bool
                 {
@@ -4809,14 +4796,13 @@ TEST(ParticipantTests, ParticipantCreationWithBuiltinTransport)
 
     {
         DomainParticipantQos qos;
-        fastdds::rtps::RTPSParticipantAttributes attributes_;
         qos.setup_transports(rtps::BuiltinTransports::LARGE_DATA);
 
         DomainParticipant* participant_ = DomainParticipantFactory::get_instance()->create_participant(
             (uint32_t)GET_PID() % 230, qos);
         ASSERT_NE(nullptr, participant_);
 
-        get_rtps_attributes(participant_, attributes_);
+        fastdds::rtps::RTPSParticipantAttributes attributes_ = get_rtps_attributes(participant_);
 
         auto transport_check = [](fastdds::rtps::RTPSParticipantAttributes& attributes_) -> bool
                 {
@@ -4851,14 +4837,13 @@ TEST(ParticipantTests, ParticipantCreationWithBuiltinTransport)
 
     {
         DomainParticipantQos qos;
-        fastdds::rtps::RTPSParticipantAttributes attributes_;
         qos.setup_transports(rtps::BuiltinTransports::LARGE_DATAv6);
 
         DomainParticipant* participant_ = DomainParticipantFactory::get_instance()->create_participant(
             (uint32_t)GET_PID() % 230, qos);
         ASSERT_NE(nullptr, participant_);
 
-        get_rtps_attributes(participant_, attributes_);
+        fastdds::rtps::RTPSParticipantAttributes attributes_ = get_rtps_attributes(participant_);
 
         auto transport_check = [](fastdds::rtps::RTPSParticipantAttributes& attributes_) -> bool
                 {
@@ -4907,8 +4892,7 @@ public:
             (uint32_t)GET_PID() % 230, qos);
         ASSERT_NE(nullptr, participant_);
 
-        fastdds::rtps::RTPSParticipantAttributes attr;
-        get_rtps_attributes(participant_, attr);
+        fastdds::rtps::RTPSParticipantAttributes attr = get_rtps_attributes(participant_);
         EXPECT_TRUE(check_options_attr(attr, options));
         EXPECT_EQ(attr.userTransports.size(), 3u);
         EXPECT_EQ(RETCODE_OK, DomainParticipantFactory::get_instance()->delete_participant(participant_));
@@ -4925,8 +4909,7 @@ public:
             (uint32_t)GET_PID() % 230, qos);
         ASSERT_NE(nullptr, participant_);
 
-        fastdds::rtps::RTPSParticipantAttributes attr;
-        get_rtps_attributes(participant_, attr);
+        fastdds::rtps::RTPSParticipantAttributes attr = get_rtps_attributes(participant_);
         bool udp_ok = false;
         for (auto& transportDescriptor : attr.userTransports)
         {
@@ -4958,8 +4941,7 @@ public:
             (uint32_t)GET_PID() % 230, qos);
         ASSERT_NE(nullptr, participant_);
 
-        fastdds::rtps::RTPSParticipantAttributes attr;
-        get_rtps_attributes(participant_, attr);
+        fastdds::rtps::RTPSParticipantAttributes attr = get_rtps_attributes(participant_);
         EXPECT_TRUE(check_default_participant(attr));
         EXPECT_EQ(RETCODE_OK, DomainParticipantFactory::get_instance()->delete_participant(participant_));
     }
@@ -5110,8 +5092,7 @@ TEST(ParticipantTests, ParticipantCreationWithLargeDataOptionsThroughAPI)
         (uint32_t)GET_PID() % 230, qos);
     ASSERT_NE(nullptr, participant_);
 
-    fastdds::rtps::RTPSParticipantAttributes attr;
-    get_rtps_attributes(participant_, attr);
+    fastdds::rtps::RTPSParticipantAttributes attr = get_rtps_attributes(participant_);
 
     EXPECT_TRUE(BuiltinTransportsOptionsTest::check_options_attr(attr, options));
     EXPECT_EQ(attr.userTransports.size(), 3u);

--- a/test/unittest/rtps/security/SecurityTests.hpp
+++ b/test/unittest/rtps/security/SecurityTests.hpp
@@ -157,7 +157,7 @@ public:
         , stateless_reader_(nullptr)
         , volatile_writer_(nullptr)
         , volatile_reader_(nullptr)
-        , manager_(&participant_, plugin_factory_)
+        , manager_(&participant_, g_security_default_values_.pattr, plugin_factory_)
         , participant_data_(c_default_RTPSParticipantAllocationAttributes)
         , default_cdr_message(RTPSMESSAGE_DEFAULT_SIZE)
     {

--- a/test/unittest/security/accesscontrol/AccessControlTests.cpp
+++ b/test/unittest/security/accesscontrol/AccessControlTests.cpp
@@ -167,6 +167,7 @@ void AccessControlTest::get_access_handle(
         bool should_success)
 {
     IdentityHandle* identity_handle = nullptr;
+    auto part_props = participant_attr.properties;
 
     ValidationResult_t result = ValidationResult_t::VALIDATION_FAILED;
     SecurityException exception;
@@ -176,7 +177,7 @@ void AccessControlTest::get_access_handle(
         &identity_handle,
         adjusted_participant_key,
         domain_id,
-        participant_attr,
+        part_props,
         candidate_participant_key,
         exception);
 
@@ -188,7 +189,7 @@ void AccessControlTest::get_access_handle(
         authentication_plugin,
         *identity_handle,
         domain_id,
-        participant_attr,
+        part_props,
         exception);
 
     bool success = *access_handle != nullptr;

--- a/test/unittest/security/authentication/AuthenticationPluginTests.hpp
+++ b/test/unittest/security/authentication/AuthenticationPluginTests.hpp
@@ -111,7 +111,7 @@ TEST_F(AuthenticationPluginTest, validate_local_identity_validation_ok)
     result = plugin.validate_local_identity(&local_identity_handle,
                     adjusted_participant_key,
                     domain_id,
-                    participant_attr,
+                    participant_attr.properties,
                     candidate_participant_key,
                     exception);
 
@@ -140,7 +140,7 @@ TEST_F(AuthenticationPluginTest, validate_local_identity_wrong_validation)
     result = plugin.validate_local_identity(&local_identity_handle,
                     adjusted_participant_key,
                     domain_id,
-                    participant_attr,
+                    participant_attr.properties,
                     candidate_participant_key,
                     exception);
 
@@ -170,7 +170,7 @@ TEST_F(AuthenticationPluginTest, handshake_process_ok)
     result = plugin.validate_local_identity(&local_identity_handle1,
                     adjusted_participant_key1,
                     domain_id,
-                    participant_attr,
+                    participant_attr.properties,
                     candidate_participant_key1,
                     exception);
 
@@ -182,7 +182,7 @@ TEST_F(AuthenticationPluginTest, handshake_process_ok)
     result = plugin.validate_local_identity(&local_identity_handle2,
                     adjusted_participant_key2,
                     domain_id,
-                    participant_attr,
+                    participant_attr.properties,
                     candidate_participant_key2,
                     exception);
 

--- a/test/unittest/security/authentication/BuiltinPKIDHTests.cpp
+++ b/test/unittest/security/authentication/BuiltinPKIDHTests.cpp
@@ -444,7 +444,7 @@ TEST_F(AuthenticationPluginTest, validate_local_identity_kagree_algo)
                 result = plugin.validate_local_identity(&local_identity_handle,
                                 adjusted_participant_key,
                                 domain_id,
-                                participant_attr,
+                                participant_attr.properties,
                                 candidate_participant_key,
                                 exception);
 
@@ -500,7 +500,7 @@ TEST_F(AuthenticationPluginTest, validate_local_identity_validation_ok_with_pwd)
     result = plugin.validate_local_identity(&local_identity_handle,
                     adjusted_participant_key,
                     domain_id,
-                    participant_attr,
+                    participant_attr.properties,
                     candidate_participant_key,
                     exception);
 
@@ -535,7 +535,7 @@ TEST_F(AuthenticationPluginTest, validate_local_identity_no_pwd)
     result = plugin.validate_local_identity(&local_identity_handle,
                     adjusted_participant_key,
                     domain_id,
-                    participant_attr,
+                    participant_attr.properties,
                     candidate_participant_key,
                     exception);
 
@@ -570,7 +570,7 @@ TEST_F(AuthenticationPluginTest, validate_local_identity_wrong_pwd)
     result = plugin.validate_local_identity(&local_identity_handle,
                     adjusted_participant_key,
                     domain_id,
-                    participant_attr,
+                    participant_attr.properties,
                     candidate_participant_key,
                     exception);
 
@@ -603,7 +603,7 @@ TEST_F(AuthenticationPluginTest, validate_local_identity_wrong_identity_ca)
     result = plugin.validate_local_identity(&local_identity_handle,
                     adjusted_participant_key,
                     domain_id,
-                    participant_attr,
+                    participant_attr.properties,
                     candidate_participant_key,
                     exception);
 
@@ -636,7 +636,7 @@ TEST_F(AuthenticationPluginTest, validate_local_identity_wrong_identity_certific
     result = plugin.validate_local_identity(&local_identity_handle,
                     adjusted_participant_key,
                     domain_id,
-                    participant_attr,
+                    participant_attr.properties,
                     candidate_participant_key,
                     exception);
 
@@ -672,7 +672,7 @@ TEST_F(AuthenticationPluginTest, validate_local_identity_revoked_certificate)
     result = plugin.validate_local_identity(&local_identity_handle,
                     adjusted_participant_key,
                     domain_id,
-                    participant_attr,
+                    participant_attr.properties,
                     candidate_participant_key,
                     exception);
 
@@ -705,7 +705,7 @@ TEST_F(AuthenticationPluginTest, validate_local_identity_revoked_certificate_wit
     result = plugin.validate_local_identity(&local_identity_handle,
                     adjusted_participant_key,
                     domain_id,
-                    participant_attr,
+                    participant_attr.properties,
                     candidate_participant_key,
                     exception);
 
@@ -738,7 +738,7 @@ TEST_F(AuthenticationPluginTest, validate_local_identity_expired_certificate)
     result = plugin.validate_local_identity(&local_identity_handle,
                     adjusted_participant_key,
                     domain_id,
-                    participant_attr,
+                    participant_attr.properties,
                     candidate_participant_key,
                     exception);
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

This PR solves a bunch of data races caused by the not-thread-safe access to RTPSParticipantAttributes via its main getter `get_attributes()`. This method returns a const reference to the object, which can be concurrently modified from other functions like `update_attributes()` causing a read-write access data race.

The proposed fix should modify the original method to return a copy of the class attribute with the mutex locked, making the access safe. However, this would imply an API break. Thus, a new method has been created to be used internally, leaving the `get_attributes()` method untouched and marked to be fixed in the next major release.

Related PR: 
- https://github.com/eProsima/Fast-DDS-python/pull/294

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.4.x 3.2.x 2.14.x
<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_: Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- _N/A_ Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
