### PR TITLE
Add new fuzzing harnesses to be consumed by OSS-Fuzz

### DIFF
--- a/fuzz/C++/fuzz_CDRMessages/CMakeLists.txt
+++ b/fuzz/C++/fuzz_CDRMessages/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(fuzz_CDRMessages VERSION 1 LANGUAGES CXX)
+
+# Find requirements
+if(NOT fastcdr_FOUND)
+    find_package(fastcdr 2 REQUIRED)
+endif()
+
+if(NOT foonathan_memory_FOUND)
+    find_package(foonathan_memory REQUIRED)
+endif()
+
+if(NOT fastdds_FOUND)
+    find_package(fastdds 3 REQUIRED)
+endif()
+
+message(STATUS "Configuring fuzz_CDRMessages...")
+file(GLOB SOURCES_CXX "fuzz_*.cxx")
+
+add_executable(fuzz_CDRMessages ${SOURCES_CXX})
+target_include_directories(fuzz_CDRMessages PRIVATE ${CMAKE_SOURCE_DIR}/src/cpp)
+target_link_libraries(fuzz_CDRMessages fastdds fastcdr foonathan_memory $ENV{LIB_FUZZING_ENGINE})

--- a/fuzz/C++/fuzz_CDRMessages/fuzz_CDRMessages.cxx
+++ b/fuzz/C++/fuzz_CDRMessages/fuzz_CDRMessages.cxx
@@ -1,0 +1,45 @@
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+
+#include <fastdds/rtps/common/CDRMessage_t.hpp>
+#include <rtps/messages/CDRMessage.hpp>
+#include <fastdds/core/policy/ParameterList.hpp>
+#include <fastdds/rtps/common/CacheChange.hpp>
+#include <rtps/security/common/ParticipantGenericMessage.h>
+
+using namespace eprosima::fastdds;
+using namespace eprosima::fastdds::rtps;
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    if (size < 5)
+    {
+        return 0;
+    }
+
+    uint8_t choice = data[0] % 2;
+    const uint8_t* fuzz_data = data + 1;
+    size_t fuzz_size = size - 1;
+
+    CDRMessage_t msg(0);
+    msg.wraps = true;
+    msg.buffer = const_cast<octet*>(fuzz_data);
+    msg.length = static_cast<uint32_t>(fuzz_size);
+    msg.max_size = static_cast<uint32_t>(fuzz_size);
+    msg.reserved_size = static_cast<uint32_t>(fuzz_size);
+
+    if (choice == 0)
+    {
+        CacheChange_t change;
+        uint32_t qos_size = 0;
+        dds::ParameterList::updateCacheChangeFromInlineQos(change, &msg, qos_size);
+    }
+    else
+    {
+        security::ParticipantGenericMessage message;
+        CDRMessage::readParticipantGenericMessage(&msg, message);
+    }
+
+    return 0;
+}

--- a/fuzz/C++/fuzz_ParameterList/CMakeLists.txt
+++ b/fuzz/C++/fuzz_ParameterList/CMakeLists.txt
@@ -1,0 +1,16 @@
+project(fuzz_ParameterList)
+
+set(FUZZ_TARGET fuzz_ParameterList)
+
+add_executable(${FUZZ_TARGET} fuzz_ParameterList.cxx)
+
+target_include_directories(${FUZZ_TARGET} PRIVATE
+    ${PROJECT_SOURCE_DIR}/src/cpp
+    ${PROJECT_SOURCE_DIR}/include
+    ${PROJECT_SOURCE_DIR}/build/include
+)
+
+target_link_libraries(${FUZZ_TARGET}
+    fastdds
+    $ENV{LIB_FUZZING_ENGINE}
+)

--- a/fuzz/C++/fuzz_ParameterList/fuzz_ParameterList.cxx
+++ b/fuzz/C++/fuzz_ParameterList/fuzz_ParameterList.cxx
@@ -1,0 +1,33 @@
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+
+#include <fastdds/rtps/common/CDRMessage_t.hpp>
+#include <rtps/messages/CDRMessage.hpp>
+#include <fastdds/core/policy/ParameterList.hpp>
+#include <fastdds/rtps/common/CacheChange.hpp>
+
+using namespace eprosima::fastdds;
+using namespace eprosima::fastdds::rtps;
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    if (size < 4)
+    {
+        return 0;
+    }
+
+    CDRMessage_t msg(0);
+    msg.wraps = true;
+    msg.buffer = const_cast<octet*>(data);
+    msg.length = static_cast<uint32_t>(size);
+    msg.max_size = static_cast<uint32_t>(size);
+    msg.reserved_size = static_cast<uint32_t>(size);
+
+    CacheChange_t change;
+    uint32_t qos_size = 0;
+    
+    dds::ParameterList::updateCacheChangeFromInlineQos(change, &msg, qos_size);
+
+    return 0;
+}

