### PR TITLE
[24338] Improve windows tests

### DIFF
--- a/test/feature/idl_parser/CMakeLists.txt
+++ b/test/feature/idl_parser/CMakeLists.txt
@@ -63,25 +63,28 @@ target_link_libraries(IdlParserTests
 gtest_discover_tests(IdlParserTests PROPERTIES ${IDLPARSERTESTS_ENV_PROPERTIES})
 
 message(STATUS "Copying IDL directory from ${PROJECT_SOURCE_DIR}/thirdparty/dds-types-test/IDL for idl_parser testing")
-add_custom_command(
-    TARGET IdlParserTests POST_BUILD
-    COMMAND ${CMAKE_COMMAND} -E copy_directory ${PROJECT_SOURCE_DIR}/thirdparty/dds-types-test/IDL ${CMAKE_CURRENT_BINARY_DIR}/IDL
-    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/test/feature/idl_parser/no_path_included.idl ${CMAKE_CURRENT_BINARY_DIR}/IDL/
-    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/test/feature/idl_parser/idl_extra_cases/extra_structures.idl ${CMAKE_CURRENT_BINARY_DIR}/IDL/
-    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/test/feature/idl_parser/idl_extra_cases/extra_unions.idl ${CMAKE_CURRENT_BINARY_DIR}/IDL/
-    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/test/feature/idl_parser/idl_extra_cases/appendable_annotation.idl ${CMAKE_CURRENT_BINARY_DIR}/IDL/
-    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/test/feature/idl_parser/idl_extra_cases/default_annotation.idl ${CMAKE_CURRENT_BINARY_DIR}/IDL/
-    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/test/feature/idl_parser/idl_extra_cases/extensibility_annotation.idl ${CMAKE_CURRENT_BINARY_DIR}/IDL/
-    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/test/feature/idl_parser/idl_extra_cases/final_annotation.idl ${CMAKE_CURRENT_BINARY_DIR}/IDL/
-    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/test/feature/idl_parser/idl_extra_cases/id_annotation.idl ${CMAKE_CURRENT_BINARY_DIR}/IDL/
-    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/test/feature/idl_parser/idl_extra_cases/key_annotation.idl ${CMAKE_CURRENT_BINARY_DIR}/IDL/
-    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/test/feature/idl_parser/idl_extra_cases/mutable_annotation.idl ${CMAKE_CURRENT_BINARY_DIR}/IDL/
-    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/test/feature/idl_parser/idl_extra_cases/optional_annotation.idl ${CMAKE_CURRENT_BINARY_DIR}/IDL/
-    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/test/feature/idl_parser/idl_extra_cases/position_annotation.idl ${CMAKE_CURRENT_BINARY_DIR}/IDL/
-    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/test/feature/idl_parser/idl_extra_cases/bit_bound_annotation.idl ${CMAKE_CURRENT_BINARY_DIR}/IDL/
-    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/test/feature/idl_parser/idl_extra_cases/external_annotation.idl ${CMAKE_CURRENT_BINARY_DIR}/IDL/
-    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/test/feature/idl_parser/idl_extra_cases/nested_annotation.idl ${CMAKE_CURRENT_BINARY_DIR}/IDL/
-    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/test/feature/idl_parser/idl_extra_cases/try_construct_annotation.idl ${CMAKE_CURRENT_BINARY_DIR}/IDL/
-    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/test/feature/idl_parser/idl_extra_cases/value_annotation.idl ${CMAKE_CURRENT_BINARY_DIR}/IDL/
-    COMMAND ${CMAKE_COMMAND} -E copy ${PROJECT_SOURCE_DIR}/test/feature/idl_parser/idl_extra_cases/default_literal_annotation.idl ${CMAKE_CURRENT_BINARY_DIR}/IDL/
+file(COPY
+    ${PROJECT_SOURCE_DIR}/thirdparty/dds-types-test/IDL/
+    DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/IDL
+)
+file(COPY
+    ${PROJECT_SOURCE_DIR}/test/feature/idl_parser/no_path_included.idl
+    ${PROJECT_SOURCE_DIR}/test/feature/idl_parser/idl_extra_cases/extra_structures.idl
+    ${PROJECT_SOURCE_DIR}/test/feature/idl_parser/idl_extra_cases/extra_unions.idl
+    ${PROJECT_SOURCE_DIR}/test/feature/idl_parser/idl_extra_cases/appendable_annotation.idl
+    ${PROJECT_SOURCE_DIR}/test/feature/idl_parser/idl_extra_cases/default_annotation.idl
+    ${PROJECT_SOURCE_DIR}/test/feature/idl_parser/idl_extra_cases/extensibility_annotation.idl
+    ${PROJECT_SOURCE_DIR}/test/feature/idl_parser/idl_extra_cases/final_annotation.idl
+    ${PROJECT_SOURCE_DIR}/test/feature/idl_parser/idl_extra_cases/id_annotation.idl
+    ${PROJECT_SOURCE_DIR}/test/feature/idl_parser/idl_extra_cases/key_annotation.idl
+    ${PROJECT_SOURCE_DIR}/test/feature/idl_parser/idl_extra_cases/mutable_annotation.idl
+    ${PROJECT_SOURCE_DIR}/test/feature/idl_parser/idl_extra_cases/optional_annotation.idl
+    ${PROJECT_SOURCE_DIR}/test/feature/idl_parser/idl_extra_cases/position_annotation.idl
+    ${PROJECT_SOURCE_DIR}/test/feature/idl_parser/idl_extra_cases/bit_bound_annotation.idl
+    ${PROJECT_SOURCE_DIR}/test/feature/idl_parser/idl_extra_cases/external_annotation.idl
+    ${PROJECT_SOURCE_DIR}/test/feature/idl_parser/idl_extra_cases/nested_annotation.idl
+    ${PROJECT_SOURCE_DIR}/test/feature/idl_parser/idl_extra_cases/try_construct_annotation.idl
+    ${PROJECT_SOURCE_DIR}/test/feature/idl_parser/idl_extra_cases/value_annotation.idl
+    ${PROJECT_SOURCE_DIR}/test/feature/idl_parser/idl_extra_cases/default_literal_annotation.idl
+    DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/IDL
 )

--- a/test/system/tools/fds/CMakeLists.txt
+++ b/test/system/tools/fds/CMakeLists.txt
@@ -95,7 +95,7 @@ if(Python3_Interpreter_FOUND)
         if(WIN32)
            add_test(
                     NAME system.tools.fastdds.${TEST}
-                    COMMAND powershell "-File" ${PWS_LAUNCHER}
+                    COMMAND powershell.exe -NoProfile -ExecutionPolicy Bypass -File ${PWS_LAUNCHER}
                             ${Python3_EXECUTABLE}
                             ${CMAKE_CURRENT_SOURCE_DIR}/tests.py
                             $<TARGET_FILE:fast-discovery-server>

--- a/test/system/tools/fds/launcher.ps1
+++ b/test/system/tools/fds/launcher.ps1
@@ -24,13 +24,18 @@ Param(
     $test_name
 )
 
-$test = Start-Process -Passthru -Wait `
-    -FilePath $python_path `
-    -ArgumentList ($test_script, $tool_path, $test_name) `
-    -WindowStyle Hidden
-
-if( $test.ExitCode -ne 0 )
+try
 {
-    $error_message = "Test: $test_name failed with exit code $($test.ExitCode)."
+    & $python_path $test_script $tool_path $test_name
+    $exit_code = $LASTEXITCODE
+}
+catch
+{
+    throw "Failed to launch test '$test_name': $($_.Exception.Message)"
+}
+
+if ($exit_code -ne 0)
+{
+    $error_message = "Test: $test_name failed with exit code $exit_code."
     throw $error_message
 }

--- a/test/system/tools/fds/tests.py
+++ b/test/system/tools/fds/tests.py
@@ -53,6 +53,9 @@ import signal
 import os
 from enum import Enum
 
+if os.name == 'nt':
+    import ctypes
+
 from xml.dom import minidom
 
 class Command_test(Enum):
@@ -86,17 +89,27 @@ def signal_handler(signum, frame):
 def send_command(command):
     print("Executing command: " + str(command))
 
-    # this subprocess cannot be executed in shell=True or using bash
+    creationflags = 0
+    if os.name == 'nt':
+        # Give the child its own console so we can deliver CTRL_C_EVENT to
+        # it without also affecting the launcher (PowerShell). We cannot use
+        # Start-Process -WindowStyle Hidden on Windows containers, and
+        # CREATE_NEW_PROCESS_GROUP + CTRL_BREAK_EVENT does not work either
+        # because the server only installs a SIGINT handler, not SIGBREAK.
+        creationflags = subprocess.CREATE_NEW_CONSOLE
+
+    # This subprocess cannot be executed in shell=True or using bash
     #  because a background script will not broadcast the signals
     #  it receives
     proc = subprocess.Popen(command,
                             stdout=subprocess.PIPE,
                             stderr=subprocess.PIPE,
-                            universal_newlines=True
+                            universal_newlines=True,
+                            creationflags=creationflags,
                             )
 
-    # sleep to let the server run
-    time.sleep(1)
+    # Sleep to let the server run
+    time.sleep(3)
 
     # 1. An exit code of 0 means everything was alright
     # 2. An exit code of 1 means the tool's process terminated before even
@@ -106,17 +119,44 @@ def send_command(command):
     #    output was different than expected
     exit_code = 0
 
-    # direct this script to ignore SIGINT
+    # If the process already exited due to failure (e.g. bad arguments, missing XML),
+    # skip signalling entirely and collect the output.
+    if proc.poll() is not None:
+        output, err = proc.communicate()
+        return output, err, exit_code
+
+    # Direct this script to ignore SIGINT
     signal.signal(signal.SIGINT, signal_handler)
 
-    # send SIGINT to process and wait for processing
+    # On Windows, detach from the launcher's console and attach to the child's brand-new
+    # console. From that attached state, GenerateConsoleCtrlEvent(CTRL_C_EVENT, 0)
+    # broadcasts CTRL+C to every process in the attached console. This reaches the server's
+    # SIGINT handler and triggers the clean-shutdown path (which prints "### Server shut down ###")
+    # without leaking the signal to PowerShell.
+    kernel32 = None
+    if os.name == 'nt':
+        kernel32 = ctypes.windll.kernel32
+        ATTACH_PARENT_PROCESS = -1
+        CTRL_C_EVENT = 0
+        kernel32.FreeConsole()
+        if not kernel32.AttachConsole(proc.pid):
+            # Restore our console and bail out hard if the attached failed
+            kernel32.AttachConsole(ATTACH_PARENT_PROCESS)
+            proc.kill()
+            print('Could not attach to child console to send CTRL_C')
+            sys.exit(2)
+        # Ignore CTRL+C in our own process so the broadcast does not terminate the Python launcher.
+        kernel32.SetConsoleCtrlHandler(None, True)
+
+    # Send signal to process and wait for processing
     lease = 0
     while True:
 
         if os.name == 'posix':
             proc.send_signal(signal.SIGINT)
         elif os.name == 'nt':
-            proc.send_signal(signal.CTRL_C_EVENT)
+            # pid == 0 targets all processes attached to our (the child's) console.
+            kernel32.GenerateConsoleCtrlEvent(0, 0)
 
         time.sleep(1)
         lease += 1
@@ -126,6 +166,12 @@ def send_command(command):
             print('iterating...')
         else:
             break
+
+    # Restore the launcher's console attachment on Windows before returning.
+    if os.name == 'nt':
+        kernel32.FreeConsole()
+        kernel32.AttachConsole(-1)  # ATTACH_PARENT_PROCESS
+        kernel32.SetConsoleCtrlHandler(None, False)
 
     # Check whether SIGINT was able to terminate the process
     if proc.poll() is None:

--- a/test/unittest/rtps/history/WriterHistoryTests.cpp
+++ b/test/unittest/rtps/history/WriterHistoryTests.cpp
@@ -78,6 +78,10 @@ void cache_change_fragment(
     {
         ASSERT_EQ(result, 0);
     }
+
+    RTPSDomain::removeRTPSWriter(writer);
+    RTPSDomain::removeRTPSParticipant(participant);
+    delete history;
 }
 
 /**
@@ -137,6 +141,10 @@ TEST(WriterHistoryTests, add_change_with_undefined_instance_handle_and_no_payloa
     ASSERT_FALSE(history->add_change(change));
     change = history->create_change(NOT_ALIVE_DISPOSED_UNREGISTERED);
     ASSERT_FALSE(history->add_change(change));
+
+    RTPSDomain::removeRTPSWriter(writer);
+    RTPSDomain::removeRTPSParticipant(participant);
+    delete history;
 }
 
 TEST(WriterHistoryTests, add_change_with_defined_instance_handle_and_no_payload)
@@ -173,6 +181,10 @@ TEST(WriterHistoryTests, add_change_with_defined_instance_handle_and_no_payload)
     change = history->create_change(NOT_ALIVE_DISPOSED_UNREGISTERED);
     change->instanceHandle.value[0] = 1;
     ASSERT_TRUE(history->add_change(change));
+
+    RTPSDomain::removeRTPSWriter(writer);
+    RTPSDomain::removeRTPSParticipant(participant);
+    delete history;
 }
 
 TEST(WriterHistoryTests, add_change_with_payload_but_undefined_handle)
@@ -208,6 +220,10 @@ TEST(WriterHistoryTests, add_change_with_payload_but_undefined_handle)
     change = history->create_change(NOT_ALIVE_DISPOSED_UNREGISTERED);
     change->serializedPayload.length = 10;
     ASSERT_TRUE(history->add_change(change));
+
+    RTPSDomain::removeRTPSWriter(writer);
+    RTPSDomain::removeRTPSParticipant(participant);
+    delete history;
 }
 
 } // namespace rtps


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

This PR improves windows tests by making system tests more robust, improving WriterHistory tests teardown and moving the copy of IDL to setup. 

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.4.x 3.2.x 2.14.x 

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_: Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
