### PR TITLE
[24364 & 24365] Add UBSan workflow and solve its errors

### DIFF
--- a/.github/workflows/config/ubsan.meta
+++ b/.github/workflows/config/ubsan.meta
@@ -1,0 +1,17 @@
+names:
+    fastdds:
+        cmake-args:
+            - "-DNO_TLS=OFF"
+            - "-DSECURITY=ON"
+            - "-DFASTDDS_STATISTICS=ON"
+            - "-DSANITIZER=Undefined"
+            - "-DCMAKE_CXX_FLAGS_INIT='-Werror'"
+            - "-DEPROSIMA_BUILD_TESTS=ON"
+            - "-DRTPS_API_TESTS=ON"
+            - "-DFASTDDS_PIM_API_TESTS=ON"
+            - "-DPERFORMANCE_TESTS=ON"
+    googletest-distribution:
+        cmake-args:
+            - "-Dgtest_force_shared_crt=ON"
+            - "-DBUILD_SHARED_LIBS=ON"
+            - "-DBUILD_GMOCK=ON"

--- a/.github/workflows/config/ubsan.meta
+++ b/.github/workflows/config/ubsan.meta
@@ -1,17 +1,17 @@
 names:
     fastdds:
         cmake-args:
-            - "-DNO_TLS=OFF"
-            - "-DSECURITY=ON"
-            - "-DFASTDDS_STATISTICS=ON"
-            - "-DSANITIZER=Undefined"
-            - "-DCMAKE_CXX_FLAGS_INIT='-Werror'"
-            - "-DEPROSIMA_BUILD_TESTS=ON"
-            - "-DRTPS_API_TESTS=ON"
-            - "-DFASTDDS_PIM_API_TESTS=ON"
-            - "-DPERFORMANCE_TESTS=ON"
+            - -DNO_TLS=OFF
+            - -DSECURITY=ON
+            - -DFASTDDS_STATISTICS=ON
+            - -DSANITIZER=Undefined
+            - -DCOMPILE_WARNING_AS_ERROR=ON
+            - -DEPROSIMA_BUILD_TESTS=ON
+            - -DRTPS_API_TESTS=ON
+            - -DFASTDDS_PIM_API_TESTS=ON
+            - -DPERFORMANCE_TESTS=ON
     googletest-distribution:
         cmake-args:
-            - "-Dgtest_force_shared_crt=ON"
-            - "-DBUILD_SHARED_LIBS=ON"
-            - "-DBUILD_GMOCK=ON"
+            - -Dgtest_force_shared_crt=ON
+            - -DBUILD_SHARED_LIBS=ON
+            - -DBUILD_GMOCK=ON

--- a/.github/workflows/reusable-sanitizers-ci.yml
+++ b/.github/workflows/reusable-sanitizers-ci.yml
@@ -15,6 +15,10 @@ on:
         description: 'Run Thread Sanitizer job for Fast DDS'
         required: false
         type: boolean
+      run_ubsan_fastdds:
+        description: 'Run Undefined Behavior Sanitizer job for Fast DDS'
+        required: false
+        type: boolean
       colcon_build_args:
         description: 'Optional colcon build arguments'
         required: false
@@ -424,3 +428,189 @@ jobs:
         run: |
           Write-Host ${{ steps.report_summary.outcome }}
           exit 1
+
+  ubsan_fastdds_build:
+    if: ${{ inputs.run_ubsan_fastdds == true }}
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Free disk space
+        uses: eProsima/eProsima-CI/ubuntu/free_disk_space@v0
+
+      - name: Sync eProsima/Fast-DDS repository
+        uses: eProsima/eProsima-CI/external/checkout@v0
+        with:
+          path: src/fastdds
+          submodules: true
+          ref: ${{ inputs.fastdds_ref }}
+
+      - name: Install Fix Python version
+        uses: eProsima/eProsima-CI/external/setup-python@v0
+        with:
+          python-version: '3.11'
+
+      - name: Get minimum supported version of CMake
+        uses: eProsima/eProsima-CI/external/get-cmake@v0
+        with:
+          cmakeVersion: '3.28.6'
+
+      - name: Install apt packages
+        uses: eProsima/eProsima-CI/ubuntu/install_apt_packages@v0
+        with:
+          packages: curl grep libasio-dev libtinyxml2-dev python3 python3-pip software-properties-common wget
+
+      - name: Install colcon
+        uses: eProsima/eProsima-CI/ubuntu/install_colcon@v0
+
+      - name: Install Python dependencies
+        uses: eProsima/eProsima-CI/ubuntu/install_python_packages@v0
+        with:
+          packages: vcstool xmlschema
+
+      - name: Setup CCache
+        uses: eProsima/eProsima-CI/external/setup-ccache-action@v0
+        if: ${{ !always() }}
+        with:
+          api_token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Get Fast CDR branch
+        id: get_fastcdr_branch
+        uses: eProsima/eProsima-CI/ubuntu/get_related_branch_from_repo@v0
+        with:
+          remote_repository: eProsima/Fast-CDR
+          fallback_branch: ${{ inputs.fastcdr_ref }}
+
+      - name: Download Fast CDR
+        uses: eProsima/eProsima-CI/external/checkout@v0
+        with:
+          repository: eProsima/Fast-CDR
+          path: ${{ github.workspace }}/src/fastcdr
+          ref: ${{ steps.get_fastcdr_branch.outputs.deduced_branch }}
+
+      - name: Fetch Fast DDS dependencies
+        uses: eProsima/eProsima-CI/ubuntu/vcs_import@v0
+        with:
+          vcs_repos_file: ${{ github.workspace }}/src/fastdds/fastdds.repos
+          destination_workspace: src
+          skip_existing: 'true'
+
+      - name: Fetch Fast DDS CI dependencies
+        uses: eProsima/eProsima-CI/ubuntu/vcs_import@v0
+        with:
+          vcs_repos_file: ${{ github.workspace }}/src/fastdds/.github/workflows/config/fastdds_test.repos
+          destination_workspace: src
+          skip_existing: 'true'
+
+      - name: Show .meta file
+        id: show_meta
+        run: |
+          cat ${{ github.workspace }}/src/fastdds/.github/workflows/config/ubsan.meta
+
+      - name: Colcon build
+        continue-on-error: false
+        uses: eProsima/eProsima-CI/ubuntu/colcon_build@v0
+        with:
+          colcon_meta_file: ${{ github.workspace }}/src/fastdds/.github/workflows/config/ubsan.meta
+          colcon_build_args: ${{ inputs.colcon_build_args }}
+          cmake_args: ${{ inputs.cmake_args }}
+          cmake_args_default: ''
+          cmake_build_type: 'Debug'
+          workspace: ${{ github.workspace }}
+          workspace_dependencies: ''
+
+      - name: Pack workspace preserving permissions
+        shell: bash
+        run: |
+          tar -C "${{ github.workspace }}" -cpf "${{ runner.temp }}/ubsan_build_${{ inputs.label }}.tar" .
+
+      - name: Upload build artifacts
+        uses: eProsima/eProsima-CI/external/upload-artifact@v0
+        with:
+          name: build_artifacts_fastdds_ubsan_${{ inputs.label }}
+          path: ${{ runner.temp }}/ubsan_build_${{ inputs.label }}.tar
+
+  ubsan_fastdds_test:
+    if: ${{ inputs.run_ubsan_fastdds == true }}
+    needs: ubsan_fastdds_build
+    runs-on: ubuntu-24.04
+    env:
+      UBSAN_OPTIONS: halt_on_error=1:abort_on_error=1:print_stacktrace=1
+    steps:
+      - name: Free disk space
+        uses: eProsima/eProsima-CI/ubuntu/free_disk_space@v0
+
+      - name: Download build artifact
+        uses: eProsima/eProsima-CI/external/download-artifact@v0
+        with:
+          name: build_artifacts_fastdds_ubsan_${{ inputs.label }}
+          path: ${{ runner.temp }}
+
+      - name: Unpack workspace preserving permissions
+        shell: bash
+        run: |
+          tar -C "${{ github.workspace }}" -xpf "${{ runner.temp }}/ubsan_build_${{ inputs.label }}.tar"
+
+      - name: Install Fix Python version
+        uses: eProsima/eProsima-CI/external/setup-python@v0
+        with:
+          python-version: '3.11'
+
+      - name: Get minimum supported version of CMake
+        uses: eProsima/eProsima-CI/external/get-cmake@v0
+        with:
+          cmakeVersion: '3.28.6'
+
+      - name: Install apt packages
+        uses: eProsima/eProsima-CI/ubuntu/install_apt_packages@v0
+        with:
+          packages: curl grep libasio-dev libtinyxml2-dev python3 python3-pip software-properties-common wget
+
+      - name: Install colcon
+        uses: eProsima/eProsima-CI/ubuntu/install_colcon@v0
+
+      - name: Install Python dependencies
+        uses: eProsima/eProsima-CI/ubuntu/install_python_packages@v0
+        with:
+          packages: setuptools gcovr tomark xmltodict jsondiff pandas psutil
+
+      - name: Set up hosts file for DNS testing
+        run: |
+          sudo echo "" | sudo tee -a /etc/hosts
+          sudo echo "127.0.0.1 localhost.test" | sudo tee -a /etc/hosts
+          sudo echo "::1 localhost.test" | sudo tee -a /etc/hosts
+          sudo echo "154.56.134.194 www.eprosima.com.test" | sudo tee -a /etc/hosts
+          sudo echo "216.58.215.164 www.acme.com.test" | sudo tee -a /etc/hosts
+          sudo echo "2a00:1450:400e:803::2004 www.acme.com.test" | sudo tee -a /etc/hosts
+          sudo echo "140.82.121.4 www.foo.com.test" | sudo tee -a /etc/hosts
+          sudo echo "140.82.121.3 www.foo.com.test" | sudo tee -a /etc/hosts
+          sudo echo "ff1e::ffff:efff:1 acme.org.test" | sudo tee -a /etc/hosts
+
+      - name: Colcon test
+        id: test
+        continue-on-error: true
+        uses: eProsima/eProsima-CI/ubuntu/colcon_test@v0
+        with:
+          colcon_args_default: ''
+          colcon_test_args: ${{ inputs.colcon_test_args }}
+          colcon_test_args_default: '--event-handlers=console_direct+ --return-code-on-test-failure'
+          ctest_args: ${{ inputs.ctest_args }}
+          ctest_args_default: '--timeout 300 --label-exclude "xfail"'
+          packages_names: fastdds
+          workspace: ${{ github.workspace }}
+          workspace_dependencies: ''
+          test_report_artifact: ${{ format('test_report_{0}_{1}', inputs.label, github.job) }}
+
+      - name: Report sanitizer errors
+        run: |
+          # UBSan finding header lines look like:
+          #   <file>:<line>:<col>: runtime error: <description>
+          # Filter on ": runtime error:" so we keep one line per finding (the header)
+          bash src/fastdds/.github/workflows/utils/specific_errors_filter.sh \
+            ": runtime error:" \
+            log/latest_test/fastdds/stdout_stderr.log \
+            _tmp_specific_error_file.log
+
+          python3 src/fastdds/.github/workflows/utils/log_parser.py \
+            --log-file log/latest_test/fastdds/stdout_stderr.log \
+            --specific-error-file _tmp_specific_error_file.log \
+            --output-file $GITHUB_STEP_SUMMARY  \
+            --sanitizer ubsan

--- a/.github/workflows/sanitizers-ci.yml
+++ b/.github/workflows/sanitizers-ci.yml
@@ -15,6 +15,10 @@ on:
         description: 'Run Thread Sanitizer job for Fast DDS'
         required: false
         type: boolean
+      run_ubsan_fastdds:
+        description: 'Run Undefined Behavior Sanitizer job for Fast DDS'
+        required: false
+        type: boolean
       colcon_build_args:
         description: 'Optional colcon build arguments'
         required: false
@@ -59,6 +63,7 @@ jobs:
       label: ${{ inputs.label || 'fastdds-sanitizers-ci' }}
       run_asan_fastdds: ${{ ((inputs.run_asan_fastdds == true) && true) || github.event_name == 'pull_request' }}
       run_tsan_fastdds: ${{ ((inputs.run_tsan_fastdds == true) && true) || github.event_name == 'pull_request' }}
+      run_ubsan_fastdds: ${{ ((inputs.run_ubsan_fastdds == true) && true) || github.event_name == 'pull_request' }}
       colcon_build_args: ${{ inputs.colcon_build_args || '' }}
       colcon_test_args: ${{ inputs.colcon_test_args || '' }}
       cmake_args: ${{ inputs.cmake_args || '' }}

--- a/.github/workflows/utils/log_parser.py
+++ b/.github/workflows/utils/log_parser.py
@@ -49,7 +49,7 @@ def parse_options():
         '--specific-error-file',
         type=str,
         required=True,
-        help='Path to file with ASAN or TSAN specific errors.'
+        help='Path to file with ASAN, TSAN or UBSAN specific errors.'
     )
     required_args.add_argument(
         '-o',
@@ -64,7 +64,7 @@ def parse_options():
         '--sanitizer',
         type=str,
         required=True,
-        help='Sanitizer to use. [ASAN|TSAN] no case sensitive.'
+        help='Sanitizer to use. [ASAN|TSAN|UBSAN] no case sensitive.'
     )
 
     return parser.parse_args()