--- a/fuzz/C++/fuzz_ParticipantGenericMessage/CMakeLists.txt
+++ b/fuzz/C++/fuzz_ParticipantGenericMessage/CMakeLists.txt
@@ -1,0 +1,16 @@
+project(fuzz_ParticipantGenericMessage)
+
+set(FUZZ_TARGET fuzz_ParticipantGenericMessage)
+
+add_executable(${FUZZ_TARGET} fuzz_ParticipantGenericMessage.cxx)
+
+target_include_directories(${FUZZ_TARGET} PRIVATE
+    ${PROJECT_SOURCE_DIR}/src/cpp
+    ${PROJECT_SOURCE_DIR}/include
+    ${PROJECT_SOURCE_DIR}/build/include
+)
+
+target_link_libraries(${FUZZ_TARGET}
+    fastdds
+    $ENV{LIB_FUZZING_ENGINE}
+)

--- a/fuzz/C++/fuzz_ParticipantGenericMessage/fuzz_ParticipantGenericMessage.cxx
+++ b/fuzz/C++/fuzz_ParticipantGenericMessage/fuzz_ParticipantGenericMessage.cxx
@@ -1,0 +1,30 @@
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+
+#include <fastdds/rtps/common/CDRMessage_t.hpp>
+#include <rtps/messages/CDRMessage.hpp>
+#include <rtps/security/common/ParticipantGenericMessage.h>
+
+using namespace eprosima::fastdds;
+using namespace eprosima::fastdds::rtps;
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    if (size < 4)
+    {
+        return 0;
+    }
+
+    CDRMessage_t msg(0);
+    msg.wraps = true;
+    msg.buffer = const_cast<octet*>(data);
+    msg.length = static_cast<uint32_t>(size);
+    msg.max_size = static_cast<uint32_t>(size);
+    msg.reserved_size = static_cast<uint32_t>(size);
+
+    security::ParticipantGenericMessage message;
+    CDRMessage::readParticipantGenericMessage(&msg, message);
+
+    return 0;
+}

--- a/fuzz/C++/fuzz_ParticipantProxyData/CMakeLists.txt
+++ b/fuzz/C++/fuzz_ParticipantProxyData/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(fuzz_ParticipantProxyData VERSION 1 LANGUAGES CXX)
+
+# Find requirements
+if(NOT fastcdr_FOUND)
+    find_package(fastcdr 2 REQUIRED)
+endif()
+
+if(NOT foonathan_memory_FOUND)
+    find_package(foonathan_memory REQUIRED)
+endif()
+
+if(NOT fastdds_FOUND)
+    find_package(fastdds 3 REQUIRED)
+endif()
+
+message(STATUS "Configuring fuzz_ParticipantProxyData...")
+file(GLOB SOURCES_CXX "fuzz_*.cxx")
+
+add_executable(fuzz_ParticipantProxyData ${SOURCES_CXX})
+target_include_directories(fuzz_ParticipantProxyData PRIVATE ${CMAKE_SOURCE_DIR}/src/cpp)
+target_link_libraries(fuzz_ParticipantProxyData fastdds fastcdr foonathan_memory $ENV{LIB_FUZZING_ENGINE})

