### PR TITLE
[21355] Make `on_xxx_matched` thread-safe

### DIFF
--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -1348,6 +1348,8 @@ void DataWriterImpl::InnerDataWriterListener::on_writer_matched(
         RTPSWriter* /*writer*/,
         const MatchingInfo& info)
 {
+    std::lock_guard<std::mutex> scoped_lock(matching_info_mutex_);
+
     data_writer_->update_publication_matched_status(info);
 
     StatusMask notify_status = StatusMask::publication_matched();

--- a/src/cpp/fastdds/publisher/DataWriterImpl.hpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.hpp
@@ -531,7 +531,10 @@ protected:
                 const uint32_t& status_id);
 #endif //FASTDDS_STATISTICS
 
+    private:
+
         DataWriterImpl* data_writer_;
+        std::mutex matching_info_mutex_;
     }
     writer_listener_;
 

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -941,6 +941,8 @@ void DataReaderImpl::InnerDataReaderListener::on_reader_matched(
         RTPSReader* /*reader*/,
         const MatchingInfo& info)
 {
+    std::lock_guard<std::mutex> scoped_lock(matching_info_mutex_);
+
     data_reader_->update_subscription_matched_status(info);
 
     StatusMask notify_status = StatusMask::subscription_matched();

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
@@ -511,7 +511,10 @@ protected:
                 const uint32_t& status_id);
 #endif //FASTDDS_STATISTICS
 
+    private:
+
         DataReaderImpl* data_reader_;
+        std::mutex matching_info_mutex_;
 
     }
     reader_listener_;

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDP.cpp
@@ -801,8 +801,8 @@ bool EDP::unpairWriterProxy(
 #endif // if HAVE_SECURITY
 
                     //MATCHED AND ADDED CORRECTLY:
-                    ReaderListener* listener = nullptr;
-                    if (nullptr != (listener = r.get_listener()))
+                    ReaderListener* listener = r.get_listener();
+                    if (nullptr != listener)
                     {
                         MatchingInfo info;
                         info.status = REMOVED_MATCHING;
@@ -836,8 +836,8 @@ bool EDP::unpairReaderProxy(
                     participant_guid, reader_guid);
 #endif // if HAVE_SECURITY
                     //MATCHED AND ADDED CORRECTLY:
-                    WriterListener* listener = nullptr;
-                    if (nullptr != (listener = w.get_listener()))
+                    WriterListener* listener = w.get_listener();
+                    if (nullptr != listener)
                     {
                         MatchingInfo info;
                         info.status = REMOVED_MATCHING;
@@ -1167,40 +1167,39 @@ bool EDP::pairingReader(
                             "WP:" << wdatait->guid << " match R:" << reader_guid << ". RLoc:"
                                   << wdatait->remote_locators);
                     //MATCHED AND ADDED CORRECTLY:
-                    if (reader->get_listener() != nullptr)
+                    ReaderListener* listener = reader->get_listener();
+                    if (nullptr != listener)
                     {
                         MatchingInfo info;
                         info.status = MATCHED_MATCHING;
                         info.remoteEndpointGuid = writer_guid;
-                        reader->get_listener()->on_reader_matched(reader, info);
+                        listener->on_reader_matched(reader, info);
                     }
                 }
 #endif // if HAVE_SECURITY
             }
             else
             {
-                if (no_match_reason.test(MatchingFailureMask::incompatible_qos) && reader->get_listener() != nullptr)
+                ReaderListener* listener = reader->get_listener();
+                if (no_match_reason.test(MatchingFailureMask::incompatible_qos) && (nullptr != listener))
                 {
-                    reader->get_listener()->on_requested_incompatible_qos(reader, incompatible_qos);
+                    listener->on_requested_incompatible_qos(reader, incompatible_qos);
                     mp_PDP->notify_incompatible_qos_matching(R->getGuid(), wdatait->guid, incompatible_qos);
                 }
 
-                //EPROSIMA_LOG_INFO(RTPS_EDP,RTPS_CYAN<<"Valid Matching to writerProxy: "<<wdatait->guid<<RTPS_DEF<<endl);
-                if (reader->matched_writer_is_matched(wdatait->guid)
-                        && reader->matched_writer_remove(wdatait->guid))
+                if (reader->matched_writer_is_matched(wdatait->guid) && reader->matched_writer_remove(wdatait->guid))
                 {
 #if HAVE_SECURITY
-                    mp_RTPSParticipant->security_manager().remove_writer(reader_guid, participant_guid,
-                            wdatait->guid);
+                    mp_RTPSParticipant->security_manager().remove_writer(reader_guid, participant_guid, wdatait->guid);
 #endif // if HAVE_SECURITY
 
                     //MATCHED AND ADDED CORRECTLY:
-                    if (reader->get_listener() != nullptr)
+                    if (nullptr != listener)
                     {
                         MatchingInfo info;
                         info.status = REMOVED_MATCHING;
                         info.remoteEndpointGuid = writer_guid;
-                        reader->get_listener()->on_reader_matched(reader, info);
+                        listener->on_reader_matched(reader, info);
                     }
                 }
             }
@@ -1261,21 +1260,23 @@ bool EDP::pairingWriter(
                             "RP:" << rdatait->guid << " match W:" << writer_guid << ". WLoc:"
                                   << rdatait->remote_locators);
                     //MATCHED AND ADDED CORRECTLY:
-                    if (writer->get_listener() != nullptr)
+                    WriterListener* listener = writer->get_listener();
+                    if (nullptr != listener)
                     {
                         MatchingInfo info;
                         info.status = MATCHED_MATCHING;
                         info.remoteEndpointGuid = reader_guid;
-                        writer->get_listener()->on_writer_matched(writer, info);
+                        listener->on_writer_matched(writer, info);
                     }
                 }
 #endif // if HAVE_SECURITY
             }
             else
             {
-                if (no_match_reason.test(MatchingFailureMask::incompatible_qos) && writer->get_listener() != nullptr)
+                WriterListener* listener = writer->get_listener();
+                if (no_match_reason.test(MatchingFailureMask::incompatible_qos) && (nullptr != listener))
                 {
-                    writer->get_listener()->on_offered_incompatible_qos(writer, incompatible_qos);
+                    listener->on_offered_incompatible_qos(writer, incompatible_qos);
                     mp_PDP->notify_incompatible_qos_matching(W->getGuid(), rdatait->guid, incompatible_qos);
                 }
 
@@ -1286,12 +1287,12 @@ bool EDP::pairingWriter(
                     mp_RTPSParticipant->security_manager().remove_reader(writer_guid, participant_guid, reader_guid);
 #endif // if HAVE_SECURITY
                     //MATCHED AND ADDED CORRECTLY:
-                    if (writer->get_listener() != nullptr)
+                    if (nullptr != listener)
                     {
                         MatchingInfo info;
                         info.status = REMOVED_MATCHING;
                         info.remoteEndpointGuid = reader_guid;
-                        writer->get_listener()->on_writer_matched(writer, info);
+                        listener->on_writer_matched(writer, info);
                     }
                 }
             }
