### PR TITLE
[24322] Bump version to 3.6.1

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,7 +29,7 @@ endif()
 ###############################################################################
 # Project                                                                     #
 ###############################################################################
-project(fastdds VERSION "3.6.0.0" LANGUAGES C CXX)
+project(fastdds VERSION "3.6.1.0" LANGUAGES C CXX)
 
 set(PROJECT_NAME_LARGE "Fast DDS")
 string(TOUPPER "${PROJECT_NAME}" PROJECT_NAME_UPPER)

--- a/package.xml
+++ b/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>fastdds</name>
-  <version>3.6.0</version>
+  <version>3.6.1</version>
   <description>
   eProsima Fast DDS is a C++ implementation of the DDS (Data Distribution Service) standard of the OMG (Object Management Group). eProsima Fast DDS implements the RTPS (Real Time Publish Subscribe) protocol, which provides publisher-subscriber communications over unreliable transports such as UDP, as defined and maintained by the Object Management Group (OMG) consortium. RTPS is also the wire interoperability protocol defined for the Data Distribution Service (DDS) standard. eProsima Fast DDS expose an API to access directly the RTPS protocol, giving the user full access to the protocol internals.
   </description>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

Bump version to 3.6.1

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.5.x 3.4.x 3.2.x 2.14.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- _N/A_ The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_ Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- _N/A_ Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- _N/A_ Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- _N/A_ Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