--- a/fuzz/C++/fuzz_ParticipantProxyData/fuzz_ParticipantProxyData.cxx
+++ b/fuzz/C++/fuzz_ParticipantProxyData/fuzz_ParticipantProxyData.cxx
@@ -1,0 +1,41 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <string.h>
+
+#include <fastdds/rtps/attributes/RTPSParticipantAttributes.hpp>
+#include <fastdds/rtps/common/CDRMessage_t.hpp>
+#include <rtps/builtin/data/ParticipantProxyData.hpp>
+#include <rtps/network/NetworkFactory.hpp>
+
+using namespace eprosima::fastdds;
+using namespace eprosima::fastdds::rtps;
+
+extern "C" int LLVMFuzzerTestOneInput(
+        const uint8_t* data,
+        size_t size)
+{
+    if (size < 4)
+    {
+        return 0;
+    }
+
+    RTPSParticipantAttributes PParam;
+    NetworkFactory network(PParam);
+
+    RTPSParticipantAllocationAttributes allocation;
+    ParticipantProxyData pdata(allocation);
+
+    CDRMessage_t msg(0);
+    msg.wraps = true;
+    msg.buffer = const_cast<octet*>(data);
+    msg.length = static_cast<uint32_t>(size);
+    msg.max_size = static_cast<uint32_t>(size);
+    msg.reserved_size = static_cast<uint32_t>(size);
+
+    // use_encapsulation = true will read first 4 bytes as encapsulation header
+    pdata.read_from_cdr_message(&msg, true, network, false);
+
+    return 0;
+}

--- a/fuzz/C++/fuzz_ProxyData/CMakeLists.txt
+++ b/fuzz/C++/fuzz_ProxyData/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(fuzz_ProxyData VERSION 1 LANGUAGES CXX)
+
+# Find requirements
+if(NOT fastcdr_FOUND)
+    find_package(fastcdr 2 REQUIRED)
+endif()
+
+if(NOT foonathan_memory_FOUND)
+    find_package(foonathan_memory REQUIRED)
+endif()
+
+if(NOT fastdds_FOUND)
+    find_package(fastdds 3 REQUIRED)
+endif()
+
+message(STATUS "Configuring fuzz_ProxyData...")
+file(GLOB SOURCES_CXX "fuzz_*.cxx")
+
+add_executable(fuzz_ProxyData ${SOURCES_CXX})
+target_include_directories(fuzz_ProxyData PRIVATE ${CMAKE_SOURCE_DIR}/src/cpp)
+target_link_libraries(fuzz_ProxyData fastdds fastcdr foonathan_memory $ENV{LIB_FUZZING_ENGINE})

--- a/fuzz/C++/fuzz_ProxyData/fuzz_ProxyData.cxx
+++ b/fuzz/C++/fuzz_ProxyData/fuzz_ProxyData.cxx
@@ -1,0 +1,60 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <string.h>
+
+#include <fastdds/rtps/attributes/RTPSParticipantAttributes.hpp>
+#include <fastdds/rtps/common/CDRMessage_t.hpp>
+#include <rtps/builtin/data/ParticipantProxyData.hpp>
+#include <rtps/builtin/data/ReaderProxyData.hpp>
+#include <rtps/builtin/data/WriterProxyData.hpp>
+#include <rtps/network/NetworkFactory.hpp>
+
+using namespace eprosima::fastdds;
+using namespace eprosima::fastdds::rtps;
+
+extern "C" int LLVMFuzzerTestOneInput(
+        const uint8_t* data,
+        size_t size)
+{
+    if (size < 5)
+    {
+        return 0;
+    }
+
+    uint8_t choice = data[0] % 3;
+    const uint8_t* fuzz_data = data + 1;
+    size_t fuzz_size = size - 1;
+
+    CDRMessage_t msg(0);
+    msg.wraps = true;
+    msg.buffer = const_cast<octet*>(fuzz_data);
+    msg.length = static_cast<uint32_t>(fuzz_size);
+    msg.max_size = static_cast<uint32_t>(fuzz_size);
+    msg.reserved_size = static_cast<uint32_t>(fuzz_size);
+
+    if (choice == 0)
+    {
+        RTPSParticipantAttributes PParam;
+        NetworkFactory network(PParam);
+
+        RTPSParticipantAllocationAttributes allocation;
+        ParticipantProxyData pdata(allocation);
+
+        // use_encapsulation = true will read first 4 bytes as encapsulation header
+        pdata.read_from_cdr_message(&msg, true, network, false);
+    }
+    else if (choice == 1)
+    {
+        ReaderProxyData pdata(10, 10);
+        pdata.read_from_cdr_message(&msg);
+    }
+    else
+    {
+        WriterProxyData pdata(10, 10);
+        pdata.read_from_cdr_message(&msg);
+    }
+
+    return 0;
+}