@@ -1338,38 +1339,39 @@ bool EDP::pairing_reader_proxy_with_any_local_writer(
                             "RP:" << rdata->guid << " match W:" << w.getGuid() << ". RLoc:"
                                   << rdata->remote_locators);
                             //MATCHED AND ADDED CORRECTLY:
-                            if (w.get_listener() != nullptr)
+                            WriterListener* listener = w.get_listener();
+                            if (nullptr != listener)
                             {
                                 MatchingInfo info;
                                 info.status = MATCHED_MATCHING;
                                 info.remoteEndpointGuid = reader_guid;
-                                w.get_listener()->on_writer_matched(&w, info);
+                                listener->on_writer_matched(&w, info);
                             }
                         }
 #endif // if HAVE_SECURITY
                     }
                     else
                     {
-                        if (no_match_reason.test(MatchingFailureMask::incompatible_qos) && w.get_listener() != nullptr)
+                        WriterListener* listener = w.get_listener();
+                        if (no_match_reason.test(MatchingFailureMask::incompatible_qos) && (nullptr != listener))
                         {
-                            w.get_listener()->on_offered_incompatible_qos(&w, incompatible_qos);
+                            listener->on_offered_incompatible_qos(&w, incompatible_qos);
                             mp_PDP->notify_incompatible_qos_matching(w.getGuid(), rdata->guid, incompatible_qos);
                         }
 
-                        if (w.matched_reader_is_matched(reader_guid)
-                        && w.matched_reader_remove(reader_guid))
+                        if (w.matched_reader_is_matched(reader_guid) && w.matched_reader_remove(reader_guid))
                         {
 #if HAVE_SECURITY
                             mp_RTPSParticipant->security_manager().remove_reader(
                                 w.getGuid(), participant_guid, reader_guid);
 #endif // if HAVE_SECURITY
                             //MATCHED AND ADDED CORRECTLY:
-                            if (w.get_listener() != nullptr)
+                            if (nullptr != listener)
                             {
                                 MatchingInfo info;
                                 info.status = REMOVED_MATCHING;
                                 info.remoteEndpointGuid = reader_guid;
-                                w.get_listener()->on_writer_matched(&w, info);
+                                listener->on_writer_matched(&w, info);
                             }
                         }
                     }
