### PR TITLE
fix: fix missing syscall.h file issue on QNX8

### DIFF
--- a/src/cpp/rtps/reader/WriterProxy.cpp
+++ b/src/cpp/rtps/reader/WriterProxy.cpp
@@ -33,7 +33,7 @@
 #include <rtps/reader/StatefulReader.hpp>
 #include <rtps/writer/BaseWriter.hpp>
 
-#if !defined(NDEBUG) && !defined(ANDROID) && defined(FASTDDS_SOURCE) && defined(__unix__)
+#if !defined(NDEBUG) && !defined(ANDROID) && defined(FASTDDS_SOURCE) && defined(__linux__)
 #define SHOULD_DEBUG_LINUX
 #endif // SHOULD_DEBUG_LINUX
 


### PR DESCRIPTION
## Description

  When compiling Fast DDS debug build on QNX 8, <sys/syscall.h> is not available, causing build failure. Added conditional include with fallback to compile successfully on QNX platforms.

Signed-off-by: Duan Yang <Yang.Duan@zf.com>

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [ ] Commit messages follow the project guidelines. 
- [ ] The code follows the style guidelines of this project. 
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- [ ] Any new/modified methods have been properly documented using Doxygen.
- [ ] Any new configuration API has an equivalent XML API (with the corresponding XSD extension) 
- [ ] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. 
- [ ] Changes are API compatible.
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. 
- [ ] Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
