### PR TITLE
[24379] Fix TCP reconnection with listening port

### DIFF
--- a/include/fastdds/rtps/transport/ChainingTransport.hpp
+++ b/include/fastdds/rtps/transport/ChainingTransport.hpp
@@ -31,6 +31,7 @@ namespace fastdds {
 namespace rtps {
 
 class ChainingReceiverResource;
+class NetworkFactory;
 
 /**
  * @brief Deleter for a ChainingReceiverResource
@@ -57,6 +58,9 @@ using ChainingReceiverResourceReferenceType =
  */
 class ChainingTransport : public TransportInterface
 {
+    // NetworkFactory needs to walk the chain of ChainingTransports down to the
+    // underlying transport for TCP comprobations.
+    friend class NetworkFactory;
 
 public:
 

--- a/include/fastdds/rtps/transport/ChainingTransport.hpp
+++ b/include/fastdds/rtps/transport/ChainingTransport.hpp
@@ -59,7 +59,7 @@ using ChainingReceiverResourceReferenceType =
 class ChainingTransport : public TransportInterface
 {
     // NetworkFactory needs to walk the chain of ChainingTransports down to the
-    // underlying transport for TCP comprobations.
+    // underlying transport for TCP checks.
     friend class NetworkFactory;
 
 public:

--- a/src/cpp/rtps/network/NetworkFactory.cpp
+++ b/src/cpp/rtps/network/NetworkFactory.cpp
@@ -20,6 +20,7 @@
 #include <fastdds/rtps/common/Guid.hpp>
 #include <fastdds/rtps/common/LocatorList.hpp>
 #include <fastdds/rtps/participant/RTPSParticipant.hpp>
+#include <fastdds/rtps/transport/ChainingTransport.hpp>
 #include <fastdds/rtps/transport/TransportDescriptorInterface.hpp>
 #include <fastdds/utils/IPFinder.hpp>
 #include <fastdds/utils/IPLocator.hpp>
@@ -553,7 +554,16 @@ void NetworkFactory::remove_participant_associated_send_resources(
     // all transports and let them decide what to do.
     for (auto& transport : mRegisteredTransports)
     {
-        TCPTransportInterface* tcp_transport = dynamic_cast<TCPTransportInterface*>(transport.get());
+        // A user-registered transport may be a ChainingTransport that wraps the actual
+        // TCP transport. Walk down the chain until we reach a non-chaining transport so
+        // that the cleanup is invoked on the concrete TCPTransportInterface.
+        TransportInterface* current = transport.get();
+        while (auto* chaining = dynamic_cast<ChainingTransport*>(current))
+        {
+            current = chaining->low_level_transport_.get();
+        }
+
+        TCPTransportInterface* tcp_transport = dynamic_cast<TCPTransportInterface*>(current);
         if (tcp_transport)
         {
             tcp_transport->cleanup_sender_resources(

--- a/src/cpp/rtps/transport/TCPSenderResource.hpp
+++ b/src/cpp/rtps/transport/TCPSenderResource.hpp
@@ -32,9 +32,11 @@ public:
 
     TCPSenderResource(
             TCPTransportInterface& transport,
-            Locator_t& locator)
+            Locator_t& locator,
+            const std::shared_ptr<TCPChannelResource>& channel = {})
         : SenderResource(transport.kind())
         , locator_(locator)
+        , channel_(channel)
     {
         // Implementation functions are bound to the right transport parameters
         clean_up = [this, &transport]()
@@ -66,6 +68,11 @@ public:
     Locator_t& locator()
     {
         return locator_;
+    }
+
+    const std::weak_ptr<TCPChannelResource>& channel() const
+    {
+        return channel_;
     }
 
     static TCPSenderResource* cast(
@@ -104,6 +111,9 @@ private:
             const SenderResource&) = delete;
 
     Locator_t locator_;
+
+    // Identity of the TCP channel at creation time, used to detect a reconnected channel sharing the same locator.
+    std::weak_ptr<TCPChannelResource> channel_;
 };
 
 } // namespace rtps

--- a/src/cpp/rtps/transport/TCPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/TCPTransportInterface.cpp
@@ -816,10 +816,10 @@ bool TCPTransportInterface::OpenOutputChannel(
         }
     }
 
+    std::shared_ptr<TCPChannelResource> channel;
     // (Server-Client Topology OR LARGE DATA with PDP discovery after TCP connection) - Server side
     if (channel_resource != channel_resources_.end())
     {
-        std::shared_ptr<TCPChannelResource> channel;
         // There is an existing channel in channel_resources_ created for reception with the remote locator as key. Use it.
         channel = channel_resource->second;
         // Add logical port to channel if it's not there yet
@@ -867,7 +867,7 @@ bool TCPTransportInterface::OpenOutputChannel(
             EPROSIMA_LOG_INFO(RTCP, "OpenOutputChannel: [CONNECT] @ " << IPLocator::to_string(locator));
 
             // Create a TCP_CONNECT_TYPE channel
-            std::shared_ptr<TCPChannelResource> channel(
+            channel.reset(
 #if TLS_FOUND
                 (configuration()->apply_security) ?
                 static_cast<TCPChannelResource*>(
@@ -896,7 +896,7 @@ bool TCPTransportInterface::OpenOutputChannel(
 
     statistics_info_.add_entry(locator);
     send_resource_list.emplace_back(
-        static_cast<SenderResource*>(new TCPSenderResource(*this, physical_locator)));
+        static_cast<SenderResource*>(new TCPSenderResource(*this, physical_locator, channel)));
 
     return true;
 }
@@ -1008,7 +1008,7 @@ bool TCPTransportInterface::CreateInitialConnect(
     channel->add_logical_port(logical_port, rtcp_message_manager_.get());
     statistics_info_.add_entry(locator);
     send_resource_list.emplace_back(
-        static_cast<SenderResource*>(new TCPSenderResource(*this, physical_locator)));
+        static_cast<SenderResource*>(new TCPSenderResource(*this, physical_locator, channel)));
 
     std::vector<fastdds::rtps::IPFinder::info_IP> local_interfaces;
     // Check if the locator is from an owned interface to link all local interfaces to the channel
@@ -2040,11 +2040,20 @@ void TCPTransportInterface::cleanup_sender_resources(
             {
                 if (tcp_sender_resource->locator() == remote_participant_physical_locator)
                 {
-                    // We must verify that the send resource is not being used by any active channel before removing it.
-                    // This might happen in a reconnection of a client with a listening port, as the bind_socket request
-                    // uses the listening port as port reference to establish the connection in TCPTransportInterface::fill_local_physical_port
+                    // Keep the send resource only if a *different* connected channel currently owns this physical
+                    // locator (reconnection of a client with a listening port; see fill_local_physical_port).
+                    // The original (tearing-down) channel must still be cleaned up even if it is momentarily in
+                    // eEstablished because its UNBIND has not yet been processed by the listener thread.
                     auto channel_resource_it = channel_resources_.find(tcp_sender_resource->locator());
-                    if (channel_resource_it == channel_resources_.end() || !channel_resource_it->second->connected())
+                    bool should_erase = false;
+                    if (channel_resource_it != channel_resources_.end() && channel_resource_it->second->connected())
+                    {
+                        const auto& stored = tcp_sender_resource->channel();
+                        const auto& current = channel_resource_it->second;
+                        const bool same_channel = !stored.owner_before(current) && !current.owner_before(stored);
+                        should_erase = same_channel;
+                    }
+                    if (should_erase)
                     {
                         it = send_resource_list.erase(it);
                         continue;

--- a/src/cpp/rtps/transport/TCPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/TCPTransportInterface.cpp
@@ -2045,7 +2045,7 @@ void TCPTransportInterface::cleanup_sender_resources(
                     // The original (tearing-down) channel must still be cleaned up even if it is momentarily in
                     // eEstablished because its UNBIND has not yet been processed by the listener thread.
                     auto channel_resource_it = channel_resources_.find(tcp_sender_resource->locator());
-                    bool should_erase = false;
+                    bool should_erase = true;
                     if (channel_resource_it != channel_resources_.end() && channel_resource_it->second->connected())
                     {
                         const auto& stored = tcp_sender_resource->channel();

--- a/src/cpp/rtps/transport/TCPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/TCPTransportInterface.cpp
@@ -2040,8 +2040,15 @@ void TCPTransportInterface::cleanup_sender_resources(
             {
                 if (tcp_sender_resource->locator() == remote_participant_physical_locator)
                 {
-                    it = send_resource_list.erase(it);
-                    continue;
+                    // We must verify that the send resource is not being used by any active channel before removing it.
+                    // This might happen in a reconnection of a client with a listening port, as the bind_socket request
+                    // uses the listening port as port reference to establish the connection in TCPTransportInterface::fill_local_physical_port
+                    auto channel_resource_it = channel_resources_.find(tcp_sender_resource->locator());
+                    if (channel_resource_it == channel_resources_.end() || !channel_resource_it->second->connected())
+                    {
+                        it = send_resource_list.erase(it);
+                        continue;
+                    }
                 }
             }
             ++it;

--- a/test/blackbox/common/BlackboxTestsTransportTCP.cpp
+++ b/test/blackbox/common/BlackboxTestsTransportTCP.cpp
@@ -674,6 +674,198 @@ TEST_P(TransportTCP, send_resource_cleanup_initial_peer)
     client->wait_discovery(2, std::chrono::seconds(0));
 }
 
+// Regression test for refs #24379: verify that a send resource is not destroyed by
+// cleanup_sender_resources() when there is still an active channel associated to it.
+//
+// Scenario: a client with a listening port connects to the server. If the client process
+// dies abruptly (SIGKILL), the destructor is not run, the participant never sends the PDP
+// dispose, and the listening port is released by the kernel without any application-level
+// cleanup. When a new client process reconnects using the same listening port, its
+// bind_socket request reuses the same physical locator (see
+// TCPTransportInterface::fill_local_physical_port, which uses the listening port as the
+// local physical port). Later, when the server drops the previously dead participant due
+// to its lease expiring, NetworkFactory::remove_participant_associated_send_resources() ->
+// TCPTransportInterface::cleanup_sender_resources() would wrongly destroy the send
+// resource that is now being used by the reconnected client's active channel. After the
+// fix, the send resource is kept if there is an active channel associated to it.
+TEST_P(TransportTCP, send_resource_cleanup_on_abrupt_disconnection)
+{
+#ifdef _WIN32
+    GTEST_SKIP() << "Test relies on POSIX fork()/SIGKILL to simulate abrupt client death";
+#else
+    eprosima::fastdds::dds::Log::SetVerbosity(eprosima::fastdds::dds::Log::Warning);
+
+    using eprosima::fastdds::rtps::DatagramInjectionTransportDescriptor;
+
+    const uint16_t server_port = global_port;
+    const uint16_t client_listening_port = static_cast<uint16_t>(global_port + 1);
+
+    // Short lease duration to accelerate the test
+    const eprosima::fastdds::dds::Duration_t short_lease(5, 0);
+    const eprosima::fastdds::dds::Duration_t short_announcement(1, 0);
+
+    // Need to fix the domain ID and the topic name relative to the parent process, otherwise forked child
+    // will have a different PID and thus different default domain ID and topic name.
+    std::ostringstream topic_oss;
+    topic_oss << TEST_TOPIC_NAME << "_" << asio::ip::host_name() << "_" << GET_PID();
+    const std::string fixed_topic_name = topic_oss.str();
+    const uint32_t fixed_domain_id = static_cast<uint32_t>(GET_PID()) % 230;
+
+    // Common client-side TCP transport setup, used by both the child (Client1) and the parent (Client2)
+    auto setup_client = [&](PubSubWriter<HelloWorldPubSubType>& c)
+            {
+                std::shared_ptr<eprosima::fastdds::rtps::TCPTransportDescriptor> client_transport;
+                Locator_t initialPeerLocator;
+                if (use_ipv6)
+                {
+                    client_transport = std::make_shared<eprosima::fastdds::rtps::TCPv6TransportDescriptor>();
+                    initialPeerLocator.kind = LOCATOR_KIND_TCPv6;
+                    IPLocator::setIPv6(initialPeerLocator, "::1");
+                }
+                else
+                {
+                    client_transport = std::make_shared<eprosima::fastdds::rtps::TCPv4TransportDescriptor>();
+                    initialPeerLocator.kind = LOCATOR_KIND_TCPv4;
+                    IPLocator::setIPv4(initialPeerLocator, 127, 0, 0, 1);
+                }
+                client_transport->add_listener_port(client_listening_port);
+                IPLocator::setPhysicalPort(initialPeerLocator, server_port);
+                IPLocator::setLogicalPort(initialPeerLocator, server_port);
+                LocatorList_t initial_peer_list;
+                initial_peer_list.push_back(initialPeerLocator);
+                c.setManualTopicName(fixed_topic_name)
+                        .set_domain_id(fixed_domain_id)
+                        .lease_duration(short_lease, short_announcement)
+                        .disable_builtin_transport()
+                        .add_user_transport_to_pparams(client_transport)
+                        .initial_peers(initial_peer_list)
+                        .init();
+            };
+
+    pid_t child_pid = fork();
+    ASSERT_NE(child_pid, -1) << "fork() failed in send_resource_cleanup_on_abrupt_disconnection test";
+
+    if (child_pid == 0)
+    {
+        // ===== Child process: become Client1 and wait until for SIGKILL =====
+        PubSubWriter<HelloWorldPubSubType> client1(TEST_TOPIC_NAME);
+        setup_client(client1);
+        if (!client1.isInitialized())
+        {
+            _exit(2);
+        }
+
+        // Block until SIGKILL is received
+        while (true)
+        {
+            pause();
+        }
+        // Unreachable.
+    }
+
+    // ===== Parent process. =====
+    // Best-effort guard: if anything below fails, make sure the child does not survive.
+    auto kill_child_on_exit = [&]()
+            {
+                kill(child_pid, SIGKILL);
+                int s = 0;
+                waitpid(child_pid, &s, 0);
+            };
+
+    PubSubReader<HelloWorldPubSubType> server(TEST_TOPIC_NAME);
+    test_transport_->add_listener_port(server_port);
+    auto server_chaining_transport = std::make_shared<DatagramInjectionTransportDescriptor>(test_transport_);
+    Locator_t locator;
+    locator.kind = use_ipv6 ? LOCATOR_KIND_TCPv6 : LOCATOR_KIND_TCPv4;
+    if (use_ipv6)
+    {
+        IPLocator::setIPv6(locator, "::1");
+    }
+    else
+    {
+        IPLocator::setIPv4(locator, 127, 0, 0, 1);
+    }
+    IPLocator::setPhysicalPort(locator, server_port);
+    IPLocator::setLogicalPort(locator, server_port);
+    eprosima::fastdds::dds::WireProtocolConfigQos wqos;
+    wqos.builtin.metatrafficUnicastLocatorList.push_back(locator);
+    wqos.default_unicast_locator_list.push_back(locator);
+
+    server.setManualTopicName(fixed_topic_name)
+            .set_domain_id(fixed_domain_id)
+            .lease_duration(short_lease, short_announcement)
+            .disable_builtin_transport()
+            .add_user_transport_to_pparams(server_chaining_transport)
+            .set_wire_protocol_qos(wqos)
+            .init();
+    if (!server.isInitialized())
+    {
+        kill_child_on_exit();
+        FAIL() << "Server failed to initialize";
+    }
+
+    // Wait until the server has discovered Client1
+    server.wait_discovery(std::chrono::seconds(15), 1);
+    if (server.get_matched() < 1u)
+    {
+        kill_child_on_exit();
+        FAIL() << "Server did not discover Client1";
+    }
+
+    auto tcp_send_resources = [](const std::set<SenderResource*>& list) -> size_t
+            {
+                size_t count = 0;
+                for (auto& sr : list)
+                {
+                    if (sr->kind() == LOCATOR_KIND_TCPv4 || sr->kind() == LOCATOR_KIND_TCPv6)
+                    {
+                        count++;
+                    }
+                }
+                return count;
+            };
+
+    // Sanity check: server has one TCP send resource for Client1's physical locator.
+    auto send_resource_list = server_chaining_transport->get_send_resource_list();
+    EXPECT_EQ(tcp_send_resources(send_resource_list), 1u);
+
+    // SIGKILL Client1
+    ASSERT_EQ(kill(child_pid, SIGKILL), 0);
+    int wait_status = 0;
+    ASSERT_EQ(waitpid(child_pid, &wait_status, 0), child_pid);
+
+    // Bring up Client2 in the parent process, BEFORE the server's lease for Client1 expires.
+    // Client2 reuses the same listening port as Client1, so its bind_socket
+    // request will produce the same physical locator on the server side, and the server
+    // will reuse the TCP channel associated with the old send resource for Client1
+    PubSubWriter<HelloWorldPubSubType> client2(TEST_TOPIC_NAME);
+    setup_client(client2);
+    ASSERT_TRUE(client2.isInitialized());
+
+    client2.wait_discovery(1, std::chrono::seconds(15));
+    ASSERT_GE(client2.get_matched(), 1u);
+
+    // Wait long enough for Client1's lease to expire on the server. This is the moment
+    // when remove_participant_associated_send_resources() -> cleanup_sender_resources()
+    // is called for the physical locator that Client2's active channel is using.
+    std::this_thread::sleep_for(std::chrono::seconds(2 * short_lease.seconds));
+
+    // After the cleanup runs, with the fix in place, the send resource must still exist
+    // because Client2's channel is still connected at that locator. Without the fix, it
+    // would have been wrongly destroyed and the count would be 0.
+    send_resource_list = server_chaining_transport->get_send_resource_list();
+    ASSERT_EQ(tcp_send_resources(send_resource_list), 1u);
+
+    // Data must still flow from Client2 to the server, which proves the send resource is still usable.
+    auto data = default_helloworld_data_generator();
+    server.startReception(data);
+    client2.send(data);
+    EXPECT_TRUE(data.empty());
+    server.block_for_all();
+    EXPECT_TRUE(client2.waitForAllAcked(std::chrono::milliseconds(500)));
+#endif // _WIN32
+}
+
 // Test TCP transport on large message with best effort reliability
 TEST_P(TransportTCP, large_message_send_receive)
 {

--- a/test/unittest/dds/publisher/CMakeLists.txt
+++ b/test/unittest/dds/publisher/CMakeLists.txt
@@ -158,6 +158,7 @@ set(DATAWRITERTESTS_SOURCE DataWriterTests.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/TimedEventImpl.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/domain/RTPSDomain.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/domain/RTPSDomainExtras.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/ChainingTransport.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/ChannelResource.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/network/NetmaskFilterKind.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/network/NetworkInterface.cpp

--- a/test/unittest/rtps/discovery/CMakeLists.txt
+++ b/test/unittest/rtps/discovery/CMakeLists.txt
@@ -140,6 +140,7 @@ set(PDPTESTS_SOURCE PDPTests.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/network/NetworkFactory.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/network/utils/netmask_filter.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/network/utils/network.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/ChainingTransport.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/network/NetmaskFilterKind.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/network/NetworkInterface.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/network/NetworkInterfaceWithFilter.cpp

--- a/test/unittest/rtps/network/CMakeLists.txt
+++ b/test/unittest/rtps/network/CMakeLists.txt
@@ -33,6 +33,7 @@ set(NETWORKFACTORYTESTS_SOURCE
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/ResourceEvent.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/TimedEvent.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/TimedEventImpl.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/ChainingTransport.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/ChannelResource.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/network/NetmaskFilterKind.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/network/NetworkInterface.cpp

--- a/test/unittest/rtps/reader/CMakeLists.txt
+++ b/test/unittest/rtps/reader/CMakeLists.txt
@@ -279,6 +279,7 @@ set(STATEFUL_READER_TESTS_SOURCE StatefulReaderTests.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/TimedEventImpl.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/domain/RTPSDomain.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/domain/RTPSDomainExtras.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/ChainingTransport.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/ChannelResource.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/network/NetmaskFilterKind.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/network/NetworkInterface.cpp
@@ -520,6 +521,7 @@ set(STATELESS_READER_TESTS_SOURCE StatelessReaderTests.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/network/NetworkBuffer.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/network/NetworkConfiguration.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/network/NetworkFactory.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/ChainingTransport.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/network/ReceiverResource.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/network/utils/external_locators.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/network/utils/netmask_filter.cpp

--- a/test/unittest/statistics/dds/CMakeLists.txt
+++ b/test/unittest/statistics/dds/CMakeLists.txt
@@ -264,6 +264,7 @@ if (SQLITE3_SUPPORT AND FASTDDS_STATISTICS AND NOT QNX)
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/TimedEventImpl.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/domain/RTPSDomain.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/domain/RTPSDomainExtras.cpp
+        ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/ChainingTransport.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/ChannelResource.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/network/NetmaskFilterKind.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/network/NetworkInterface.cpp
@@ -453,6 +454,7 @@ if (SQLITE3_SUPPORT AND FASTDDS_STATISTICS AND NOT QNX)
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/TimedEventImpl.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/domain/RTPSDomain.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/domain/RTPSDomainExtras.cpp
+        ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/ChainingTransport.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/ChannelResource.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/network/NetmaskFilterKind.cpp
         ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/network/NetworkInterface.cpp

--- a/test/unittest/statistics/rtps/CMakeLists.txt
+++ b/test/unittest/statistics/rtps/CMakeLists.txt
@@ -94,6 +94,7 @@ set(STATISTICS_RTPS_MONITORSERVICETESTS_SOURCE
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/ResourceEvent.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/TimedEvent.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/TimedEventImpl.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/ChainingTransport.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/network/NetmaskFilterKind.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/network/NetworkInterface.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/network/NetworkInterfaceWithFilter.cpp

--- a/test/unittest/transport/CMakeLists.txt
+++ b/test/unittest/transport/CMakeLists.txt
@@ -81,6 +81,7 @@ set(UDPV4TESTS_SOURCE
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/network/NetworkFactory.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/network/utils/netmask_filter.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/network/utils/network.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/ChainingTransport.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/ChannelResource.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/network/NetmaskFilterKind.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/network/NetworkInterface.cpp
@@ -114,6 +115,7 @@ set(ASIOHELPERSTESTS_SOURCE
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/network/NetworkFactory.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/network/utils/netmask_filter.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/network/utils/network.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/ChainingTransport.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/ChannelResource.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/network/NetmaskFilterKind.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/network/NetworkInterface.cpp
@@ -148,6 +150,7 @@ set(UDPV6TESTS_SOURCE
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/network/NetworkFactory.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/network/utils/netmask_filter.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/network/utils/network.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/ChainingTransport.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/ChannelResource.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/network/NetmaskFilterKind.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/network/NetworkInterface.cpp
@@ -188,6 +191,7 @@ set(TCPV4TESTS_SOURCE
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/ResourceEvent.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/TimedEvent.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/TimedEventImpl.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/ChainingTransport.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/ChannelResource.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/network/NetmaskFilterKind.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/network/NetworkInterface.cpp
@@ -239,6 +243,7 @@ set(TCPV6TESTS_SOURCE
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/ResourceEvent.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/TimedEvent.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/resources/TimedEventImpl.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/ChainingTransport.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/ChannelResource.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/network/NetmaskFilterKind.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/network/NetworkInterface.cpp
@@ -284,6 +289,7 @@ set(SHAREDMEMTESTS_SOURCE
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/network/NetworkFactory.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/network/utils/netmask_filter.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/network/utils/network.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/ChainingTransport.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/ChannelResource.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/network/NetmaskFilterKind.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/network/NetworkInterface.cpp


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

This PR fixes a bug in which a TCP server wrongly cleans up its TCP client participants if they have a listening port defined.  

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.4.x 3.2.x 2.14.x

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- _N/A_: Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- _N/A_: Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