@@ -1419,25 +1421,24 @@ bool EDP::pairing_reader_proxy_with_local_writer(
                         }
                         else
                         {
-                            if (no_match_reason.test(MatchingFailureMask::incompatible_qos) &&
-                            w.get_listener() != nullptr)
+                            WriterListener* listener = w.get_listener();
+                            if (no_match_reason.test(MatchingFailureMask::incompatible_qos) && (nullptr != listener))
                             {
-                                w.get_listener()->on_offered_incompatible_qos(&w, incompatible_qos);
+                                listener->on_offered_incompatible_qos(&w, incompatible_qos);
                                 mp_PDP->notify_incompatible_qos_matching(local_writer, rdata.guid, incompatible_qos);
                             }
 
-                            if (w.matched_reader_is_matched(reader_guid)
-                            && w.matched_reader_remove(reader_guid))
+                            if (w.matched_reader_is_matched(reader_guid) && w.matched_reader_remove(reader_guid))
                             {
                                 mp_RTPSParticipant->security_manager().remove_reader(w.getGuid(),
                                 remote_participant_guid, reader_guid);
                                 //MATCHED AND ADDED CORRECTLY:
-                                if (w.get_listener() != nullptr)
+                                if (nullptr != listener)
                                 {
                                     MatchingInfo info;
                                     info.status = REMOVED_MATCHING;
                                     info.remoteEndpointGuid = reader_guid;
-                                    w.get_listener()->on_writer_matched(&w, info);
+                                    listener->on_writer_matched(&w, info);
                                 }
                             }
                         }
@@ -1474,12 +1475,13 @@ bool EDP::pairing_remote_reader_with_local_writer_after_security(
                         matched = true;
 
                         //MATCHED AND ADDED CORRECTLY:
-                        if (w.get_listener() != nullptr)
+                        WriterListener* listener = w.get_listener();
+                        if (nullptr != listener)
                         {
                             MatchingInfo info;
                             info.status = MATCHED_MATCHING;
                             info.remoteEndpointGuid = reader_guid;
-                            w.get_listener()->on_writer_matched(&w, info);
+                            listener->on_writer_matched(&w, info);
                         }
                     }
                     // don't look anymore
@@ -1533,38 +1535,39 @@ bool EDP::pairing_writer_proxy_with_any_local_reader(
                             "WP:" << wdata->guid << " match R:" << r.getGuid() << ". WLoc:"
                                   << wdata->remote_locators);
                             //MATCHED AND ADDED CORRECTLY:
-                            if (r.get_listener() != nullptr)
+                            ReaderListener* listener = r.get_listener();
+                            if (nullptr != listener)
                             {
                                 MatchingInfo info;
                                 info.status = MATCHED_MATCHING;
                                 info.remoteEndpointGuid = writer_guid;
-                                r.get_listener()->on_reader_matched(&r, info);
+                                listener->on_reader_matched(&r, info);
                             }
                         }
 #endif // if HAVE_SECURITY
                     }
                     else
                     {
-                        if (no_match_reason.test(MatchingFailureMask::incompatible_qos) && r.get_listener() != nullptr)
+                        ReaderListener* listener = r.get_listener();
+                        if (no_match_reason.test(MatchingFailureMask::incompatible_qos) && (nullptr != listener))
                         {
-                            r.get_listener()->on_requested_incompatible_qos(&r, incompatible_qos);
+                            listener->on_requested_incompatible_qos(&r, incompatible_qos);
                             mp_PDP->notify_incompatible_qos_matching(r.getGuid(), wdata->guid, incompatible_qos);
                         }
 
-                        if (r.matched_writer_is_matched(writer_guid)
-                        && r.matched_writer_remove(writer_guid))
+                        if (r.matched_writer_is_matched(writer_guid) && r.matched_writer_remove(writer_guid))
                         {
 #if HAVE_SECURITY
                             mp_RTPSParticipant->security_manager().remove_writer(readerGUID, participant_guid,
                             writer_guid);
 #endif // if HAVE_SECURITY
                             //MATCHED AND ADDED CORRECTLY:
-                            if (r.get_listener() != nullptr)
+                            if (nullptr != listener)
                             {
                                 MatchingInfo info;
                                 info.status = REMOVED_MATCHING;
                                 info.remoteEndpointGuid = writer_guid;
-                                r.get_listener()->on_reader_matched(&r, info);
+                                listener->on_reader_matched(&r, info);
                             }
                         }
                     }