@@ -148,6 +148,24 @@ def tsan_line_splitter(
         text_to_split_end=' (pid=')
 
 
+# Each UBSan finding starts with a source location followed by " runtime error: <description>".
+# We group findings by "<basename>:<line>:<col>: <description>" so that the same UB at the
+# same site collapses into a single row regardless of repetition or ctest line prefixes
+_UBSAN_LINE_RE = re.compile(
+    r'(?P<path>\S+?):(?P<line>\d+):(?P<col>\d+):\s*runtime error:\s*(?P<desc>.+?)\s*$'
+)
+
+
+def ubsan_line_splitter(
+        line: str):
+    match = _UBSAN_LINE_RE.search(line.rstrip('\r\n'))
+    if not match:
+        return line.strip()
+    basename = match.group('path').rsplit('/', 1)[-1]
+    return (f"{basename}:{match.group('line')}:{match.group('col')}: "
+            f"{match.group('desc')}")
+
+
 def common_specific_errors_list(
         errors_file_path: str,
         line_splitter):
@@ -203,10 +221,19 @@ def main():
     # Parse arguments
     args = parse_options()
 
-    # Get specific ASAN or TSAN variables
-    asan = args.sanitizer.lower() == 'asan'
-    line_splitter = (asan_line_splitter if asan else tsan_line_splitter)
-    file_title = ('ASAN' if asan else 'TSAN') + ' Errors Summary'
+    # Select the splitter and report title for the requested sanitizer.
+    sanitizer = args.sanitizer.lower()
+    splitters = {
+        'asan': (asan_line_splitter, 'ASAN'),
+        'tsan': (tsan_line_splitter, 'TSAN'),
+        'ubsan': (ubsan_line_splitter, 'UBSAN'),
+    }
+    if sanitizer not in splitters:
+        raise SystemExit(
+            f"Unsupported sanitizer '{args.sanitizer}'. Expected one of: "
+            f"{', '.join(s.upper() for s in splitters)}.")
+    line_splitter, title_prefix = splitters[sanitizer]
+    file_title = f'{title_prefix} Errors Summary'
 
     # Execute specific errors parse
     specific_errors, n_errors = common_specific_errors_list(

--- a/.github/workflows/utils/log_parser.py
+++ b/.github/workflows/utils/log_parser.py
@@ -154,16 +154,25 @@ def tsan_line_splitter(
 _UBSAN_LINE_RE = re.compile(
     r'(?P<path>\S+?):(?P<line>\d+):(?P<col>\d+):\s*runtime error:\s*(?P<desc>.+?)\s*$'
 )
+# Strip GitHub Actions ISO-8601 timestamp prefix and/or a ctest line prefix ("<test-id>: ").
+_GH_TIMESTAMP_RE = re.compile(r'^\d{4}-\d{2}-\d{2}T\S+\s+')
+_CTEST_PREFIX_RE = re.compile(r'^\d+:\s*')
+# Hex addresses ("0x55ade3179480") differ across runs but represent the same logical UB;
+# normalize them to "0x..." so identical findings at the same site collapse into one row.
+_HEX_ADDRESS_RE = re.compile(r'0x[0-9a-fA-F]+')
 
 
 def ubsan_line_splitter(
         line: str):
-    match = _UBSAN_LINE_RE.search(line.rstrip('\r\n'))
+    stripped = _GH_TIMESTAMP_RE.sub('', line.rstrip('\r\n'))
+    stripped = _CTEST_PREFIX_RE.sub('', stripped)
+    match = _UBSAN_LINE_RE.search(stripped)
     if not match:
-        return line.strip()
+        # Not an UBSan finding header
+        return None
     basename = match.group('path').rsplit('/', 1)[-1]
-    return (f"{basename}:{match.group('line')}:{match.group('col')}: "
-            f"{match.group('desc')}")
+    desc = _HEX_ADDRESS_RE.sub('0x...', match.group('desc'))
+    return f"{basename}:{match.group('line')}:{match.group('col')}: {desc}"
 
 
 def common_specific_errors_list(
@@ -188,11 +197,14 @@ def common_specific_errors_dict(
         errors_file_path: str,
         line_splitter):
 
-    # failed tests
+    # Open with newline='' so Python's universal-newline mode does not split a single
+    # grep-emitted line on bare '\r' characters.
     errors = {}
-    with open(errors_file_path, 'r') as file:
-        for line in file.readlines():
+    with open(errors_file_path, 'r', newline='') as file:
+        for line in file:
             error_id = line_splitter(line)
+            if error_id is None:
+                continue
             if error_id in errors:
                 errors[error_id] += 1
             else:

--- a/.github/workflows/utils/log_parser.py
+++ b/.github/workflows/utils/log_parser.py
@@ -22,6 +22,23 @@ from tomark import Tomark
 DESCRIPTION = """Script to read a test log and return a summary table"""
 USAGE = ('python3 log_parser.py')
 
+# Each UBSan finding starts with a source location followed by " runtime error: <description>".
+# We group findings by "<basename>:<line>:<col>: <description>" so that the same UB at the
+# same site collapses into a single row regardless of repetition or ctest line prefixes
+_UBSAN_LINE_RE = re.compile(
+    r'(?P<path>\S+?):(?P<line>\d+):(?P<col>\d+):\s*runtime error:\s*(?P<desc>.+?)\s*$'
+)
+# Strip GitHub Actions ISO-8601 timestamp prefix and/or a ctest line prefix ("<test-id>: ").
+# The ctest prefix captures the test id so we can attribute UBSan findings to their test;
+# .sub() still strips just the prefix, and .match() exposes the id via the named group.
+_GH_TIMESTAMP_RE = re.compile(r'^\d{4}-\d{2}-\d{2}T\S+\s+')
+_CTEST_PREFIX_RE = re.compile(r'^(?P<id>\d+):\s*')
+# Hex addresses ("0x55ade3179480") differ across runs but represent the same logical UB;
+# normalize them to "0x..." so identical findings at the same site collapse into one row.
+_HEX_ADDRESS_RE = re.compile(r'0x[0-9a-fA-F]+')
+# Path fragments whose UBSan findings are suppressed (thirdparty code we don't maintain).
+_UBSAN_IGNORED_PATH_SUBSTRINGS = ('sqlite3.c',)
+
 
 def parse_options():
     """
@@ -71,7 +88,10 @@ def parse_options():
 
 
 def failure_test_list(
-        log_file_path: str):
+        log_file_path: str,
+        ignored_test_ids: set = None):
+
+    ignored_test_ids = ignored_test_ids or set()
 
     # failed tests
     saved_lines = []
@@ -93,12 +113,16 @@ def failure_test_list(
             # Thus, it uses this variable to get the correct # of spaces in error name
             n_spaces_in_error = len(test[test.find('(')+1:test.find(')')].split()) - 1
 
+            test_id = split_test[- 4 - n_spaces_in_error]
+            if test_id in ignored_test_ids:
+                continue
+
             # Insert as failed test (in first place, because we are reading them inversed)
             # the new test failed with the name and id taken from split line
             failed_tests.insert(
                 0,
                 dict({
-                    'ID': split_test[- 4 - n_spaces_in_error],
+                    'ID': test_id,
                     'Name': split_test[- 2 - n_spaces_in_error],
                     'Type': test[test.find('(')+1:test.find(')')]
                 }))
@@ -115,6 +139,35 @@ def failure_test_list(
                 }))
 
     return failed_tests, n_errors
+
+
+def tests_failing_only_in_ignored_ubsan_paths(
+        log_file_path: str,
+        ignored_path_substrings: tuple):
+    """
+    Return the set of ctest test ids whose UBSan findings are exclusively in files
+    matching ignored_path_substrings. Tests with no UBSan findings or with at least
+    one finding outside the ignored paths are excluded (i.e., they remain reported).
+    """
+    test_id_to_paths = {}
+    with open(log_file_path, 'r', encoding='utf-8', errors='replace') as file:
+        for line in file:
+            stripped = _GH_TIMESTAMP_RE.sub('', line.rstrip('\r\n'))
+            id_match = _CTEST_PREFIX_RE.match(stripped)
+            if not id_match:
+                continue
+            ubsan_match = _UBSAN_LINE_RE.search(stripped[id_match.end():])
+            if not ubsan_match:
+                continue
+            test_id_to_paths.setdefault(id_match.group('id'), set()).add(
+                ubsan_match.group('path'))
+
+    return {
+        test_id for test_id, paths in test_id_to_paths.items()
+        if paths and all(
+            any(sub in path for sub in ignored_path_substrings)
+            for path in paths)
+    }
 
 
 def _common_line_splitter(
@@ -148,20 +201,6 @@ def tsan_line_splitter(
         text_to_split_end=' (pid=')
 
 
-# Each UBSan finding starts with a source location followed by " runtime error: <description>".
-# We group findings by "<basename>:<line>:<col>: <description>" so that the same UB at the
-# same site collapses into a single row regardless of repetition or ctest line prefixes
-_UBSAN_LINE_RE = re.compile(
-    r'(?P<path>\S+?):(?P<line>\d+):(?P<col>\d+):\s*runtime error:\s*(?P<desc>.+?)\s*$'
-)
-# Strip GitHub Actions ISO-8601 timestamp prefix and/or a ctest line prefix ("<test-id>: ").
-_GH_TIMESTAMP_RE = re.compile(r'^\d{4}-\d{2}-\d{2}T\S+\s+')
-_CTEST_PREFIX_RE = re.compile(r'^\d+:\s*')
-# Hex addresses ("0x55ade3179480") differ across runs but represent the same logical UB;
-# normalize them to "0x..." so identical findings at the same site collapse into one row.
-_HEX_ADDRESS_RE = re.compile(r'0x[0-9a-fA-F]+')
-
-
 def ubsan_line_splitter(
         line: str):
     stripped = _GH_TIMESTAMP_RE.sub('', line.rstrip('\r\n'))
@@ -169,6 +208,9 @@ def ubsan_line_splitter(
     match = _UBSAN_LINE_RE.search(stripped)
     if not match:
         # Not an UBSan finding header
+        return None
+    if any(sub in match.group('path') for sub in _UBSAN_IGNORED_PATH_SUBSTRINGS):
+        # Ignore UBSan findings in thirdparty code we don't maintain.
         return None
     basename = match.group('path').rsplit('/', 1)[-1]
     desc = _HEX_ADDRESS_RE.sub('0x...', match.group('desc'))
@@ -256,9 +298,18 @@ def main():
         result=specific_errors,
         output_file_path=args.output_file)
 
+    # For UBSan, also drop from the "Tests failed" table any test whose findings
+    # were all in ignored thirdparty paths (matches what we suppress above).
+    ignored_test_ids = set()
+    if sanitizer == 'ubsan':
+        ignored_test_ids = tests_failing_only_in_ignored_ubsan_paths(
+            log_file_path=args.log_file,
+            ignored_path_substrings=_UBSAN_IGNORED_PATH_SUBSTRINGS)
+
     # Execute failed tests
     tests_failed, _ = failure_test_list(
-        log_file_path=args.log_file)
+        log_file_path=args.log_file,
+        ignored_test_ids=ignored_test_ids)
     print_list_to_markdown(
         title='Tests failed',
         result=tests_failed,

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,23 @@ if (SANITIZER)
             message(FATAL_ERROR "Thread sanitizer requires Clang or GCC. Aborting.")
         endif()
 
+    elseif(${SANITIZER} STREQUAL "UNDEFINED")
+        message(STATUS "Enabling undefined behavior sanitizer...")
+        # Warning/Error messages
+        if(NOT (CMAKE_BUILD_TYPE STREQUAL "Debug"))
+            message(WARNING "Undefined behavior sanitizer results with an optimized (non-Debug) build may be misleading")
+        endif()
+
+        if(CMAKE_COMPILER_IS_GNUCXX)
+            message(STATUS "Building with Undefined behavior sanitizer Tools")
+
+            set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -fsanitize=undefined -fno-omit-frame-pointer -fsanitize=float-cast-overflow -fsanitize=float-divide-by-zero -fsanitize=bounds-strict")
+            set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -fsanitize=undefined -fno-omit-frame-pointer -fsanitize=float-cast-overflow -fsanitize=float-divide-by-zero -fsanitize=bounds-strict")
+
+        else()
+            message(FATAL_ERROR "Undefined behavior sanitizer requires GCC. Aborting.")
+        endif()
+
     else()
         message(WARNING "Sanitizer option not supported. Continuing without any code instrumentation... ")
 

--- a/include/fastdds/statistics/dds/domain/DomainParticipant.hpp
+++ b/include/fastdds/statistics/dds/domain/DomainParticipant.hpp
@@ -26,7 +26,9 @@
 #include <fastdds/dds/builtin/topic/PublicationBuiltinTopicData.hpp>
 #include <fastdds/dds/builtin/topic/SubscriptionBuiltinTopicData.hpp>
 #include <fastdds/dds/core/ReturnCode.hpp>
+#include <fastdds/dds/core/status/StatusMask.hpp>
 #include <fastdds/dds/domain/DomainParticipant.hpp>
+#include <fastdds/dds/domain/DomainParticipantFactory.hpp>
 #include <fastdds/dds/publisher/qos/DataWriterQos.hpp>
 #include <fastdds/fastdds_dll.hpp>
 
@@ -46,6 +48,13 @@ namespace dds {
 class DomainParticipant : public eprosima::fastdds::dds::DomainParticipant
 {
     DomainParticipant() = delete;
+
+protected:
+
+    DomainParticipant(
+            const eprosima::fastdds::dds::StatusMask& mask);
+
+    friend class eprosima::fastdds::dds::DomainParticipantFactory;
 
 public:
 

--- a/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
@@ -39,6 +39,10 @@
 #include <xmlparser/XMLEndpointParser.h>
 #include <xmlparser/XMLProfileManager.h>
 
+#ifdef FASTDDS_STATISTICS
+#include <fastdds/statistics/dds/domain/DomainParticipant.hpp>
+#endif // ifdef FASTDDS_STATISTICS
+
 using namespace eprosima::fastdds::xmlparser;
 
 using eprosima::fastdds::rtps::RTPSDomain;
@@ -157,10 +161,11 @@ DomainParticipant* DomainParticipantFactory::create_participant(
 
     const DomainParticipantQos& pqos = (&qos == &PARTICIPANT_QOS_DEFAULT) ? default_participant_qos_ : qos;
 
-    DomainParticipant* dom_part = new DomainParticipant(mask);
 #ifndef FASTDDS_STATISTICS
+    DomainParticipant* dom_part = new DomainParticipant(mask);
     DomainParticipantImpl* dom_part_impl = new DomainParticipantImpl(dom_part, did, pqos, listener);
 #else
+    statistics::dds::DomainParticipant* dom_part = new statistics::dds::DomainParticipant(mask);
     statistics::dds::DomainParticipantImpl* dom_part_impl =
             new statistics::dds::DomainParticipantImpl(dom_part, did, pqos, listener);
 #endif // FASTDDS_STATISTICS

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -1619,7 +1619,7 @@ void DataWriterImpl::configure_deadline_timer_()
                 return deadline_missed();
             },
             // Park timer with a huge interval (prevents spurious callbacks); we'll arm/cancel explicitly
-            std::numeric_limits<double>::max()
+            std::chrono::microseconds::max()
             );
     }
 

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -17,6 +17,8 @@
  */
 #include <fastdds/subscriber/DataReaderImpl.hpp>
 
+#include <cstdint>
+#include <limits>
 #include <memory>
 #include <stdexcept>
 #if defined(__has_include) && __has_include(<version>)
@@ -1576,8 +1578,29 @@ LivelinessChangedStatus& DataReaderImpl::update_liveliness_status(
 const SampleLostStatus& DataReaderImpl::update_sample_lost_status(
         int32_t sample_lost_since_last_update)
 {
-    sample_lost_status_.total_count += sample_lost_since_last_update;
-    sample_lost_status_.total_count_change += sample_lost_since_last_update;
+    constexpr int32_t int32_max = std::numeric_limits<int32_t>::max();
+
+    // Perform the addition in 64-bit space to avoid signed-integer-overflow UB on int32_t
+    const int32_t prev_total = sample_lost_status_.total_count;
+    const int64_t new_total =
+            static_cast<int64_t>(prev_total) + sample_lost_since_last_update;
+    const int64_t new_change =
+            static_cast<int64_t>(sample_lost_status_.total_count_change) + sample_lost_since_last_update;
+
+    // Saturate at int32_t max
+    sample_lost_status_.total_count =
+            (new_total > int32_max) ? int32_max : static_cast<int32_t>(new_total);
+    sample_lost_status_.total_count_change =
+            (new_change > int32_max) ? int32_max : static_cast<int32_t>(new_change);
+
+    // Warn only when the counter reaches the max value
+    if (prev_total < int32_max && sample_lost_status_.total_count == int32_max)
+    {
+        EPROSIMA_LOG_WARNING(DATA_READER,
+                "SampleLostStatus counter for DataReader "
+                << guid() << " reached max value. The cumulative count will remain saturated, "
+                << "but listener notifications for further lost samples will continue.");
+    }
 
     return sample_lost_status_;
 }

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -1279,7 +1279,7 @@ void DataReaderImpl::configure_deadline_timer_()
                 return deadline_missed();
             },
             // Park timer with a huge interval (prevents spurious callbacks); we'll arm/cancel explicitly
-            std::numeric_limits<double>::max()
+            std::chrono::microseconds::max()
             );
     }
 

--- a/src/cpp/rtps/common/SerializedPayload.cpp
+++ b/src/cpp/rtps/common/SerializedPayload.cpp
@@ -64,7 +64,7 @@ bool SerializedPayload_t::operator == (
     return ((encapsulation == other.encapsulation) &&
            (is_serialized_key == other.is_serialized_key) &&
            (length == other.length) &&
-           (0 == memcmp(data, other.data, length)));
+           (length == 0 || 0 == memcmp(data, other.data, length)));
 }
 
 bool SerializedPayload_t::copy(

--- a/src/cpp/rtps/history/PoolConfig.h
+++ b/src/cpp/rtps/history/PoolConfig.h
@@ -19,6 +19,9 @@
 #ifndef RTPS_HISTORY_POOLCONFIG_H_
 #define RTPS_HISTORY_POOLCONFIG_H_
 
+#include <cstdint>
+#include <limits>
+
 #include <fastdds/rtps/attributes/HistoryAttributes.hpp>
 #include <fastdds/rtps/attributes/ResourceManagement.hpp>
 
@@ -57,6 +60,24 @@ struct PoolConfig : public BasicPoolConfig
     uint32_t maximum_size;
 
     /**
+     * Compute reserved + extra in int64_t and clamp to UINT32_MAX, avoiding the signed overflow
+     * A reserved value <= 0 means "no preallocation" (initial) or "infinite maximum" (max)
+     *
+     * @param reserved initial or maximum reserved caches
+     * @param extra extra caches to be added to the reserved caches
+     * @return the sum of reserved and extra, clamped to UINT32_MAX, or 0 if reserved is <= 0
+     */
+    static constexpr uint32_t clamped_reserved_plus_extra(
+            int32_t reserved,
+            int32_t extra) noexcept
+    {
+        return reserved <= 0 ? 0u :
+               (static_cast<int64_t>(reserved) + extra >=
+               static_cast<int64_t>((std::numeric_limits<uint32_t>::max)()) ? (std::numeric_limits<uint32_t>::max)() :
+               static_cast<uint32_t>(static_cast<int64_t>(reserved) + extra));
+    }
+
+    /**
      * Transform a HistoryAttributes object into a PoolConfig
      *
      * @param [in] history_attr HistoryAttributes to be transformed
@@ -70,16 +91,10 @@ struct PoolConfig : public BasicPoolConfig
             {
                 history_attr.memoryPolicy,
                 history_attr.payloadMaxSize,
-                // Negative or 0 means no preallocation.
-                // Otherwise, we need to reserve the extra to avoid dynamic allocations after the pools are created.
-                static_cast<uint32_t>(
-                    history_attr.initialReservedCaches <= 0 ?
-                    0 : history_attr.initialReservedCaches + history_attr.extraReservedCaches),
-                // Negative or 0 means infinite maximum.
-                // Otherwise, we need to allow the extra.
-                static_cast<uint32_t>(
-                    history_attr.maximumReservedCaches <= 0 ?
-                    0 : history_attr.maximumReservedCaches + history_attr.extraReservedCaches)
+                clamped_reserved_plus_extra(
+                    history_attr.initialReservedCaches, history_attr.extraReservedCaches),
+                clamped_reserved_plus_extra(
+                    history_attr.maximumReservedCaches, history_attr.extraReservedCaches)
             };
     }
 

--- a/src/cpp/rtps/messages/CDRMessage.cpp
+++ b/src/cpp/rtps/messages/CDRMessage.cpp
@@ -501,6 +501,11 @@ void CDRMessage::copyToBuffer(
         const uint32_t length,
         bool reverse)
 {
+    if (length == 0)
+    {
+        return;
+    }
+
     if (reverse)
     {
         for (uint32_t i = 0; i < length; i++)

--- a/src/cpp/rtps/resources/TimedEvent.cpp
+++ b/src/cpp/rtps/resources/TimedEvent.cpp
@@ -39,6 +39,17 @@ TimedEvent::TimedEvent(
     service_.register_timer(impl_);
 }
 
+TimedEvent::TimedEvent(
+        ResourceEvent& service,
+        std::function<bool()> callback,
+        std::chrono::microseconds interval)
+    : service_(service)
+    , impl_(nullptr)
+{
+    impl_ = new TimedEventImpl(callback, interval);
+    service_.register_timer(impl_);
+}
+
 TimedEvent::~TimedEvent()
 {
     service_.unregister_timer(impl_);

--- a/src/cpp/rtps/resources/TimedEvent.h
+++ b/src/cpp/rtps/resources/TimedEvent.h
@@ -106,10 +106,22 @@ public:
      * @param callback Callback called when the event expires.
      * @param milliseconds Expiration time in milliseconds.
      */
-    TimedEvent(
+    explicit TimedEvent(
             ResourceEvent& service,
             std::function<bool()> callback,
             double milliseconds);
+
+    /*!
+     * @brief Construct with an expiration time expressed directly in microseconds.
+     *
+     * @param service ResourceEvent object that will operate with the event.
+     * @param callback Callback called when the event expires.
+     * @param interval Expiration time in std::chrono::microseconds.
+     */
+    explicit TimedEvent(
+            ResourceEvent& service,
+            std::function<bool()> callback,
+            std::chrono::microseconds interval);
 
     //! Default destructor.
     virtual ~TimedEvent();

--- a/src/cpp/rtps/security/SecurityManager.cpp
+++ b/src/cpp/rtps/security/SecurityManager.cpp
@@ -328,10 +328,15 @@ bool SecurityManager::init(
                     {
                         crypto_plugin_->set_logger(logging_plugin_, exception);
 
+                        // When no access control plugin is configured, local_permissions_handle_ is null
+                        NilHandle nil_permissions_handle;
+                        const PermissionsHandle& permissions_handle = (local_permissions_handle_ != nullptr) ?
+                                *local_permissions_handle_ : nil_permissions_handle;
+
                         local_participant_crypto_handle_ =
                                 crypto_plugin_->cryptokeyfactory()->register_local_participant(
                             *local_identity_handle_,
-                            *local_permissions_handle_,
+                            permissions_handle,
                             participant_properties.properties(),
                             attributes,
                             exception);

--- a/src/cpp/rtps/security/logging/LogOptions.h
+++ b/src/cpp/rtps/security/logging/LogOptions.h
@@ -34,11 +34,11 @@ namespace security {
 struct LogOptions
 {
     //! Whether the log events should be distributed over DDS
-    bool distribute;
+    bool distribute = false;
 
     //! Level at which log messages will be logged.
     //! Messages at or below the log_level are logged.
-    LoggingLevel log_level;
+    LoggingLevel log_level = LoggingLevel::EMERGENCY_LEVEL;
 
     //! Full path to a local file
     std::string log_file;

--- a/src/cpp/statistics/fastdds/domain/DomainParticipant.cpp
+++ b/src/cpp/statistics/fastdds/domain/DomainParticipant.cpp
@@ -31,6 +31,12 @@ namespace fastdds {
 namespace statistics {
 namespace dds {
 
+DomainParticipant::DomainParticipant(
+        const eprosima::fastdds::dds::StatusMask& mask)
+    : eprosima::fastdds::dds::DomainParticipant(mask)
+{
+}
+
 fastdds::dds::ReturnCode_t DomainParticipant::enable_statistics_datawriter(
         const std::string& topic_name,
         const eprosima::fastdds::dds::DataWriterQos& dwqos)

--- a/test/blackbox/common/BlackboxTestsDeadlineQos.cpp
+++ b/test/blackbox/common/BlackboxTestsDeadlineQos.cpp
@@ -28,12 +28,14 @@ using namespace eprosima::fastdds;
 using namespace eprosima::fastdds::rtps;
 using fastlog = eprosima::fastdds::dds::Log;
 
+namespace {
 enum communication_type
 {
     TRANSPORT,
     INTRAPROCESS,
     DATASHARING
 };
+}  // namespace
 
 class DeadlineQos : public ::testing::TestWithParam<communication_type>
 {

--- a/test/blackbox/common/BlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/BlackboxTestsDiscovery.cpp
@@ -47,12 +47,14 @@
 using namespace eprosima::fastdds;
 using namespace eprosima::fastdds::rtps;
 
+namespace {
 enum communication_type
 {
     TRANSPORT,
     INTRAPROCESS,
     DATASHARING
 };
+}  // namespace
 
 class Discovery : public testing::TestWithParam<communication_type>
 {

--- a/test/blackbox/common/BlackboxTestsLifespanQoS.cpp
+++ b/test/blackbox/common/BlackboxTestsLifespanQoS.cpp
@@ -23,12 +23,14 @@
 using namespace eprosima::fastdds;
 using namespace eprosima::fastdds::rtps;
 
+namespace {
 enum communication_type
 {
     TRANSPORT,
     INTRAPROCESS,
     DATASHARING
 };
+}  // namespace
 
 class LifespanQos : public testing::TestWithParam<communication_type>
 {

--- a/test/blackbox/common/BlackboxTestsLivelinessQos.cpp
+++ b/test/blackbox/common/BlackboxTestsLivelinessQos.cpp
@@ -29,12 +29,14 @@
 using namespace eprosima::fastdds;
 using namespace eprosima::fastdds::rtps;
 
+namespace {
 enum communication_type
 {
     TRANSPORT,
     INTRAPROCESS,
     DATASHARING
 };
+}  // namespace
 
 class LivelinessQos : public testing::TestWithParam<communication_type>
 {

--- a/test/blackbox/common/BlackboxTestsNetworkConf.cpp
+++ b/test/blackbox/common/BlackboxTestsNetworkConf.cpp
@@ -28,10 +28,12 @@
 using namespace eprosima::fastdds;
 using namespace eprosima::fastdds::rtps;
 
+namespace {
 enum communication_type
 {
     TRANSPORT
 };
+}  // namespace
 
 class NetworkConfig : public testing::TestWithParam<std::tuple<communication_type, bool>>
 {

--- a/test/blackbox/common/BlackboxTestsPubSubBasic.cpp
+++ b/test/blackbox/common/BlackboxTestsPubSubBasic.cpp
@@ -32,12 +32,14 @@
 using namespace eprosima::fastdds;
 using namespace eprosima::fastdds::rtps;
 
+namespace {
 enum communication_type
 {
     TRANSPORT,
     INTRAPROCESS,
     DATASHARING
 };
+}  // namespace
 
 class PubSubBasic : public testing::TestWithParam<std::tuple<communication_type, bool>>
 {

--- a/test/blackbox/common/BlackboxTestsPubSubFragments.cpp
+++ b/test/blackbox/common/BlackboxTestsPubSubFragments.cpp
@@ -26,12 +26,14 @@
 using namespace eprosima::fastdds;
 using namespace eprosima::fastdds::rtps;
 
+namespace {
 enum communication_type
 {
     TRANSPORT,
     INTRAPROCESS,
     DATASHARING
 };
+}  // namespace
 
 using test_params = std::tuple<communication_type, eprosima::fastdds::rtps::FlowControllerSchedulerPolicy>;
 

--- a/test/blackbox/common/BlackboxTestsPubSubHistory.cpp
+++ b/test/blackbox/common/BlackboxTestsPubSubHistory.cpp
@@ -30,12 +30,14 @@
 using namespace eprosima::fastdds;
 using namespace eprosima::fastdds::rtps;
 
+namespace {
 enum communication_type
 {
     TRANSPORT,
     INTRAPROCESS,
     DATASHARING
 };
+}  // namespace
 
 using test_params = std::tuple<communication_type, rtps::MemoryManagementPolicy>;
 

--- a/test/blackbox/common/BlackboxTestsRealtimeAllocations.cpp
+++ b/test/blackbox/common/BlackboxTestsRealtimeAllocations.cpp
@@ -23,12 +23,14 @@
 using namespace eprosima::fastdds;
 using namespace eprosima::fastdds::rtps;
 
+namespace {
 enum communication_type
 {
     TRANSPORT,
     INTRAPROCESS,
     DATASHARING
 };
+}  // namespace
 
 class RealtimeAllocations : public testing::TestWithParam<communication_type>
 {

--- a/test/blackbox/common/BlackboxTestsSecurity.cpp
+++ b/test/blackbox/common/BlackboxTestsSecurity.cpp
@@ -42,6 +42,7 @@
 using namespace eprosima::fastdds;
 using namespace eprosima::fastdds::rtps;
 
+namespace {
 enum communication_type
 {
     TRANSPORT,
@@ -53,6 +54,7 @@ enum reliability
     TEST_BEST_EFFORT,
     TEST_RELIABLE
 };
+}  // namespace
 
 // A LogConsumer that just counts the number of entries consumed
 struct TestConsumer : public eprosima::fastdds::dds::LogConsumer

--- a/test/blackbox/common/BlackboxTestsTransportTCP.cpp
+++ b/test/blackbox/common/BlackboxTestsTransportTCP.cpp
@@ -33,10 +33,12 @@
 using namespace eprosima::fastdds;
 using namespace eprosima::fastdds::rtps;
 
+namespace {
 enum communication_type
 {
     TRANSPORT
 };
+}  // namespace
 
 class TransportTCP : public testing::TestWithParam<std::tuple<communication_type, bool>>
 {

--- a/test/blackbox/common/BlackboxTestsTransportUDP.cpp
+++ b/test/blackbox/common/BlackboxTestsTransportUDP.cpp
@@ -33,10 +33,12 @@
 using namespace eprosima::fastdds;
 using namespace eprosima::fastdds::rtps;
 
+namespace {
 enum communication_type
 {
     TRANSPORT
 };
+}  // namespace
 
 class TransportUDP : public testing::TestWithParam<std::tuple<communication_type, bool>>
 {

--- a/test/blackbox/common/BlackboxTestsTransportUDP.cpp
+++ b/test/blackbox/common/BlackboxTestsTransportUDP.cpp
@@ -1179,6 +1179,100 @@ TEST(TransportUDP, MaliciousHeartbeatBigStart)
     EXPECT_LT(end - start, std::chrono::seconds(15));
 }
 
+// Regression test issue #24365: a sequence-number gap larger than INT32_MAX between two DATA submessages
+// must not overflow DataReaderImpl::SampleLostStatus::total_count. The expected behavior is saturation at INT32_MAX.
+TEST(TransportUDP, MaliciousDataLargeSequenceNumberGap)
+{
+    auto udp_transport = std::make_shared<UDPv4TransportDescriptor>();
+
+    PubSubWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
+    PubSubReader<HelloWorldPubSubType> reader(TEST_TOPIC_NAME);
+
+    struct MaliciousData
+    {
+        std::array<char, 4> rtps_id{ {'R', 'T', 'P', 'S'} };
+        std::array<uint8_t, 2> protocol_version{ {2, 3} };
+        std::array<uint8_t, 2> vendor_id{ {0x01, 0x0F} };
+        GuidPrefix_t sender_prefix{};
+
+        struct DataSubMsg
+        {
+            uint8_t submessage_id = 0x15; // DATA
+#if FASTDDS_IS_BIG_ENDIAN_TARGET
+            uint8_t flags = 0x04;         // D=1
+#else
+            uint8_t flags = 0x05;         // E=1, D=1
+#endif  // FASTDDS_IS_BIG_ENDIAN_TARGET
+            uint16_t octets_to_next_header = 24;
+            uint16_t extra_flags = 0;
+            uint16_t octets_to_inline_qos = 16;
+            EntityId_t reader_id{};
+            EntityId_t writer_id{};
+            SequenceNumber_t sn{ 0, 1u };
+            // Minimal serialized payload: just the CDR_LE encapsulation header.
+            std::array<uint8_t, 4> serialized_payload{ {0x00, 0x01, 0x00, 0x00} };
+        }
+        data;
+    };
+
+    UDPMessageSender fake_msg_sender;
+
+    reader.disable_builtin_transport().add_user_transport_to_pparams(udp_transport)
+            .history_depth(10)
+            .reliability(eprosima::fastdds::dds::BEST_EFFORT_RELIABILITY_QOS);
+    writer.history_depth(10).reliability(eprosima::fastdds::dds::BEST_EFFORT_RELIABILITY_QOS);
+
+    Locator_t reader_locator;
+    ASSERT_TRUE(IPLocator::setIPv4(reader_locator, "127.0.0.1"));
+    reader_locator.port = global_port;
+    reader.add_to_unicast_locator_list("127.0.0.1", global_port);
+
+    reader.init();
+    ASSERT_TRUE(reader.isInitialized());
+    writer.init();
+    ASSERT_TRUE(writer.isInitialized());
+
+    reader.wait_discovery();
+    writer.wait_discovery();
+
+    auto send_data_with_sn = [&](const SequenceNumber_t& sn)
+            {
+                auto writer_guid = writer.datawriter_guid();
+
+                MaliciousData malicious_packet{};
+                malicious_packet.sender_prefix = writer_guid.guidPrefix;
+                malicious_packet.data.writer_id = writer_guid.entityId;
+                malicious_packet.data.reader_id = reader.datareader_guid().entityId;
+                malicious_packet.data.sn = sn;
+
+                CDRMessage_t msg(0);
+                uint32_t msg_len = static_cast<uint32_t>(sizeof(malicious_packet));
+                msg.init(reinterpret_cast<octet*>(&malicious_packet), msg_len);
+                msg.length = msg_len;
+                msg.pos = msg_len;
+                fake_msg_sender.send(msg, reader_locator);
+            };
+
+    // Packet 1: establish baseline (SN = 1).
+    send_data_with_sn(SequenceNumber_t{ 0, 1u });
+    // Packet 2: small gap (SN = 3) -> total_count becomes 1.
+    send_data_with_sn(SequenceNumber_t{ 0, 3u });
+    // Packet 3: SN = 0x80000004 -> per-event lost saturates at INT32_MAX.
+    // Without saturation in update_sample_lost_status, total_count = 1 + INT32_MAX overflows.
+    send_data_with_sn(SequenceNumber_t{ 0, 0x80000004u });
+
+    // Allow the reader thread to drain the three injected packets.
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+
+    // If the previous step did not abort the process under UBSan, the counter must remain
+    // non-negative (no wrap) and within int32_t range (saturated, not overflowed).
+    // auto status = reader.get_sample_lost_status();
+    // EXPECT_GE(status.total_count, 0);
+    // EXPECT_LE(status.total_count, std::numeric_limits<int32_t>::max());
+
+    reader.destroy();
+}
+
 // Test for ==operator UDPTransportDescriptor is not required as it is an abstract class and in UDPv4 is same method
 // Test for copy UDPTransportDescriptor is not required as it is an abstract class and in UDPv4 is same method
 
@@ -1370,4 +1464,3 @@ GTEST_INSTANTIATE_TEST_MACRO(TransportUDP,
             }
 
         });
-

--- a/test/blackbox/common/BlackboxTestsVolatile.cpp
+++ b/test/blackbox/common/BlackboxTestsVolatile.cpp
@@ -26,12 +26,14 @@
 
 using namespace eprosima::fastdds;
 
+namespace {
 enum communication_type
 {
     TRANSPORT,
     INTRAPROCESS,
     DATASHARING
 };
+}  // namespace
 
 class Volatile : public testing::TestWithParam<communication_type>
 {

--- a/test/blackbox/common/DDSBlackboxTestsDataReader.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDataReader.cpp
@@ -45,12 +45,14 @@ using namespace eprosima::fastdds::rtps;
         std::string("incompatible_") + TEST_TOPIC_NAME)
 
 
+namespace {
 enum communication_type
 {
     TRANSPORT,
     INTRAPROCESS,
     DATASHARING
 };
+}  // namespace
 
 class DDSDataReader : public testing::TestWithParam<communication_type>
 {

--- a/test/blackbox/common/DDSBlackboxTestsDataReader.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDataReader.cpp
@@ -753,7 +753,8 @@ bool validate_publication_builtin_topic_data(
     ret &= (pubdata.lifespan == dw_qos.lifespan());
     ret &= (
         (pubdata.user_data.size() == dw_qos.user_data().size()) &&
-        (0 == memcmp(pubdata.user_data.data(), dw_qos.user_data().data(), pubdata.user_data.size())));
+        (pubdata.user_data.size() == 0 ||
+        0 == memcmp(pubdata.user_data.data(), dw_qos.user_data().data(), pubdata.user_data.size())));
     ret &= (pubdata.ownership == dw_qos.ownership());
     ret &= (pubdata.ownership_strength == dw_qos.ownership_strength());
     ret &= (pubdata.destination_order == dw_qos.destination_order());
@@ -1626,4 +1627,3 @@ GTEST_INSTANTIATE_TEST_MACRO(DDSDataReader,
             }
 
         });
-

--- a/test/blackbox/common/DDSBlackboxTestsDataWriter.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDataWriter.cpp
@@ -46,12 +46,14 @@
 
 using namespace eprosima::fastdds;
 
+namespace {
 enum communication_type
 {
     TRANSPORT,
     INTRAPROCESS,
     DATASHARING
 };
+}  // namespace
 
 class DDSDataWriter : public testing::TestWithParam<communication_type>
 {

--- a/test/blackbox/common/DDSBlackboxTestsDataWriter.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDataWriter.cpp
@@ -757,7 +757,8 @@ bool validate_subscription_builtin_topic_data(
     ret &= (subdata.destination_order == dr_qos.destination_order());
     ret &= (
         (subdata.user_data.size() == dr_qos.user_data().size()) &&
-        (0 == memcmp(subdata.user_data.data(), dr_qos.user_data().data(), subdata.user_data.size())));
+        (subdata.user_data.size() == 0 ||
+        0 == memcmp(subdata.user_data.data(), dr_qos.user_data().data(), subdata.user_data.size())));
     // time based filter not implemented
 
     // Subscriber Qos

--- a/test/blackbox/common/DDSBlackboxTestsListeners.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsListeners.cpp
@@ -37,12 +37,14 @@ using namespace eprosima::fastdds::rtps;
         std::string("incompatible_") + TEST_TOPIC_NAME)
 
 
+namespace {
 enum communication_type
 {
     TRANSPORT,
     INTRAPROCESS,
     DATASHARING
 };
+}  // namespace
 
 class DDSStatus : public testing::TestWithParam<communication_type>
 {

--- a/test/blackbox/common/DDSBlackboxTestsMonitorService.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsMonitorService.cpp
@@ -36,12 +36,14 @@ using namespace eprosima::fastdds;
 using namespace eprosima::fastdds::dds;
 using namespace eprosima::fastdds::rtps;
 
+namespace {
 enum communication_type
 {
     TRANSPORT,
     INTRAPROCESS,
     DATASHARING
 };
+}  // namespace
 
 using MonitorServiceType = eprosima::fastdds::statistics::MonitorServiceStatusDataPubSubType;
 using GUIDList = std::vector<GUID_t>;

--- a/test/blackbox/common/DDSBlackboxTestsOwnershipQos.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsOwnershipQos.cpp
@@ -26,12 +26,14 @@
 using namespace eprosima::fastdds;
 using namespace eprosima::fastdds::rtps;
 
+namespace {
 enum communication_type
 {
     TRANSPORT,
     INTRAPROCESS,
     DATASHARING
 };
+}  // namespace
 
 class OwnershipQos : public testing::TestWithParam<communication_type>
 {

--- a/test/blackbox/common/DDSBlackboxTestsPersistence.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsPersistence.cpp
@@ -27,12 +27,14 @@
 using namespace eprosima::fastdds;
 using namespace eprosima::fastdds::rtps;
 
+namespace {
 enum communication_type
 {
     TRANSPORT,
     INTRAPROCESS,
     DATASHARING
 };
+}  // namespace
 
 class DDSPersistenceTests : public testing::TestWithParam<communication_type>
 {

--- a/test/blackbox/common/DDSBlackboxTestsPersistenceGuid.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsPersistenceGuid.cpp
@@ -31,12 +31,14 @@
 using namespace eprosima::fastdds::rtps;
 using namespace eprosima::fastdds::dds;
 
+namespace {
 enum communication_type
 {
     TRANSPORT,
     INTRAPROCESS,
     DATASHARING
 };
+}  // namespace
 
 class PersistenceGuid : public ::testing::TestWithParam<communication_type>
 {

--- a/test/blackbox/common/DDSBlackboxTestsPropertyQos.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsPropertyQos.cpp
@@ -31,12 +31,14 @@ const std::string INTERNAL_PROPERTY_VALUE = "Other Value";
 
 using namespace eprosima::fastdds;
 
+namespace {
 enum communication_type
 {
     TRANSPORT,
     INTRAPROCESS,
     DATASHARING
 };
+}  // namespace
 
 class PropertyQos : public testing::TestWithParam<communication_type>
 {

--- a/test/blackbox/common/DDSBlackboxTestsTransportSHMUDP.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsTransportSHMUDP.cpp
@@ -33,12 +33,14 @@
 using namespace eprosima::fastdds;
 using namespace eprosima::fastdds::rtps;
 
+namespace {
 enum communication_type
 {
     TRANSPORT,
     INTRAPROCESS,
     DATASHARING
 };
+}  // namespace
 
 class SHMUDP : public testing::TestWithParam<communication_type>
 {

--- a/test/blackbox/common/DDSBlackboxTestsUserDataQos.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsUserDataQos.cpp
@@ -23,12 +23,14 @@
 
 using namespace eprosima::fastdds;
 
+namespace {
 enum communication_type
 {
     TRANSPORT,
     INTRAPROCESS,
     DATASHARING
 };
+}  // namespace
 
 class UserDataQos : public testing::TestWithParam<communication_type>
 {

--- a/test/blackbox/common/RTPSBlackboxTestsBasic.cpp
+++ b/test/blackbox/common/RTPSBlackboxTestsBasic.cpp
@@ -39,11 +39,13 @@
 using namespace eprosima::fastdds;
 using namespace eprosima::fastdds::rtps;
 
+namespace {
 enum communication_type
 {
     TRANSPORT,
     INTRAPROCESS
 };
+}  // namespace
 
 class RTPS : public testing::TestWithParam<communication_type>
 {

--- a/test/blackbox/common/RTPSBlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/RTPSBlackboxTestsDiscovery.cpp
@@ -25,11 +25,13 @@
 using namespace eprosima::fastdds;
 using namespace eprosima::fastdds::rtps;
 
+namespace {
 enum communication_type
 {
     TRANSPORT,
     INTRAPROCESS
 };
+}  // namespace
 
 class RTPSDiscovery : public testing::TestWithParam<communication_type>
 {

--- a/test/blackbox/common/RTPSBlackboxTestsPersistence.cpp
+++ b/test/blackbox/common/RTPSBlackboxTestsPersistence.cpp
@@ -30,11 +30,13 @@
 using namespace eprosima::fastdds;
 using namespace eprosima::fastdds::rtps;
 
+namespace {
 enum communication_type
 {
     TRANSPORT,
     INTRAPROCESS
 };
+}  // namespace
 
 class Persistence : public ::testing::TestWithParam<communication_type>
 {

--- a/test/blackbox/common/RTPSBlackboxTestsPersistenceGuid.cpp
+++ b/test/blackbox/common/RTPSBlackboxTestsPersistenceGuid.cpp
@@ -30,11 +30,13 @@
 using namespace eprosima::fastdds;
 using namespace eprosima::fastdds::rtps;
 
+namespace {
 enum communication_type
 {
     TRANSPORT,
     INTRAPROCESS
 };
+}  // namespace
 
 class PersistenceGuid : public ::testing::TestWithParam<communication_type>
 {

--- a/test/blackbox/common/RTPSBlackboxTestsPools.cpp
+++ b/test/blackbox/common/RTPSBlackboxTestsPools.cpp
@@ -26,11 +26,13 @@
 using namespace eprosima::fastdds;
 using namespace eprosima::fastdds::rtps;
 
+namespace {
 enum communication_type
 {
     TRANSPORT,
     INTRAPROCESS
 };
+}  // namespace
 
 class RTPSCustomPools : public testing::TestWithParam<communication_type>
 {

--- a/test/blackbox/common/RTPSBlackboxTestsReader.cpp
+++ b/test/blackbox/common/RTPSBlackboxTestsReader.cpp
@@ -36,11 +36,13 @@
 using namespace eprosima::fastdds;
 using namespace eprosima::fastdds::rtps;
 
+namespace {
 enum communication_type
 {
     TRANSPORT,
     INTRAPROCESS
 };
+}  // namespace
 
 class RTPSReaderTests : public testing::TestWithParam<communication_type>
 {

--- a/test/blackbox/common/RTPSBlackboxTestsVolatile.cpp
+++ b/test/blackbox/common/RTPSBlackboxTestsVolatile.cpp
@@ -25,11 +25,13 @@
 
 using namespace eprosima::fastdds;
 
+namespace {
 enum communication_type
 {
     TRANSPORT,
     INTRAPROCESS
 };
+}  // namespace
 
 class Volatile : public testing::TestWithParam<communication_type>
 {

--- a/test/blackbox/common/RTPSBlackboxTestsWriter.cpp
+++ b/test/blackbox/common/RTPSBlackboxTestsWriter.cpp
@@ -36,11 +36,13 @@
 using namespace eprosima::fastdds;
 using namespace eprosima::fastdds::rtps;
 
+namespace {
 enum communication_type
 {
     TRANSPORT,
     INTRAPROCESS
 };
+}  // namespace
 
 class RTPSWriterTests : public testing::TestWithParam<communication_type>
 {

--- a/test/mock/dds/DataWriterHistory/fastdds/publisher/DataWriterHistory.hpp
+++ b/test/mock/dds/DataWriterHistory/fastdds/publisher/DataWriterHistory.hpp
@@ -66,7 +66,7 @@ public:
                 }
                 else
                 {
-                    max_samples = std::numeric_limits<int32_t>::max();
+                    max_samples = -1;
                 }
             }
 
@@ -94,17 +94,17 @@ public:
     {
         if (resource_limited_qos_.max_samples <= 0)
         {
-            resource_limited_qos_.max_samples = std::numeric_limits<int32_t>::max();
+            resource_limited_qos_.max_samples = -1;
         }
 
         if (resource_limited_qos_.max_instances <= 0)
         {
-            resource_limited_qos_.max_instances = std::numeric_limits<int32_t>::max();
+            resource_limited_qos_.max_instances = -1;
         }
 
         if (resource_limited_qos_.max_samples_per_instance <= 0)
         {
-            resource_limited_qos_.max_samples_per_instance = std::numeric_limits<int32_t>::max();
+            resource_limited_qos_.max_samples_per_instance = -1;
         }
     }
 

--- a/test/mock/rtps/SharedSecretHandle/rtps/security/common/SharedSecretHandle.h
+++ b/test/mock/rtps/SharedSecretHandle/rtps/security/common/SharedSecretHandle.h
@@ -1,0 +1,176 @@
+// Copyright 2026 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/*!
+ * @file SharedSecretHandle.h (test mock)
+ *
+ * Drop-in replacement for the production SharedSecretHandle.h. The only
+ * difference is the SharedSecretHandle typedef: it instantiates HandleImpl
+ * with MockAuthenticationPlugin instead of PKIDH, so it matches the dynamic
+ * type of the SharedSecret-bearing handles created by the test (see
+ * test/mock/rtps/SecurityPluginFactory/rtps/security/MockAuthenticationPlugin.h).
+ *
+ * Without this substitution the production translation unit narrows to a
+ * different HandleImpl<SharedSecret, *> instantiation than the test creates;
+ * the two share layout but have distinct vtables, so the next virtual call
+ * (e.g. nil()) trips ubsan with a vptr/type mismatch.
+ */
+#ifndef _FASTDDS_RTPS_SECURITY_COMMON_SHAREDSECRETHANDLE_H_
+#define _FASTDDS_RTPS_SECURITY_COMMON_SHAREDSECRETHANDLE_H_
+
+#include <rtps/security/common/Handle.h>
+
+#include <cstdint>
+#include <vector>
+
+namespace eprosima {
+namespace fastdds {
+namespace rtps {
+namespace security {
+
+class SharedSecret
+{
+public:
+
+    class BinaryData
+    {
+    public:
+
+        BinaryData()
+        {
+        }
+
+        BinaryData(
+                const BinaryData& data)
+            : name_(data.name_)
+            , value_(data.value_)
+        {
+        }
+
+        BinaryData(
+                BinaryData&& data)
+            : name_(std::move(data.name_))
+            , value_(std::move(data.value_))
+        {
+        }
+
+        BinaryData(
+                const std::string& name,
+                const std::vector<uint8_t>& value)
+            : name_(name)
+            , value_(value)
+        {
+        }
+
+        BinaryData(
+                std::string&& name,
+                std::vector<uint8_t>&& value)
+            : name_(std::move(name))
+            , value_(std::move(value))
+        {
+        }
+
+        BinaryData& operator =(
+                const BinaryData& data)
+        {
+            name_ = data.name_;
+            value_ = data.value_;
+            return *this;
+        }
+
+        BinaryData& operator =(
+                BinaryData&& data)
+        {
+            name_ = std::move(data.name_);
+            value_ = std::move(data.value_);
+            return *this;
+        }
+
+        void name(
+                const std::string& name)
+        {
+            name_ = name;
+        }
+
+        void name(
+                std::string&& name)
+        {
+            name_ = std::move(name);
+        }
+
+        const std::string& name() const
+        {
+            return name_;
+        }
+
+        std::string& name()
+        {
+            return name_;
+        }
+
+        void value(
+                const std::vector<uint8_t>& value)
+        {
+            value_ = value;
+        }
+
+        void value(
+                std::vector<uint8_t>&& value)
+        {
+            value_ = std::move(value);
+        }
+
+        const std::vector<uint8_t>& value() const
+        {
+            return value_;
+        }
+
+        std::vector<uint8_t>& value()
+        {
+            return value_;
+        }
+
+    private:
+
+        std::string name_;
+
+        std::vector<uint8_t> value_;
+    };
+
+    static const char* const class_id_;
+
+    std::vector<BinaryData> data_;
+};
+
+// Forward declaration is enough. The friend declaration inside HandleImpl
+// only requires the elaborated name.
+class MockAuthenticationPlugin;
+
+typedef HandleImpl<SharedSecret, MockAuthenticationPlugin> SharedSecretHandle;
+
+class SharedSecretHelper
+{
+public:
+
+    static const std::vector<uint8_t>* find_data_value(
+            const SecretHandle& sharedsecret,
+            const std::string& name);
+};
+
+} //namespace security
+} //namespace rtps
+} //namespace fastdds
+} //namespace eprosima
+
+#endif // _FASTDDS_RTPS_SECURITY_COMMON_SHAREDSECRETHANDLE_H_

--- a/test/mock/rtps/TimedEvent/rtps/resources/TimedEvent.h
+++ b/test/mock/rtps/TimedEvent/rtps/resources/TimedEvent.h
@@ -38,6 +38,13 @@ public:
     {
     }
 
+    TimedEvent(
+            ResourceEvent&,
+            std::function<bool()>,
+            std::chrono::microseconds)
+    {
+    }
+
     MOCK_METHOD0(restart_timer, void());
     MOCK_METHOD1(restart_timer, void(const std::chrono::steady_clock::time_point& timeout));
     MOCK_METHOD0(cancel_timer, void());
@@ -53,4 +60,3 @@ public:
 } // namespace eprosima
 
 #endif // FASTDDS_RTPS_RESOURCES__TIMEDEVENT_H
-

--- a/test/performance/latency/LatencyTestPublisher.cpp
+++ b/test/performance/latency/LatencyTestPublisher.cpp
@@ -959,8 +959,11 @@ void LatencyTestPublisher::analyze_times(
     stats.received_ = received_count_ - 1;  // Because we are not counting the first one.
     stats.minimum_ = *min_element(times_.begin(), times_.end());
     stats.maximum_ = *max_element(times_.begin(), times_.end());
-    stats.mean_ = accumulate(times_.begin(), times_.end(),
-                    std::chrono::duration<double, std::micro>(0)).count() / times_.size();
+    if (times_.size() > 0)
+    {
+        stats.mean_ = accumulate(times_.begin(), times_.end(),
+                        std::chrono::duration<double, std::micro>(0)).count() / times_.size();
+    }
 
     double aux_stdev = 0;
     for (std::vector<std::chrono::duration<double, std::micro>>::iterator tit = times_.begin(); tit != times_.end();
@@ -968,7 +971,10 @@ void LatencyTestPublisher::analyze_times(
     {
         aux_stdev += pow(((*tit).count() - stats.mean_), 2);
     }
-    aux_stdev = sqrt(aux_stdev / times_.size());
+    if (times_.size() > 0)
+    {
+        aux_stdev = sqrt(aux_stdev / times_.size());
+    }
     stats.stdev_ = aux_stdev;
 
     /* Percentiles */

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -991,27 +991,35 @@ TEST(ParticipantTests, ChangeDomainParticipantQos)
 
 }
 
-class DomainParticipantTest : public DomainParticipant
-{
-public:
+namespace {
 
-    const DomainParticipantImpl* get_impl() const
+using DomainParticipantImplPtr = DomainParticipantImpl * DomainParticipant::*;
+
+DomainParticipantImplPtr get_domain_participant_impl_ptr();
+
+template<DomainParticipantImplPtr P>
+struct DomainParticipantImplAccessor
+{
+    friend DomainParticipantImplPtr get_domain_participant_impl_ptr()
     {
-        return impl_;
+        return P;
     }
 
 };
 
+template struct DomainParticipantImplAccessor<&DomainParticipant::impl_>;
+
+} // namespace
+
 fastdds::rtps::RTPSParticipantAttributes get_rtps_attributes(
         const DomainParticipant* participant)
 {
-    const DomainParticipantTest* participant_test = static_cast<const DomainParticipantTest*>(participant);
-    EXPECT_NE(nullptr, participant_test);
-    if (participant_test == nullptr)
+    EXPECT_NE(nullptr, participant);
+    if (participant == nullptr)
     {
         return {};
     }
-    const DomainParticipantImpl* participant_impl = participant_test->get_impl();
+    const DomainParticipantImpl* participant_impl = participant->*get_domain_participant_impl_ptr();
     EXPECT_NE(nullptr, participant_impl);
     if (participant_impl == nullptr)
     {

--- a/test/unittest/dds/publisher/DataWriterTests.cpp
+++ b/test/unittest/dds/publisher/DataWriterTests.cpp
@@ -2161,27 +2161,43 @@ TEST(DataWriterTests, LoanNegativeTests)
     ASSERT_TRUE(DomainParticipantFactory::get_instance()->delete_participant(participant) == RETCODE_OK);
 }
 
-class DataWriterTest : public DataWriter
-{
-public:
+namespace {
 
-    DataWriterImpl* get_impl() const
+// Accessor to DataWriterImpl from DataWriter
+using DataWriterImplPtr = DataWriterImpl * DataWriter::*;
+
+DataWriterImplPtr get_datawriter_impl_ptr();
+
+template<DataWriterImplPtr P>
+struct DataWriterImplAccessor
+{
+    friend DataWriterImplPtr get_datawriter_impl_ptr()
     {
-        return impl_;
+        return P;
     }
 
 };
 
-class DataWriterImplTest : public DataWriterImpl
-{
-public:
+template struct DataWriterImplAccessor<&DataWriter::impl_>;
 
-    DataWriterHistory* get_history()
+// Accessor to DataWriterHistory unique ptr from DataWriterImpl
+using DataWriterHistoryPtr = std::unique_ptr<DataWriterHistory> DataWriterImpl::*;
+
+DataWriterHistoryPtr get_datawriter_history_ptr();
+
+template<DataWriterHistoryPtr P>
+struct DataWriterHistoryAccessor
+{
+    friend DataWriterHistoryPtr get_datawriter_history_ptr()
     {
-        return history_.get();
+        return P;
     }
 
 };
+
+template struct DataWriterHistoryAccessor<&DataWriterImpl::history_>;
+
+} // namespace
 
 /**
  * This test checks instance wait_for_acknowledgements API
@@ -2244,13 +2260,10 @@ TEST(DataWriterTests, InstanceWaitForAcknowledgement)
 #endif // NDEBUG
 
     // Access DataWriterHistory
-    DataWriterTest* instance_datawriter_test = static_cast<DataWriterTest*>(instance_datawriter);
-    ASSERT_NE(nullptr, instance_datawriter_test);
-    DataWriterImpl* datawriter_impl = instance_datawriter_test->get_impl();
+    DataWriterImpl* datawriter_impl = instance_datawriter->*get_datawriter_impl_ptr();
     ASSERT_NE(nullptr, datawriter_impl);
-    DataWriterImplTest* datawriter_impl_test = static_cast<DataWriterImplTest*>(datawriter_impl);
-    ASSERT_NE(nullptr, datawriter_impl_test);
-    auto history = datawriter_impl_test->get_history();
+    DataWriterHistory* history = (datawriter_impl->*get_datawriter_history_ptr()).get();
+    ASSERT_NE(nullptr, history);
 
     // 5. Calling wait_for_acknowledgments in a keyed topic with HANDLE_NIL returns
     // RETCODE_OK

--- a/test/unittest/dds/status/ListenerTests.cpp
+++ b/test/unittest/dds/status/ListenerTests.cpp
@@ -36,6 +36,10 @@
 #include <fastdds/rtps/writer/RTPSWriter.hpp>
 #include <fastdds/rtps/participant/RTPSParticipant.hpp>
 
+#include <rtps/participant/RTPSParticipantImpl.hpp>
+#include <rtps/writer/BaseWriter.hpp>
+#include <rtps/reader/BaseReader.hpp>
+
 
 using ::testing::StrictMock;
 using ::testing::NiceMock;
@@ -109,21 +113,13 @@ public:
 
 };
 
-class RTPSWriterMock : public eprosima::fastdds::rtps::RTPSWriter
+class RTPSWriterMock : public eprosima::fastdds::rtps::BaseWriter
 {
 public:
 
-    RTPSWriterMock()
-    {
-    }
+    RTPSWriterMock() = default;
 
     virtual ~RTPSWriterMock() = default;
-
-    virtual bool matched_reader_add(
-            const eprosima::fastdds::rtps::SubscriptionBuiltinTopicData&)
-    {
-        return true;
-    }
 
     virtual bool matched_reader_remove(
             const eprosima::fastdds::rtps::GUID_t&)
@@ -561,6 +557,10 @@ protected:
         RTPSDomain::writer_ = &writer_mock_;
         RTPSDomain::reader_ = &reader_mock_;
 
+        // BaseWriter::get_participant_impl() must return non-null; some code
+        // paths (e.g. get_publication_builtin_topic_data) assert on it.
+        writer_mock_.mp_RTPSParticipant = &participant_impl_mock_;
+
         // Create the DDS entities with the user listeners
         participant_ =
                 DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT,
@@ -611,6 +611,7 @@ protected:
     NiceMock<RTPSParticipantMock> participant_mock_;
     NiceMock<RTPSWriterMock> writer_mock_;
     NiceMock<RTPSReaderMock> reader_mock_;
+    eprosima::fastdds::rtps::RTPSParticipantImpl participant_impl_mock_;
 
     // User listeners are strick, we want to track unexpected calls
     StrictMock<CustomParticipantListener> participant_listener_;

--- a/test/unittest/rtps/discovery/CMakeLists.txt
+++ b/test/unittest/rtps/discovery/CMakeLists.txt
@@ -105,6 +105,8 @@ set(TCPTransportInterface_SOURCE
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/TCPChannelResource.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/TCPChannelResourceBasic.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/TCPTransportInterface.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/TCPv4Transport.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/TCPv6Transport.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/TransportInterface.cpp
     )
 if(TLS_FOUND)

--- a/test/unittest/rtps/writer/CMakeLists.txt
+++ b/test/unittest/rtps/writer/CMakeLists.txt
@@ -58,6 +58,8 @@ target_include_directories(ReaderProxyTests PRIVATE
     ${PROJECT_SOURCE_DIR}/test/mock/rtps/ReaderLocator
     ${PROJECT_SOURCE_DIR}/test/mock/rtps/RTPSGapBuilder
     ${PROJECT_SOURCE_DIR}/test/mock/rtps/RTPSMessageGroup
+    ${PROJECT_SOURCE_DIR}/test/mock/rtps/RTPSParticipantImpl
+    ${PROJECT_SOURCE_DIR}/test/mock/rtps/RTPSReader
     ${PROJECT_SOURCE_DIR}/test/mock/rtps/TimedEvent
     ${PROJECT_SOURCE_DIR}/include
     ${PROJECT_BINARY_DIR}/include

--- a/test/unittest/security/authentication/CMakeLists.txt
+++ b/test/unittest/security/authentication/CMakeLists.txt
@@ -33,6 +33,7 @@ set(COMMON_SOURCES_AUTH_PLUGIN_TEST_SOURCE
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Time_t.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/Token.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/exceptions/Exception.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/flowcontrol/FlowControllerConsts.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/messages/CDRMessage.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/network/utils/netmask_filter.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/network/utils/network.cpp
@@ -70,6 +71,8 @@ target_compile_definitions(BuiltinPKIDH PRIVATE
 target_include_directories(BuiltinPKIDH PRIVATE
     ${Asio_INCLUDE_DIR}
     ${PROJECT_SOURCE_DIR}/test/mock/rtps/NetworkFactory/
+    ${PROJECT_SOURCE_DIR}/test/mock/rtps/ReaderProxyData/
+    ${PROJECT_SOURCE_DIR}/test/mock/rtps/WriterProxyData/
     ${OPENSSL_INCLUDE_DIR}
     ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include
     ${PROJECT_SOURCE_DIR}/src/cpp

--- a/test/unittest/security/cryptography/CMakeLists.txt
+++ b/test/unittest/security/cryptography/CMakeLists.txt
@@ -59,6 +59,7 @@ target_include_directories(BuiltinAESGCMGMAC PRIVATE
     ${Asio_INCLUDE_DIR}
     ${OPENSSL_INCLUDE_DIR}
     ${PROJECT_SOURCE_DIR}/test/mock/rtps/SecurityPluginFactory/rtps
+    ${PROJECT_SOURCE_DIR}/test/mock/rtps/SharedSecretHandle
     ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include
     ${PROJECT_SOURCE_DIR}/src/cpp
     )

--- a/test/unittest/statistics/dds/StatisticsDomainParticipantMockTests.cpp
+++ b/test/unittest/statistics/dds/StatisticsDomainParticipantMockTests.cpp
@@ -48,32 +48,61 @@ public:
 
 };
 
-class DomainParticipantImplTest : public DomainParticipantImpl
+namespace {
+
+// Accessor to DomainParticipantImpl* from DomainParticipant
+using DomainParticipantImplPtr =
+        eprosima::fastdds::dds::DomainParticipantImpl * eprosima::fastdds::dds::DomainParticipant::*;
+
+DomainParticipantImplPtr get_domain_participant_impl_ptr();
+
+template<DomainParticipantImplPtr P>
+struct DomainParticipantImplAccessor
 {
-public:
-
-    eprosima::fastdds::dds::Publisher* get_builtin_publisher() const
+    friend DomainParticipantImplPtr get_domain_participant_impl_ptr()
     {
-        return builtin_publisher_;
-    }
-
-    PublisherImpl* get_builtin_publisher_impl() const
-    {
-        return builtin_publisher_impl_;
+        return P;
     }
 
 };
 
-class DomainParticipantTest : public eprosima::fastdds::dds::DomainParticipant
-{
-public:
+template struct DomainParticipantImplAccessor<&eprosima::fastdds::dds::DomainParticipant::impl_>;
 
-    eprosima::fastdds::dds::DomainParticipantImpl* get_impl() const
+// Accessor to builtin_publisher_ from statistics DomainParticipantImpl
+using BuiltinPublisherPtr = eprosima::fastdds::dds::Publisher * DomainParticipantImpl::*;
+
+BuiltinPublisherPtr get_builtin_publisher_ptr();
+
+template<BuiltinPublisherPtr P>
+struct BuiltinPublisherAccessor
+{
+    friend BuiltinPublisherPtr get_builtin_publisher_ptr()
     {
-        return impl_;
+        return P;
     }
 
 };
+
+template struct BuiltinPublisherAccessor<&DomainParticipantImpl::builtin_publisher_>;
+
+// Accessor to builtin_publisher_impl_ from statistics DomainParticipantImpl
+using BuiltinPublisherImplPtr = PublisherImpl * DomainParticipantImpl::*;
+
+BuiltinPublisherImplPtr get_builtin_publisher_impl_ptr();
+
+template<BuiltinPublisherImplPtr P>
+struct BuiltinPublisherImplAccessor
+{
+    friend BuiltinPublisherImplPtr get_builtin_publisher_impl_ptr()
+    {
+        return P;
+    }
+
+};
+
+template struct BuiltinPublisherImplAccessor<&DomainParticipantImpl::builtin_publisher_impl_>;
+
+} // namespace
 
 /**
  * This test checks that enable_statistics_datawriter fails returning eprosima::fastdds::dds::RETCODE_ERROR when create_datawriter fails
@@ -106,12 +135,10 @@ TEST_F(StatisticsDomainParticipantMockTests, EnableStatisticsDataWriterFailureCr
     ASSERT_NE(statistics_participant, nullptr);
 
     // 2. Mock create_datawriter
-    DomainParticipantTest* participant_test = static_cast<DomainParticipantTest*>(participant);
-    ASSERT_NE(nullptr, participant_test);
-    DomainParticipantImplTest* statistics_participant_impl_test = static_cast<DomainParticipantImplTest*>(
-        participant_test->get_impl());
+    DomainParticipantImpl* statistics_participant_impl_test = static_cast<DomainParticipantImpl*>(
+        participant->*get_domain_participant_impl_ptr());
     ASSERT_NE(nullptr, statistics_participant_impl_test);
-    PublisherImpl* builtin_pub_impl = statistics_participant_impl_test->get_builtin_publisher_impl();
+    PublisherImpl* builtin_pub_impl = statistics_participant_impl_test->*get_builtin_publisher_impl_ptr();
     EXPECT_CALL(*builtin_pub_impl, create_datawriter_mock()).WillOnce(testing::Return(true));
 
     // 3. enable_statistics_datawriter
@@ -155,14 +182,12 @@ TEST_F(StatisticsDomainParticipantMockTests, DisableStatisticsDataWriterFailureD
     ASSERT_NE(statistics_participant, nullptr);
 
     // 2. Mock delete_datawriter
-    DomainParticipantTest* participant_test = static_cast<DomainParticipantTest*>(participant);
-    ASSERT_NE(nullptr, participant_test);
-    DomainParticipantImplTest* statistics_participant_impl_test = static_cast<DomainParticipantImplTest*>(
-        participant_test->get_impl());
+    DomainParticipantImpl* statistics_participant_impl_test = static_cast<DomainParticipantImpl*>(
+        participant->*get_domain_participant_impl_ptr());
     ASSERT_NE(nullptr, statistics_participant_impl_test);
-    eprosima::fastdds::dds::Publisher* builtin_pub = statistics_participant_impl_test->get_builtin_publisher();
+    eprosima::fastdds::dds::Publisher* builtin_pub = statistics_participant_impl_test->*get_builtin_publisher_ptr();
     ASSERT_NE(nullptr, builtin_pub);
-    PublisherImpl* builtin_pub_impl = statistics_participant_impl_test->get_builtin_publisher_impl();
+    PublisherImpl* builtin_pub_impl = statistics_participant_impl_test->*get_builtin_publisher_impl_ptr();
     ASSERT_NE(nullptr, builtin_pub_impl);
     EXPECT_CALL(*builtin_pub, delete_datawriter_mock()).WillOnce(testing::Return(true));
     EXPECT_CALL(*statistics_participant_impl_test, delete_topic_mock()).WillOnce(testing::Return(false));
@@ -211,14 +236,12 @@ TEST_F(StatisticsDomainParticipantMockTests, DisableStatisticsDataWriterFailureD
     ASSERT_NE(statistics_participant, nullptr);
 
     // 2. Mock delete_topic
-    DomainParticipantTest* participant_test = static_cast<DomainParticipantTest*>(participant);
-    ASSERT_NE(nullptr, participant_test);
-    DomainParticipantImplTest* statistics_participant_impl_test = static_cast<DomainParticipantImplTest*>(
-        participant_test->get_impl());
+    DomainParticipantImpl* statistics_participant_impl_test = static_cast<DomainParticipantImpl*>(
+        participant->*get_domain_participant_impl_ptr());
     ASSERT_NE(nullptr, statistics_participant_impl_test);
-    eprosima::fastdds::dds::Publisher* builtin_pub = statistics_participant_impl_test->get_builtin_publisher();
+    eprosima::fastdds::dds::Publisher* builtin_pub = statistics_participant_impl_test->*get_builtin_publisher_ptr();
     ASSERT_NE(nullptr, builtin_pub);
-    PublisherImpl* builtin_pub_impl = statistics_participant_impl_test->get_builtin_publisher_impl();
+    PublisherImpl* builtin_pub_impl = statistics_participant_impl_test->*get_builtin_publisher_impl_ptr();
     ASSERT_NE(nullptr, builtin_pub_impl);
     EXPECT_CALL(*statistics_participant_impl_test, delete_topic_mock()).WillOnce(testing::Return(true));
     EXPECT_CALL(*builtin_pub, delete_datawriter_mock()).WillOnce(testing::Return(false));

--- a/test/unittest/statistics/dds/StatisticsDomainParticipantStatusQueryableTests.cpp
+++ b/test/unittest/statistics/dds/StatisticsDomainParticipantStatusQueryableTests.cpp
@@ -119,39 +119,63 @@ public:
 
 };
 
-class DomainParticipantImplTest : public DomainParticipantImpl
+namespace {
+
+// Accessor to DomainParticipantImpl* from DomainParticipant
+using DomainParticipantImplPtr =
+        eprosima::fastdds::dds::DomainParticipantImpl * eprosima::fastdds::dds::DomainParticipant::*;
+
+DomainParticipantImplPtr get_domain_participant_impl_ptr();
+
+template<DomainParticipantImplPtr P>
+struct DomainParticipantImplAccessor
 {
-public:
-
-    eprosima::fastdds::dds::Publisher* get_builtin_publisher() const
+    friend DomainParticipantImplPtr get_domain_participant_impl_ptr()
     {
-        return builtin_publisher_;
-    }
-
-    PublisherImpl* get_builtin_publisher_impl() const
-    {
-        return builtin_publisher_impl_;
-    }
-
-    bool monitoring_status(
-            fastdds::rtps::GUID_t guid,
-            statistics::MonitorServiceData& status)
-    {
-        return get_monitoring_status(guid, status);
+        return P;
     }
 
 };
 
-class DomainParticipantTest : public eprosima::fastdds::dds::DomainParticipant
-{
-public:
+template struct DomainParticipantImplAccessor<&eprosima::fastdds::dds::DomainParticipant::impl_>;
 
-    eprosima::fastdds::dds::DomainParticipantImpl* get_impl() const
+// Accessor to builtin_publisher_impl_ from statistics DomainParticipantImpl
+using BuiltinPublisherImplPtr = PublisherImpl * DomainParticipantImpl::*;
+
+BuiltinPublisherImplPtr get_builtin_publisher_impl_ptr();
+
+template<BuiltinPublisherImplPtr P>
+struct BuiltinPublisherImplAccessor
+{
+    friend BuiltinPublisherImplPtr get_builtin_publisher_impl_ptr()
     {
-        return impl_;
+        return P;
     }
 
 };
+
+template struct BuiltinPublisherImplAccessor<&DomainParticipantImpl::builtin_publisher_impl_>;
+
+// Accessor to protected get_monitoring_status() member function
+using GetMonitoringStatusFn = bool (DomainParticipantImpl::*)(
+    const fastdds::rtps::GUID_t&,
+    statistics::MonitorServiceData&);
+
+GetMonitoringStatusFn get_monitoring_status_fn();
+
+template<GetMonitoringStatusFn F>
+struct GetMonitoringStatusAccessor
+{
+    friend GetMonitoringStatusFn get_monitoring_status_fn()
+    {
+        return F;
+    }
+
+};
+
+template struct GetMonitoringStatusAccessor<&DomainParticipantImpl::get_monitoring_status>;
+
+} // namespace
 
 TEST_F(StatisticsDomainParticipantStatusQueryableTests, istatus_queryable_get_incompatible_qos)
 {
@@ -165,18 +189,15 @@ TEST_F(StatisticsDomainParticipantStatusQueryableTests, istatus_queryable_get_in
     DomainParticipant* statistics_participant = DomainParticipant::narrow(participant);
     ASSERT_NE(statistics_participant, nullptr);
 
-    DomainParticipantTest* participant_test = static_cast<DomainParticipantTest*>(participant);
-    ASSERT_NE(nullptr, participant_test);
-    DomainParticipantImplTest* statistics_participant_impl_test = static_cast<DomainParticipantImplTest*>(
-        participant_test->get_impl());
-
+    DomainParticipantImpl* statistics_participant_impl_test = static_cast<DomainParticipantImpl*>(
+        participant->*get_domain_participant_impl_ptr());
     ASSERT_NE(nullptr, statistics_participant_impl_test);
 
     fastdds::dds::TypeSupport type(new TopicDataTypeMock());
     type.register_type(statistics_participant);
 
-    auto publisher = participant_test->create_publisher(fastdds::dds::PUBLISHER_QOS_DEFAULT);
-    auto topic = participant_test->create_topic(TEST_TOPIC, "footype", fastdds::dds::TOPIC_QOS_DEFAULT);
+    auto publisher = participant->create_publisher(fastdds::dds::PUBLISHER_QOS_DEFAULT);
+    auto topic = participant->create_topic(TEST_TOPIC, "footype", fastdds::dds::TOPIC_QOS_DEFAULT);
 
     //! Create DataWriters
     EXPECT_CALL(*publisher, create_datawriter_mock()).WillRepeatedly(testing::Return(false));
@@ -195,8 +216,8 @@ TEST_F(StatisticsDomainParticipantStatusQueryableTests, istatus_queryable_get_in
     incomp_qos_status_dw_1.incompatible_qos_status(IncompatibleQoSStatus_s{});
     MonitorServiceData incomp_qos_status_dw_2;
     incomp_qos_status_dw_2.incompatible_qos_status(IncompatibleQoSStatus_s{});
-    ASSERT_TRUE(statistics_participant_impl_test->monitoring_status(dw1->guid(), incomp_qos_status_dw_1));
-    ASSERT_TRUE(statistics_participant_impl_test->monitoring_status(dw2->guid(), incomp_qos_status_dw_2));
+    ASSERT_TRUE((statistics_participant_impl_test->*get_monitoring_status_fn())(dw1->guid(), incomp_qos_status_dw_1));
+    ASSERT_TRUE((statistics_participant_impl_test->*get_monitoring_status_fn())(dw2->guid(), incomp_qos_status_dw_2));
 
     //! Expect incompatibilities
     ASSERT_EQ(1u, incomp_qos_status_dw_1.incompatible_qos_status().total_count());
@@ -228,18 +249,15 @@ TEST_F(StatisticsDomainParticipantStatusQueryableTests, istatus_queryable_get_li
     DomainParticipant* statistics_participant = DomainParticipant::narrow(participant);
     ASSERT_NE(statistics_participant, nullptr);
 
-    DomainParticipantTest* participant_test = static_cast<DomainParticipantTest*>(participant);
-    ASSERT_NE(nullptr, participant_test);
-    DomainParticipantImplTest* statistics_participant_impl_test = static_cast<DomainParticipantImplTest*>(
-        participant_test->get_impl());
-
+    DomainParticipantImpl* statistics_participant_impl_test = static_cast<DomainParticipantImpl*>(
+        participant->*get_domain_participant_impl_ptr());
     ASSERT_NE(nullptr, statistics_participant_impl_test);
 
     fastdds::dds::TypeSupport type(new TopicDataTypeMock());
     type.register_type(statistics_participant);
 
-    auto publisher = participant_test->create_publisher(fastdds::dds::PUBLISHER_QOS_DEFAULT);
-    auto topic = participant_test->create_topic(TEST_TOPIC, "footype", fastdds::dds::TOPIC_QOS_DEFAULT);
+    auto publisher = participant->create_publisher(fastdds::dds::PUBLISHER_QOS_DEFAULT);
+    auto topic = participant->create_topic(TEST_TOPIC, "footype", fastdds::dds::TOPIC_QOS_DEFAULT);
 
     //! Create DataWriters
     EXPECT_CALL(*publisher, create_datawriter_mock()).WillRepeatedly(testing::Return(false));
@@ -258,8 +276,8 @@ TEST_F(StatisticsDomainParticipantStatusQueryableTests, istatus_queryable_get_li
     liv_lost_status_dw_1.liveliness_lost_status(LivelinessLostStatus_s{});
     MonitorServiceData liv_lost_status_dw_2;
     liv_lost_status_dw_2.liveliness_lost_status(LivelinessLostStatus_s{});
-    ASSERT_TRUE(statistics_participant_impl_test->monitoring_status(dw1->guid(), liv_lost_status_dw_1));
-    ASSERT_TRUE(statistics_participant_impl_test->monitoring_status(dw2->guid(), liv_lost_status_dw_2));
+    ASSERT_TRUE((statistics_participant_impl_test->*get_monitoring_status_fn())(dw1->guid(), liv_lost_status_dw_1));
+    ASSERT_TRUE((statistics_participant_impl_test->*get_monitoring_status_fn())(dw2->guid(), liv_lost_status_dw_2));
 
     //! Expect incompatibilities
     ASSERT_EQ(1u, liv_lost_status_dw_1.liveliness_lost_status().total_count());
@@ -287,18 +305,15 @@ TEST_F(StatisticsDomainParticipantStatusQueryableTests, istatus_queryable_get_de
     DomainParticipant* statistics_participant = DomainParticipant::narrow(participant);
     ASSERT_NE(statistics_participant, nullptr);
 
-    DomainParticipantTest* participant_test = static_cast<DomainParticipantTest*>(participant);
-    ASSERT_NE(nullptr, participant_test);
-    DomainParticipantImplTest* statistics_participant_impl_test = static_cast<DomainParticipantImplTest*>(
-        participant_test->get_impl());
-
+    DomainParticipantImpl* statistics_participant_impl_test = static_cast<DomainParticipantImpl*>(
+        participant->*get_domain_participant_impl_ptr());
     ASSERT_NE(nullptr, statistics_participant_impl_test);
 
     fastdds::dds::TypeSupport type(new TopicDataTypeMock());
     type.register_type(statistics_participant);
 
-    auto publisher = participant_test->create_publisher(fastdds::dds::PUBLISHER_QOS_DEFAULT);
-    auto topic = participant_test->create_topic(TEST_TOPIC, "footype", fastdds::dds::TOPIC_QOS_DEFAULT);
+    auto publisher = participant->create_publisher(fastdds::dds::PUBLISHER_QOS_DEFAULT);
+    auto topic = participant->create_topic(TEST_TOPIC, "footype", fastdds::dds::TOPIC_QOS_DEFAULT);
 
     //! Create DataWriters
     EXPECT_CALL(*publisher, create_datawriter_mock()).WillRepeatedly(testing::Return(false));
@@ -317,8 +332,10 @@ TEST_F(StatisticsDomainParticipantStatusQueryableTests, istatus_queryable_get_de
     deadline_missed_status_dw_1.deadline_missed_status(DeadlineMissedStatus_s{});
     MonitorServiceData deadline_missed_status_dw_2;
     deadline_missed_status_dw_2.deadline_missed_status(DeadlineMissedStatus_s{});
-    ASSERT_TRUE(statistics_participant_impl_test->monitoring_status(dw1->guid(), deadline_missed_status_dw_1));
-    ASSERT_TRUE(statistics_participant_impl_test->monitoring_status(dw2->guid(), deadline_missed_status_dw_2));
+    ASSERT_TRUE((statistics_participant_impl_test->*get_monitoring_status_fn())(dw1->guid(),
+            deadline_missed_status_dw_1));
+    ASSERT_TRUE((statistics_participant_impl_test->*get_monitoring_status_fn())(dw2->guid(),
+            deadline_missed_status_dw_2));
 
     //! Expect incompatibilities
     ASSERT_EQ(1u, deadline_missed_status_dw_1.deadline_missed_status().total_count());

--- a/test/unittest/statistics/dds/StatisticsQosTests.cpp
+++ b/test/unittest/statistics/dds/StatisticsQosTests.cpp
@@ -39,33 +39,53 @@ namespace fastdds {
 namespace statistics {
 namespace dds {
 
+#ifdef FASTDDS_STATISTICS
+namespace {
+
+// Accessor to DomainParticipantImpl* from DomainParticipant
+using DomainParticipantImplPtr = efd::DomainParticipantImpl * efd::DomainParticipant::*;
+
+DomainParticipantImplPtr get_domain_participant_impl_ptr();
+
+template<DomainParticipantImplPtr P>
+struct DomainParticipantImplAccessor
+{
+    friend DomainParticipantImplPtr get_domain_participant_impl_ptr()
+    {
+        return P;
+    }
+
+};
+
+template struct DomainParticipantImplAccessor<&efd::DomainParticipant::impl_>;
+
+// Accessor to builtin_publisher_ from statistics DomainParticipantImpl
+using BuiltinPublisherPtr =
+        efd::Publisher * eprosima::fastdds::statistics::dds::DomainParticipantImpl::*;
+
+BuiltinPublisherPtr get_builtin_publisher_ptr();
+
+template<BuiltinPublisherPtr P>
+struct BuiltinPublisherAccessor
+{
+    friend BuiltinPublisherPtr get_builtin_publisher_ptr()
+    {
+        return P;
+    }
+
+};
+
+template struct BuiltinPublisherAccessor<
+    & eprosima::fastdds::statistics::dds::DomainParticipantImpl::builtin_publisher_>;
+
+} // namespace
+#endif // ifdef FASTDDS_STATISTICS
+
 class StatisticsFromXMLProfileTests : public ::testing::Test
 {
 public:
 
 #ifdef FASTDDS_STATISTICS
-    class TestDomainParticipant : public eprosima::fastdds::statistics::dds::DomainParticipant
-    {
-    public:
-
-        DomainParticipantImpl* get_domain_participant_impl()
-        {
-            return static_cast<DomainParticipantImpl*>(impl_);
-        }
-
-    };
-
-    class TestDomainParticipantImpl : public eprosima::fastdds::statistics::dds::DomainParticipantImpl
-    {
-    public:
-
-        efd::Publisher*  get_publisher()
-        {
-            return builtin_publisher_;
-        }
-
-    };
-
     eprosima::fastdds::statistics::dds::DomainParticipant* statistics_participant = nullptr;
     eprosima::fastdds::dds::Publisher* statistics_publisher = nullptr;
 
@@ -89,24 +109,18 @@ public:
                 eprosima::fastdds::statistics::dds::DomainParticipant::narrow(participant);
         ASSERT_NE(_statistics_participant, nullptr);
 
-        // Static conversion to child class TestDomainParticipant
-        TestDomainParticipant* test_statistics_participant =
-                static_cast<TestDomainParticipant*>(_statistics_participant);
-        ASSERT_NE(test_statistics_participant, nullptr);
+        // Get DomainParticipantImpl via accessor (no UB downcast)
+        efd::DomainParticipantImpl* base_impl =
+                _statistics_participant->*get_domain_participant_impl_ptr();
+        ASSERT_NE(base_impl, nullptr);
 
-        // Get DomainParticipantImpl
         eprosima::fastdds::statistics::dds::DomainParticipantImpl* domain_statistics_participant_impl =
-                test_statistics_participant->get_domain_participant_impl();
+                static_cast<eprosima::fastdds::statistics::dds::DomainParticipantImpl*>(base_impl);
         ASSERT_NE(domain_statistics_participant_impl, nullptr);
 
-        // Static conversion to child class TestDomainParticipantImpl
-        TestDomainParticipantImpl* test_statistics_domain_participant_impl =
-                static_cast<TestDomainParticipantImpl*>(domain_statistics_participant_impl);
-        ASSERT_NE(test_statistics_domain_participant_impl, nullptr);
-
-        // Get Publisher
+        // Get Publisher via accessor
         statistics_pub =
-                test_statistics_domain_participant_impl->get_publisher();
+                domain_statistics_participant_impl->*get_builtin_publisher_ptr();
         ASSERT_NE(statistics_pub, nullptr);
     }
 

--- a/test/unittest/statistics/rtps/CMakeLists.txt
+++ b/test/unittest/statistics/rtps/CMakeLists.txt
@@ -58,6 +58,8 @@ set(TCPTransportInterface_SOURCE
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/TCPChannelResource.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/TCPChannelResourceBasic.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/TCPTransportInterface.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/TCPv4Transport.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/TCPv6Transport.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/TransportInterface.cpp
     )
 if(TLS_FOUND)

--- a/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
+++ b/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
@@ -67,9 +67,7 @@ public:
         return mp_impl;
     }
 
-private:
-
-    ~RTPSParticipantMock();
+    virtual ~RTPSParticipantMock() = default;
 };
 
 struct MockListener : IListener

--- a/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
+++ b/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
@@ -57,20 +57,27 @@ namespace fastdds {
 namespace statistics {
 namespace rtps {
 
-class RTPSParticipantMock : public fastdds::rtps::RTPSParticipant
+namespace {
+
+// Accessor to RTPSParticipantImpl* from RTPSParticipant
+using RTPSParticipantImplPtr = fastdds::rtps::RTPSParticipantImpl * fastdds::rtps::RTPSParticipant::*;
+
+RTPSParticipantImplPtr get_rtps_part_impl();
+
+template<RTPSParticipantImplPtr P>
+struct RTPSParticipantImplAccessor
 {
-
-public:
-
-    fastdds::rtps::RTPSParticipantImpl* get_impl()
+    friend RTPSParticipantImplPtr get_rtps_part_impl()
     {
-        return mp_impl;
+        return P;
     }
 
-private:
-
-    ~RTPSParticipantMock() = default;
 };
+
+template struct RTPSParticipantImplAccessor<&fastdds::rtps::RTPSParticipant::mp_impl>;
+
+} // namespace
+
 
 struct MockListener : IListener
 {
@@ -1394,8 +1401,7 @@ TEST_F(RTPSStatisticsTests, iconnections_queryable_get_entity_connections)
     // match writer and reader on a dummy topic
     match_endpoints(false, "string", "test_topic_name");
 
-    auto participant_mock = static_cast<RTPSParticipantMock*>(participant_);
-    auto part_impl = participant_mock->get_impl();
+    eprosima::fastdds::rtps::RTPSParticipantImpl* part_impl = participant_->*get_rtps_part_impl();
 
     part_impl->get_entity_connections(reader_->getGuid(), conns_reader);
     part_impl->get_entity_connections(writer_->getGuid(), conns_writer);

--- a/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
+++ b/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
@@ -67,7 +67,9 @@ public:
         return mp_impl;
     }
 
-    virtual ~RTPSParticipantMock() = default;
+private:
+
+    ~RTPSParticipantMock() = default;
 };
 
 struct MockListener : IListener

--- a/test/unittest/statistics/rtps/mock/StatisticsBase/statistics/rtps/monitor-service/MonitorService.hpp
+++ b/test/unittest/statistics/rtps/mock/StatisticsBase/statistics/rtps/monitor-service/MonitorService.hpp
@@ -86,7 +86,7 @@ public:
     void set_writer(
             fastdds::rtps::RTPSWriter* writer)
     {
-        status_writer_ = static_cast<fastdds::rtps::StatefulWriter*>(writer);
+        status_writer_ = writer;
     }
 
     ~MonitorService();
@@ -276,7 +276,7 @@ private:
 
     MonitorServiceListener* listener_;
 
-    fastdds::rtps::StatefulWriter* status_writer_;
+    fastdds::rtps::RTPSWriter* status_writer_;
 
     std::unique_ptr<fastdds::rtps::WriterHistory> status_writer_history_;
 
@@ -302,4 +302,3 @@ private:
 } // namespace eprosima
 
 #endif // _STATISTICS_RTPS_MONITOR_SERVICE_MONITORSERVICE_HPP_
-

--- a/test/unittest/transport/CMakeLists.txt
+++ b/test/unittest/transport/CMakeLists.txt
@@ -57,6 +57,8 @@ set(TCPTransportInterface_SOURCE
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/TCPChannelResource.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/TCPChannelResourceBasic.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/TCPTransportInterface.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/TCPv4Transport.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/TCPv6Transport.cpp
     )
 if(TLS_FOUND)
     set(TCPTransportInterface_SOURCE
@@ -259,6 +261,7 @@ set(TCPV6TESTS_SOURCE
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/TCPChannelResource.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/TCPChannelResourceBasic.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/TCPTransportInterface.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/TCPv4Transport.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/TCPv6Transport.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/rtps/transport/TransportInterface.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/utils/Host.cpp

--- a/test/unittest/transport/TCPv4Tests.cpp
+++ b/test/unittest/transport/TCPv4Tests.cpp
@@ -1559,7 +1559,7 @@ TEST_F(TCPv4Tests, secure_non_blocking_send)
     auto sender_unbound_channel_resources = senderTransportUnderTest.get_unbound_channel_resources();
     ASSERT_TRUE(sender_unbound_channel_resources.size() == 1u);
     auto sender_channel_resource =
-            std::static_pointer_cast<TCPChannelResourceBasic>(
+            std::static_pointer_cast<TCPChannelResourceSecure>(
         sender_unbound_channel_resources[0]);
 
     // Prepare the message


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

This PR adds a new workflow to Fast DDS: UBSan.

- It adds a new valid value for `-DSANITIZER=Undefined`, which sets `-fsanitize=undefined -fno-omit-frame-pointer -fsanitize=float-cast-overflow -fsanitize=float-divide-by-zero -fsanitize=bounds-strict`
- It fixes build of Tests with the new UBSan flags and solves one ODR warning
- It adds a new regression test which must fail as it guarantees an UB error.
- It fixes every UB error of the whole Fast DDS Suite. Most of the errors where test-related, although some minor fixes also applied to the library itself.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.2.x 2.14.x 
## Related PRs
- https://github.com/eProsima/Fast-CDR/pull/313

## Merge after
- https://github.com/eProsima/Fast-DDS/pull/6277

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_: Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x]  Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