--- a/fuzz/C++/fuzz_ReaderProxyData/CMakeLists.txt
+++ b/fuzz/C++/fuzz_ReaderProxyData/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(fuzz_ReaderProxyData VERSION 1 LANGUAGES CXX)
+
+# Find requirements
+if(NOT fastcdr_FOUND)
+    find_package(fastcdr 2 REQUIRED)
+endif()
+
+if(NOT foonathan_memory_FOUND)
+    find_package(foonathan_memory REQUIRED)
+endif()
+
+if(NOT fastdds_FOUND)
+    find_package(fastdds 3 REQUIRED)
+endif()
+
+message(STATUS "Configuring fuzz_ReaderProxyData...")
+file(GLOB SOURCES_CXX "fuzz_*.cxx")
+
+add_executable(fuzz_ReaderProxyData ${SOURCES_CXX})
+target_include_directories(fuzz_ReaderProxyData PRIVATE ${CMAKE_SOURCE_DIR}/src/cpp)
+target_link_libraries(fuzz_ReaderProxyData fastdds fastcdr foonathan_memory $ENV{LIB_FUZZING_ENGINE})

--- a/fuzz/C++/fuzz_ReaderProxyData/fuzz_ReaderProxyData.cxx
+++ b/fuzz/C++/fuzz_ReaderProxyData/fuzz_ReaderProxyData.cxx
@@ -1,0 +1,35 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <string.h>
+
+#include <fastdds/rtps/common/CDRMessage_t.hpp>
+#include <rtps/builtin/data/ReaderProxyData.hpp>
+
+using namespace eprosima::fastdds;
+using namespace eprosima::fastdds::rtps;
+
+extern "C" int LLVMFuzzerTestOneInput(
+        const uint8_t* data,
+        size_t size)
+{
+    if (size < 4)
+    {
+        return 0;
+    }
+
+    ReaderProxyData pdata(10, 10);
+
+    CDRMessage_t msg(0);
+    msg.wraps = true;
+    msg.buffer = const_cast<octet*>(data);
+    msg.length = static_cast<uint32_t>(size);
+    msg.max_size = static_cast<uint32_t>(size);
+    msg.reserved_size = static_cast<uint32_t>(size);
+
+    // bool read_from_cdr_message(CDRMessage_t* msg, fastdds::rtps::VendorId_t source_vendor_id = c_VendorId_eProsima);
+    pdata.read_from_cdr_message(&msg);
+
+    return 0;
+}

--- a/fuzz/C++/fuzz_TypeLookupTypes/CMakeLists.txt
+++ b/fuzz/C++/fuzz_TypeLookupTypes/CMakeLists.txt
@@ -1,0 +1,17 @@
+project(fuzz_TypeLookupTypes)
+
+set(FUZZ_TARGET fuzz_TypeLookupTypes)
+
+add_executable(${FUZZ_TARGET} fuzz_TypeLookupTypes.cxx)
+
+target_include_directories(${FUZZ_TARGET} PRIVATE
+    ${PROJECT_SOURCE_DIR}/src/cpp
+    ${PROJECT_SOURCE_DIR}/include
+    ${PROJECT_SOURCE_DIR}/build/include
+    ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/builtin/type_lookup_service/detail
+)
+
+target_link_libraries(${FUZZ_TARGET}
+    fastdds
+    $ENV{LIB_FUZZING_ENGINE}
+)

--- a/fuzz/C++/fuzz_TypeLookupTypes/fuzz_TypeLookupTypes.cxx
+++ b/fuzz/C++/fuzz_TypeLookupTypes/fuzz_TypeLookupTypes.cxx
@@ -1,0 +1,47 @@
+#include <stdint.h>
+#include <stddef.h>
+#include <string.h>
+
+#include <fastdds/rtps/common/SerializedPayload.hpp>
+#include <fastdds/builtin/type_lookup_service/detail/TypeLookupTypesPubSubTypes.hpp>
+#include <fastdds/builtin/type_lookup_service/detail/TypeLookupTypes.hpp>
+
+using namespace eprosima::fastdds;
+using namespace eprosima::fastdds::dds::builtin;
+using namespace eprosima::fastdds::rtps;
+
+extern "C" int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size)
+{
+    if (size < 4)
+    {
+        return 0;
+    }
+
+    SerializedPayload_t payload(static_cast<uint32_t>(size));
+    memcpy(payload.data, data, size);
+    payload.length = static_cast<uint32_t>(size);
+
+    // Fuzz different TypeLookup structures
+    uint8_t choice = data[0] % 3;
+
+    if (choice == 0)
+    {
+        TypeLookup_getTypes_In data_obj;
+        TypeLookup_getTypes_InPubSubType pubsub_type;
+        pubsub_type.deserialize(payload, &data_obj);
+    }
+    else if (choice == 1)
+    {
+        TypeLookup_getTypeDependencies_In data_obj;
+        TypeLookup_getTypeDependencies_InPubSubType pubsub_type;
+        pubsub_type.deserialize(payload, &data_obj);
+    }
+    else
+    {
+        TypeLookup_getTypes_Out data_obj;
+        TypeLookup_getTypes_OutPubSubType pubsub_type;
+        pubsub_type.deserialize(payload, &data_obj);
+    }
+
+    return 0;
+}