@@ -1614,25 +1617,24 @@ bool EDP::pairing_writer_proxy_with_local_reader(
                         }
                         else
                         {
-                            if (no_match_reason.test(MatchingFailureMask::incompatible_qos) &&
-                            r.get_listener() != nullptr)
+                            ReaderListener* listener = r.get_listener();
+                            if (no_match_reason.test(MatchingFailureMask::incompatible_qos) && (nullptr != listener))
                             {
-                                r.get_listener()->on_requested_incompatible_qos(&r, incompatible_qos);
+                                listener->on_requested_incompatible_qos(&r, incompatible_qos);
                                 mp_PDP->notify_incompatible_qos_matching(local_reader, wdata.guid, incompatible_qos);
                             }
 
-                            if (r.matched_writer_is_matched(writer_guid)
-                            && r.matched_writer_remove(writer_guid))
+                            if (r.matched_writer_is_matched(writer_guid) && r.matched_writer_remove(writer_guid))
                             {
                                 mp_RTPSParticipant->security_manager().remove_writer(readerGUID,
                                 remote_participant_guid, writer_guid);
                                 //MATCHED AND ADDED CORRECTLY:
-                                if (r.get_listener() != nullptr)
+                                if (nullptr != listener)
                                 {
                                     MatchingInfo info;
                                     info.status = REMOVED_MATCHING;
                                     info.remoteEndpointGuid = writer_guid;
-                                    r.get_listener()->on_reader_matched(&r, info);
+                                    listener->on_reader_matched(&r, info);
                                 }
                             }
                         }
@@ -1671,13 +1673,13 @@ bool EDP::pairing_remote_writer_with_local_reader_after_security(
                         matched = true;
 
                         //MATCHED AND ADDED CORRECTLY:
-                        if (r.get_listener() != nullptr)
+                        ReaderListener* listener = r.get_listener();
+                        if (nullptr != listener)
                         {
                             MatchingInfo info;
                             info.status = MATCHED_MATCHING;
                             info.remoteEndpointGuid = writer_guid;
-                            r.get_listener()->on_reader_matched(&r, info);
-
+                            listener->on_reader_matched(&r, info);
                         }
                     }
                     // dont' look anymore

--- a/test/blackbox/common/DDSBlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDiscovery.cpp
@@ -483,6 +483,125 @@ TEST(DDSDiscovery, UpdateMatchedStatus)
     datawriter_2.destroy();
 }
 
