### PR TITLE
Lower minimum CMake version in examples

### DIFF
--- a/examples/cpp/benchmark/CMakeLists.txt
+++ b/examples/cpp/benchmark/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.28)
+cmake_minimum_required(VERSION 3.22) # TODO 3.28
 
 project(fastdds_benchamrk_example VERSION 1 LANGUAGES CXX)
 

--- a/examples/cpp/configuration/CMakeLists.txt
+++ b/examples/cpp/configuration/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.28)
+cmake_minimum_required(VERSION 3.22) # TODO 3.28
 
 project(fastdds_configuration_example VERSION 1 LANGUAGES CXX)
 

--- a/examples/cpp/content_filter/CMakeLists.txt
+++ b/examples/cpp/content_filter/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.28)
+cmake_minimum_required(VERSION 3.22) # TODO 3.28
 
 project(fastdds_content_filter_example VERSION 1 LANGUAGES CXX)
 

--- a/examples/cpp/custom_payload_pool/CMakeLists.txt
+++ b/examples/cpp/custom_payload_pool/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.28)
+cmake_minimum_required(VERSION 3.22) # TODO 3.28
 
 project(custom_payload_pool VERSION 1 LANGUAGES CXX)
 

--- a/examples/cpp/delivery_mechanisms/CMakeLists.txt
+++ b/examples/cpp/delivery_mechanisms/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.28)
+cmake_minimum_required(VERSION 3.22) # TODO 3.28
 
 project(fastdds_delivery_mechanisms_example VERSION 1 LANGUAGES CXX)
 

--- a/examples/cpp/discovery_server/CMakeLists.txt
+++ b/examples/cpp/discovery_server/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.28)
+cmake_minimum_required(VERSION 3.22) # TODO 3.28
 
 project(fastdds_discovery_server_example VERSION 1 LANGUAGES CXX)
 

--- a/examples/cpp/flow_control/CMakeLists.txt
+++ b/examples/cpp/flow_control/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.28)
+cmake_minimum_required(VERSION 3.22) # TODO 3.28
 
 project(fastdds_flow_control_example VERSION 1 LANGUAGES CXX)
 

--- a/examples/cpp/hello_world/CMakeLists.txt
+++ b/examples/cpp/hello_world/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.28)
+cmake_minimum_required(VERSION 3.22) # TODO 3.28
 
 project(fastdds_hello_world_example VERSION 1 LANGUAGES CXX)
 

--- a/examples/cpp/rtps/CMakeLists.txt
+++ b/examples/cpp/rtps/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.28)
+cmake_minimum_required(VERSION 3.22) # TODO 3.28
 
 project(fastdds_rtps_example VERSION 1 LANGUAGES CXX)
 

--- a/examples/cpp/security/CMakeLists.txt
+++ b/examples/cpp/security/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.28)
+cmake_minimum_required(VERSION 3.22) # TODO 3.28
 
 project(fastdds_security_example VERSION 1 LANGUAGES CXX)
 

--- a/examples/cpp/static_edp_discovery/CMakeLists.txt
+++ b/examples/cpp/static_edp_discovery/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.28)
+cmake_minimum_required(VERSION 3.22) # TODO 3.28
 
 project(fastdds_static_edp_discovery_example VERSION 1 LANGUAGES CXX)
 

--- a/examples/cpp/topic_instances/CMakeLists.txt
+++ b/examples/cpp/topic_instances/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.28)
+cmake_minimum_required(VERSION 3.22) # TODO 3.28
 
 project(fastdds_topic_instances_example VERSION 1 LANGUAGES CXX)
 

--- a/examples/cpp/xtypes/CMakeLists.txt
+++ b/examples/cpp/xtypes/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.28)
+cmake_minimum_required(VERSION 3.22) # TODO 3.28
 
 project(fastdds_xtypes_example VERSION 1 LANGUAGES CXX)
 

--- a/fuzz/C++/fuzz_XMLProfiles/CMakeLists.txt
+++ b/fuzz/C++/fuzz_XMLProfiles/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.28)
+cmake_minimum_required(VERSION 3.22) # TODO 3.28
 
 project(fuzz_XMLProfiles VERSION 1 LANGUAGES CXX)
 

--- a/fuzz/C++/fuzz_processCDRMsg/CMakeLists.txt
+++ b/fuzz/C++/fuzz_processCDRMsg/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.28)
+cmake_minimum_required(VERSION 3.22) # TODO 3.28
 
 project(fuzz_processCDRMsg VERSION 1 LANGUAGES CXX)
 

--- a/test/profiling/allocations/CMakeLists.txt
+++ b/test/profiling/allocations/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-cmake_minimum_required(VERSION 3.28)
+cmake_minimum_required(VERSION 3.22) # TODO 3.28
 
 project(fastdds_allocation_test VERSION 1 LANGUAGES CXX)
 

--- a/test/unittest/cmake/force_cxx/CMakeLists.txt
+++ b/test/unittest/cmake/force_cxx/CMakeLists.txt
@@ -15,7 +15,7 @@
 ###############################################################################
 # Auxiliary project for check_configuration.cmake module testing
 ###############################################################################
-cmake_minimum_required(VERSION 3.28)
+cmake_minimum_required(VERSION 3.22) # TODO 3.28
 
 # setup
 option(TEST_FALLBACK "Ignore CMake builtin instrospection and use our original fallback" OFF)


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
Set CMake minimum version in examples to be the same as the one in the library project for consistency. 
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.5.x 3.4.x 3.2.x 2.14.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_ Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_ Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- _N/A_ Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- _N/A_ Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- _N/A_ Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