--- a/fuzz/C++/fuzz_WriterProxyData/CMakeLists.txt
+++ b/fuzz/C++/fuzz_WriterProxyData/CMakeLists.txt
@@ -1,0 +1,23 @@
+cmake_minimum_required(VERSION 3.22)
+
+project(fuzz_WriterProxyData VERSION 1 LANGUAGES CXX)
+
+# Find requirements
+if(NOT fastcdr_FOUND)
+    find_package(fastcdr 2 REQUIRED)
+endif()
+
+if(NOT foonathan_memory_FOUND)
+    find_package(foonathan_memory REQUIRED)
+endif()
+
+if(NOT fastdds_FOUND)
+    find_package(fastdds 3 REQUIRED)
+endif()
+
+message(STATUS "Configuring fuzz_WriterProxyData...")
+file(GLOB SOURCES_CXX "fuzz_*.cxx")
+
+add_executable(fuzz_WriterProxyData ${SOURCES_CXX})
+target_include_directories(fuzz_WriterProxyData PRIVATE ${CMAKE_SOURCE_DIR}/src/cpp)
+target_link_libraries(fuzz_WriterProxyData fastdds fastcdr foonathan_memory $ENV{LIB_FUZZING_ENGINE})

--- a/fuzz/C++/fuzz_WriterProxyData/fuzz_WriterProxyData.cxx
+++ b/fuzz/C++/fuzz_WriterProxyData/fuzz_WriterProxyData.cxx
@@ -1,0 +1,34 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdarg.h>
+#include <string.h>
+
+#include <fastdds/rtps/common/CDRMessage_t.hpp>
+#include <rtps/builtin/data/WriterProxyData.hpp>
+
+using namespace eprosima::fastdds;
+using namespace eprosima::fastdds::rtps;
+
+extern "C" int LLVMFuzzerTestOneInput(
+        const uint8_t* data,
+        size_t size)
+{
+    if (size < 4)
+    {
+        return 0;
+    }
+
+    WriterProxyData pdata(10, 10);
+
+    CDRMessage_t msg(0);
+    msg.wraps = true;
+    msg.buffer = const_cast<octet*>(data);
+    msg.length = static_cast<uint32_t>(size);
+    msg.max_size = static_cast<uint32_t>(size);
+    msg.reserved_size = static_cast<uint32_t>(size);
+
+    pdata.read_from_cdr_message(&msg);
+
+    return 0;
+}

--- a/fuzz/CMakeLists.txt
+++ b/fuzz/CMakeLists.txt
@@ -16,3 +16,6 @@ set(fastdds_FOUND TRUE)
 
 add_subdirectory(C++/fuzz_XMLProfiles)
 add_subdirectory(C++/fuzz_processCDRMsg)
+add_subdirectory(C++/fuzz_ProxyData)
+add_subdirectory(C++/fuzz_CDRMessages)
+add_subdirectory(C++/fuzz_TypeLookupTypes)


### PR DESCRIPTION
The goal is to increase code coverage of which there is a recent report here:
https://storage.googleapis.com/oss-fuzz-coverage/fast-dds/reports/20260504/linux/report.html

This adds several new fuzzing harnesses. These will be automatically picked up by OSS-Fuzz to be built and run.

<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.4.x 3.2.x 2.14.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [ ] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [ ] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [ ] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [ ] Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [ ] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [ ] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [ ] Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