+/*
+ * This is a regression test for redmine issue 21355.
+ *
+ * In order to check that the on_publication_matched() and on_subscription_matched() callbacks are always called with
+ * either +1 or -1 as the current_count_change, this test creates and destroys multiple DataReaders and DataWriters in
+ * different threads, with a listener that counts the number of times on_publication_matched() and
+ * on_subscription_matched() are called with current_count_change different than 1 or -1.
+ *
+ * The test fails if any of the calls to on_publication_matched() or on_subscription_matched() is made with a
+ * current_count_change different than 1 or -1.
+ */
+TEST(DDSDiscovery, MatchedCallbackListenerMultithread)
+{
+    constexpr size_t NUM_THREADS = 25;
+
+    struct TestListener
+        : public eprosima::fastdds::dds::DataReaderListener
+        , public eprosima::fastdds::dds::DataWriterListener
+    {
+        std::atomic<uint32_t> reader_other_calls{ 0 };
+        std::atomic<uint32_t> writer_other_calls{ 0 };
+
+        void on_publication_matched(
+                eprosima::fastdds::dds::DataWriter*,
+                const eprosima::fastdds::dds::PublicationMatchedStatus& info) override
+        {
+            if ((info.current_count_change != 1) && (info.current_count_change != -1))
+            {
+                ++writer_other_calls;
+            }
+        }
+
+        void on_subscription_matched(
+                eprosima::fastdds::dds::DataReader*,
+                const eprosima::fastdds::dds::SubscriptionMatchedStatus& info) override
+        {
+            if ((info.current_count_change != 1) && (info.current_count_change != -1))
+            {
+                ++reader_other_calls;
+            }
+        }
+
+    };
+
+    std::ostringstream t;
+    t << TEST_TOPIC_NAME << "_" << asio::ip::host_name() << "_" << GET_PID();
+    std::string topic_name = t.str();
+    TestListener listener;
+    eprosima::fastdds::dds::TypeSupport type(new HelloWorldPubSubType());
+
+    auto create_entities = [&listener, &topic_name, &type]()
+            {
+                using namespace eprosima::fastdds::dds;
+
+                uint32_t domain_id = static_cast<uint32_t>(GET_PID()) % 100;
+                auto factory = DomainParticipantFactory::get_shared_instance();
+                DomainParticipantQos participant_qos;
+                factory->get_default_participant_qos(participant_qos);
+                participant_qos.setup_transports(eprosima::fastdds::rtps::BuiltinTransports::UDPv4);
+                participant_qos.wire_protocol().builtin.discovery_config.leaseDuration.seconds = 0;
+                participant_qos.wire_protocol().builtin.discovery_config.leaseDuration.nanosec = 100000000;
+                participant_qos.wire_protocol().builtin.discovery_config.leaseDuration_announcementperiod.seconds = 0;
+                participant_qos.wire_protocol().builtin.discovery_config.leaseDuration_announcementperiod.nanosec =
+                        50000000;
+
+                auto participant = factory->create_participant(domain_id, participant_qos);
+                ASSERT_NE(participant, nullptr);
+
+                type.register_type(participant);
+                auto topic = participant->create_topic(topic_name, type.get_type_name(), TOPIC_QOS_DEFAULT);
+                ASSERT_NE(topic, nullptr);
+
+                auto publisher = participant->create_publisher(PUBLISHER_QOS_DEFAULT);
+                ASSERT_NE(publisher, nullptr);
+
+                DataWriterQos datawriter_qos;
+                publisher->get_default_datawriter_qos(datawriter_qos);
+                datawriter_qos.data_sharing().off();
+                auto datawriter = publisher->create_datawriter(topic, datawriter_qos, &listener);
+                ASSERT_NE(datawriter, nullptr);
+
+                auto subscriber = participant->create_subscriber(SUBSCRIBER_QOS_DEFAULT);
+                ASSERT_NE(subscriber, nullptr);
+
+                DataReaderQos datareader_qos;
+                subscriber->get_default_datareader_qos(datareader_qos);
+                datareader_qos.data_sharing().off();
+                auto datareader = subscriber->create_datareader(topic, datareader_qos, &listener);
+                ASSERT_NE(datareader, nullptr);
+
+                HelloWorld msg;
+                msg.index(1);
+                datawriter->write(&msg);
+
+                SampleInfo info;
+                datareader->take_next_sample(&msg, &info);
+
+                participant->delete_contained_entities();
+                factory->delete_participant(participant);
+
+                std::this_thread::sleep_for(std::chrono::milliseconds(200));
+            };
+
+    std::vector<std::thread> threads;
+    threads.reserve(NUM_THREADS);
+    for (size_t i = 0; i < NUM_THREADS; ++i)
+    {
+        threads.emplace_back(create_entities);
+    }
+
+    for (auto& thread : threads)
+    {
+        thread.join();
+    }
+
+    EXPECT_EQ(listener.reader_other_calls.load(), 0u);
+    EXPECT_EQ(listener.writer_other_calls.load(), 0u);
+}
+
 TEST(DDSDiscovery, EndpointMatchingCallbackAlwaysTrue)
 {
     using namespace std::chrono_literals;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This fixes a data race in the matched callbacks of the inner listeners in DataReaderImpl and DataWriterImpl.
The regression test does not always fail before the fix (but always fails for me with `--repeat until-fail:100`).
It always passes with the fix in place.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.4.x 3.2.x 2.14.x

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
