### PR TITLE
[23767] Fix data races on DataWriterImpl qos access

### DIFF
--- a/src/cpp/fastdds/publisher/DataWriter.cpp
+++ b/src/cpp/fastdds/publisher/DataWriter.cpp
@@ -209,8 +209,7 @@ const DataWriterQos& DataWriter::get_qos() const
 ReturnCode_t DataWriter::get_qos(
         DataWriterQos& qos) const
 {
-    qos = impl_->get_qos();
-    return RETCODE_OK;
+    return impl_->get_qos(qos);
 }
 
 ReturnCode_t DataWriter::set_listener(

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -250,137 +250,148 @@ ReturnCode_t DataWriterImpl::enable()
 {
     assert(writer_ == nullptr);
 
-    std::unique_lock<std::mutex> qos_lock(qos_mutex_);
-
-    auto history_att = DataWriterHistory::to_history_attributes(
-        qos_.history(),
-        qos_.resource_limits(),
-        (type_->is_compute_key_provided ? WITH_KEY : NO_KEY),
-        type_->get_max_serialized_size_ctx(type_support_context_),
-        qos_.endpoint().history_memory_policy);
-    pool_config_ = PoolConfig::from_history_attributes(history_att);
-
-    // When the user requested PREALLOCATED_WITH_REALLOC, but we know the type cannot
-    // grow, we translate the policy into bare PREALLOCATED
-    if (PREALLOCATED_WITH_REALLOC_MEMORY_MODE == pool_config_.memory_policy &&
-            (type_->is_bounded_ctx(type_support_context_) ||
-            type_->is_plain_ctx(type_support_context_, data_representation_)))
-    {
-        pool_config_.memory_policy = PREALLOCATED_MEMORY_MODE;
-    }
-
     WriterAttributes w_att;
-    w_att.endpoint.durabilityKind = qos_.durability().durabilityKind();
-    w_att.endpoint.endpointKind = WRITER;
-    w_att.endpoint.reliabilityKind = qos_.reliability().kind == RELIABLE_RELIABILITY_QOS ? RELIABLE : BEST_EFFORT;
-    w_att.endpoint.topicKind = type_->is_compute_key_provided ? WITH_KEY : NO_KEY;
-    w_att.endpoint.multicastLocatorList = qos_.endpoint().multicast_locator_list;
-    w_att.endpoint.unicastLocatorList = qos_.endpoint().unicast_locator_list;
-    w_att.endpoint.remoteLocatorList = qos_.endpoint().remote_locator_list;
-    w_att.endpoint.external_unicast_locators = qos_.endpoint().external_unicast_locators;
-    w_att.endpoint.ignore_non_matching_locators = qos_.endpoint().ignore_non_matching_locators;
-    w_att.mode = qos_.publish_mode().kind == SYNCHRONOUS_PUBLISH_MODE ? SYNCHRONOUS_WRITER : ASYNCHRONOUS_WRITER;
-    w_att.flow_controller_name = qos_.publish_mode().flow_controller_name;
-    w_att.endpoint.properties = qos_.properties();
-    w_att.endpoint.ownershipKind = qos_.ownership().kind;
-    w_att.endpoint.setEntityID(qos_.endpoint().entity_id);
-    w_att.endpoint.setUserDefinedID(qos_.endpoint().user_defined_id);
-    w_att.times = qos_.reliable_writer_qos().times;
-    w_att.liveliness_kind = qos_.liveliness().kind;
-    w_att.liveliness_lease_duration = qos_.liveliness().lease_duration;
-    w_att.liveliness_announcement_period = qos_.liveliness().announcement_period;
-    w_att.matched_readers_allocation = qos_.writer_resource_limits().matched_subscriber_allocation;
-    w_att.disable_heartbeat_piggyback = qos_.reliable_writer_qos().disable_heartbeat_piggyback;
-    w_att.transport_priority = qos_.transport_priority().value;
+    bool filtering_enabled = false;
+    fastdds::ResourceLimitedContainerConfig reader_filters_alloc{};
+    fastdds::dds::Duration_t lifespan_duration{};
 
-    // TODO(Ricardo) Remove in future
-    // Insert topic_name and partitions
-    Property property;
-    property.name("topic_name");
-    property.value(topic_->get_name().c_str());
-    w_att.endpoint.properties.properties().push_back(std::move(property));
-
-    std::string* endpoint_partitions = PropertyPolicyHelper::find_property(qos_.properties(), "partitions");
-
-    if (endpoint_partitions)
     {
-        property.name("partitions");
-        property.value(*endpoint_partitions);
-        w_att.endpoint.properties.properties().push_back(std::move(property));
-    }
-    else if (publisher_->get_qos().partition().names().size() > 0)
-    {
-        property.name("partitions");
-        std::string partitions;
-        bool is_first_partition = true;
-        for (auto partition : publisher_->get_qos().partition().names())
+        std::lock_guard<std::mutex> qos_guard(qos_mutex_);
+
+        auto history_att = DataWriterHistory::to_history_attributes(
+            qos_.history(),
+            qos_.resource_limits(),
+            (type_->is_compute_key_provided ? WITH_KEY : NO_KEY),
+            type_->get_max_serialized_size_ctx(type_support_context_),
+            qos_.endpoint().history_memory_policy);
+        pool_config_ = PoolConfig::from_history_attributes(history_att);
+
+        // When the user requested PREALLOCATED_WITH_REALLOC, but we know the type cannot
+        // grow, we translate the policy into bare PREALLOCATED
+        if (PREALLOCATED_WITH_REALLOC_MEMORY_MODE == pool_config_.memory_policy &&
+                (type_->is_bounded_ctx(type_support_context_) ||
+                type_->is_plain_ctx(type_support_context_, data_representation_)))
         {
-            partitions += (is_first_partition ? "" : ";") + partition;
-            is_first_partition = false;
+            pool_config_.memory_policy = PREALLOCATED_MEMORY_MODE;
         }
-        property.value(std::move(partitions));
+
+        w_att.endpoint.durabilityKind = qos_.durability().durabilityKind();
+        w_att.endpoint.endpointKind = WRITER;
+        w_att.endpoint.reliabilityKind = qos_.reliability().kind == RELIABLE_RELIABILITY_QOS ? RELIABLE : BEST_EFFORT;
+        w_att.endpoint.topicKind = type_->is_compute_key_provided ? WITH_KEY : NO_KEY;
+        w_att.endpoint.multicastLocatorList = qos_.endpoint().multicast_locator_list;
+        w_att.endpoint.unicastLocatorList = qos_.endpoint().unicast_locator_list;
+        w_att.endpoint.remoteLocatorList = qos_.endpoint().remote_locator_list;
+        w_att.endpoint.external_unicast_locators = qos_.endpoint().external_unicast_locators;
+        w_att.endpoint.ignore_non_matching_locators = qos_.endpoint().ignore_non_matching_locators;
+        w_att.mode = qos_.publish_mode().kind == SYNCHRONOUS_PUBLISH_MODE ? SYNCHRONOUS_WRITER : ASYNCHRONOUS_WRITER;
+        w_att.flow_controller_name = qos_.publish_mode().flow_controller_name;
+        w_att.endpoint.properties = qos_.properties();
+        w_att.endpoint.ownershipKind = qos_.ownership().kind;
+        w_att.endpoint.setEntityID(qos_.endpoint().entity_id);
+        w_att.endpoint.setUserDefinedID(qos_.endpoint().user_defined_id);
+        w_att.times = qos_.reliable_writer_qos().times;
+        w_att.liveliness_kind = qos_.liveliness().kind;
+        w_att.liveliness_lease_duration = qos_.liveliness().lease_duration;
+        w_att.liveliness_announcement_period = qos_.liveliness().announcement_period;
+        w_att.matched_readers_allocation = qos_.writer_resource_limits().matched_subscriber_allocation;
+        w_att.disable_heartbeat_piggyback = qos_.reliable_writer_qos().disable_heartbeat_piggyback;
+        w_att.transport_priority = qos_.transport_priority().value;
+
+        // TODO(Ricardo) Remove in future
+        // Insert topic_name and partitions
+        Property property;
+        property.name("topic_name");
+        property.value(topic_->get_name().c_str());
         w_att.endpoint.properties.properties().push_back(std::move(property));
-    }
 
-    if (qos_.reliable_writer_qos().disable_positive_acks.enabled &&
-            qos_.reliable_writer_qos().disable_positive_acks.duration != dds::c_TimeInfinite)
-    {
-        w_att.disable_positive_acks = true;
-        w_att.keep_duration = qos_.reliable_writer_qos().disable_positive_acks.duration;
-    }
+        std::string* endpoint_partitions = PropertyPolicyHelper::find_property(qos_.properties(), "partitions");
 
-    ReturnCode_t ret_code = check_datasharing_compatible(w_att, is_data_sharing_compatible_);
-    if (ret_code != RETCODE_OK)
-    {
-        return ret_code;
-    }
-
-    if (is_data_sharing_compatible_)
-    {
-        DataSharingQosPolicy datasharing(qos_.data_sharing());
-        if (datasharing.domain_ids().empty())
+        if (endpoint_partitions)
         {
-            datasharing.add_domain_id(utils::default_domain_id());
+            property.name("partitions");
+            property.value(*endpoint_partitions);
+            w_att.endpoint.properties.properties().push_back(std::move(property));
         }
-        w_att.endpoint.set_data_sharing_configuration(datasharing);
-
-        // Update pool config for KEEP_ALL when max_samples is infinite
-        if ((0 == pool_config_.maximum_size) && (KEEP_ALL_HISTORY_QOS == qos_.history().kind))
+        else if (publisher_->get_qos().partition().names().size() > 0)
         {
-            // Override infinite with old default value for max_samples + extra samples
-            pool_config_.maximum_size = 5000;
-            if (0 < qos_.resource_limits().extra_samples)
+            property.name("partitions");
+            std::string partitions;
+            bool is_first_partition = true;
+            for (auto partition : publisher_->get_qos().partition().names())
             {
-                pool_config_.maximum_size += static_cast<uint32_t>(qos_.resource_limits().extra_samples);
+                partitions += (is_first_partition ? "" : ";") + partition;
+                is_first_partition = false;
             }
-            EPROSIMA_LOG_ERROR(DATA_WRITER,
-                    "DataWriter with KEEP_ALL history and infinite max_samples is not compatible with DataSharing. "
-                    "Setting max_samples to " << pool_config_.maximum_size);
+            property.value(std::move(partitions));
+            w_att.endpoint.properties.properties().push_back(std::move(property));
         }
-    }
-    else
-    {
-        DataSharingQosPolicy datasharing;
-        datasharing.off();
-        w_att.endpoint.set_data_sharing_configuration(datasharing);
-    }
 
-    bool filtering_enabled =
-            qos_.liveliness().lease_duration.is_infinite() &&
-            (0 < qos_.writer_resource_limits().reader_filters_allocation.maximum);
+        if (qos_.reliable_writer_qos().disable_positive_acks.enabled &&
+                qos_.reliable_writer_qos().disable_positive_acks.duration != dds::c_TimeInfinite)
+        {
+            w_att.disable_positive_acks = true;
+            w_att.keep_duration = qos_.reliable_writer_qos().disable_positive_acks.duration;
+        }
+
+        ReturnCode_t ret_code = check_datasharing_compatible(w_att, is_data_sharing_compatible_);
+        if (ret_code != RETCODE_OK)
+        {
+            return ret_code;
+        }
+
+        if (is_data_sharing_compatible_)
+        {
+            DataSharingQosPolicy datasharing(qos_.data_sharing());
+            if (datasharing.domain_ids().empty())
+            {
+                datasharing.add_domain_id(utils::default_domain_id());
+            }
+            w_att.endpoint.set_data_sharing_configuration(datasharing);
+
+            // Update pool config for KEEP_ALL when max_samples is infinite
+            if ((0 == pool_config_.maximum_size) && (KEEP_ALL_HISTORY_QOS == qos_.history().kind))
+            {
+                // Override infinite with old default value for max_samples + extra samples
+                pool_config_.maximum_size = 5000;
+                if (0 < qos_.resource_limits().extra_samples)
+                {
+                    pool_config_.maximum_size += static_cast<uint32_t>(qos_.resource_limits().extra_samples);
+                }
+                EPROSIMA_LOG_ERROR(DATA_WRITER,
+                        "DataWriter with KEEP_ALL history and infinite max_samples is not compatible with DataSharing. "
+                        "Setting max_samples to " << pool_config_.maximum_size);
+            }
+        }
+        else
+        {
+            DataSharingQosPolicy datasharing;
+            datasharing.off();
+            w_att.endpoint.set_data_sharing_configuration(datasharing);
+        }
+
+        filtering_enabled =
+                qos_.liveliness().lease_duration.is_infinite() &&
+                (0 < qos_.writer_resource_limits().reader_filters_allocation.maximum);
+
+        if (filtering_enabled)
+        {
+            reader_filters_alloc = qos_.writer_resource_limits().reader_filters_allocation;
+        }
+
+        // Set Datawriter's DataRepresentationId taking into account the QoS.
+        data_representation_ = qos_.representation().m_value.empty()
+                || XCDR_DATA_REPRESENTATION == qos_.representation().m_value.at(0)
+                        ? XCDR_DATA_REPRESENTATION : XCDR2_DATA_REPRESENTATION;
+
+        lifespan_duration = qos_.lifespan().duration;
+    }
 
     if (filtering_enabled)
     {
         std::lock_guard<std::mutex> lock(filters_mtx_);
-        reader_filters_.reset(new ReaderFilterCollection(qos_.writer_resource_limits().reader_filters_allocation));
+        reader_filters_.reset(new ReaderFilterCollection(reader_filters_alloc));
     }
-
-    // Set Datawriter's DataRepresentationId taking into account the QoS.
-    data_representation_ = qos_.representation().m_value.empty()
-            || XCDR_DATA_REPRESENTATION == qos_.representation().m_value.at(0)
-                    ? XCDR_DATA_REPRESENTATION : XCDR2_DATA_REPRESENTATION;
-
-    qos_lock.unlock();
 
     auto change_pool = get_change_pool();
     if (!change_pool)
@@ -465,23 +476,19 @@ ReturnCode_t DataWriterImpl::enable()
 
     configure_deadline_timer_();
 
+    lifespan_timer_ = new TimedEvent(publisher_->rtps_participant()->get_resource_event(),
+                    [&]() -> bool
+                    {
+                        return lifespan_expired();
+                    },
+                    lifespan_duration.to_ns() * 1e-6);
+
+    // In case it has been loaded from the persistence DB, expire old samples.
+    if (lifespan_duration != dds::c_TimeInfinite)
     {
-        std::lock_guard<RecursiveTimedMutex> writer_lock(writer_->getMutex());
-
-        lifespan_timer_ = new TimedEvent(publisher_->rtps_participant()->get_resource_event(),
-                        [&]() -> bool
-                        {
-                            return lifespan_expired();
-                        },
-                        qos_.lifespan().duration.to_ns() * 1e-6);
-
-        // In case it has been loaded from the persistence DB, expire old samples.
-        if (qos_.lifespan().duration != dds::c_TimeInfinite)
+        if (lifespan_expired())
         {
-            if (lifespan_expired())
-            {
-                lifespan_timer_->restart_timer();
-            }
+            lifespan_timer_->restart_timer();
         }
     }
 
@@ -1239,16 +1246,23 @@ InstanceHandle_t DataWriterImpl::get_instance_handle() const
 
 void DataWriterImpl::publisher_qos_updated()
 {
-    if (writer_ != nullptr)
+    fastdds::rtps::BaseWriter* writer_snapshot = nullptr;
+    WriterQos wqos;
+
     {
-        WriterQos wqos;
+        std::lock_guard<std::mutex> qos_guard(qos_mutex_);
+
+        if (writer_ == nullptr)
         {
-            std::lock_guard<RecursiveTimedMutex> writer_lock(writer_->getMutex());
-            wqos = qos_.get_writerqos(get_publisher()->get_qos(), topic_->get_qos());
+            return;
         }
-        // NOTIFY THE BUILTIN PROTOCOLS THAT THE WRITER HAS CHANGED
-        publisher_->rtps_participant()->update_writer(writer_, wqos);
+
+        writer_snapshot = writer_;
+        wqos = qos_.get_writerqos(get_publisher()->get_qos(), topic_->get_qos());
     }
+
+    // NOTIFY THE BUILTIN PROTOCOLS THAT THE WRITER HAS CHANGED
+    publisher_->rtps_participant()->update_writer(writer_snapshot, wqos);
 }
 
 ReturnCode_t DataWriterImpl::set_qos(
@@ -1274,51 +1288,49 @@ ReturnCode_t DataWriterImpl::set_qos(
         }
     }
 
-    std::unique_lock<std::mutex> qos_lock(qos_mutex_);
-    bool enabled = writer_ != nullptr;
-
-    if (!enabled)
-    {
-        set_qos(qos_, qos_to_set, true);
-        return RETCODE_OK;
-    }
-
-    if (!can_qos_be_updated(qos_, qos_to_set))
-    {
-        return RETCODE_IMMUTABLE_POLICY;
-    }
-
-    qos_lock.unlock();
-
     DataWriterQos old_qos;
+    DataWriterQos new_qos;
+    {
+        std::lock_guard<std::mutex> qos_guard(qos_mutex_);
+        bool enabled = writer_ != nullptr;
+
+        if (!enabled)
+        {
+            set_qos(qos_, qos_to_set, true);
+            return RETCODE_OK;
+        }
+
+        if (!can_qos_be_updated(qos_, qos_to_set))
+        {
+            return RETCODE_IMMUTABLE_POLICY;
+        }
+
+        old_qos = qos_;
+        set_qos(qos_, qos_to_set, false);
+        new_qos = qos_;
+    }
+
     WriterQos wqos;
     bool update_attributes = false;
     WriterAttributes w_att;
     bool deadline_changed = false;
     bool lifespan_changed = false;
 
+    int32_t transport_priority = writer_->get_transport_priority();
+    if ((new_qos.reliability().kind == ReliabilityQosPolicyKind::RELIABLE_RELIABILITY_QOS &&
+            new_qos.reliable_writer_qos() == qos_to_set.reliable_writer_qos()) ||
+            (transport_priority != qos_to_set.transport_priority().value))
     {
-        std::lock_guard<RecursiveTimedMutex> writer_lock(writer_->getMutex());
-
-        old_qos = qos_;
-        set_qos(qos_, qos_to_set, false);
-
-        int32_t transport_priority = writer_->get_transport_priority();
-        if ((qos_.reliability().kind == ReliabilityQosPolicyKind::RELIABLE_RELIABILITY_QOS &&
-                qos_.reliable_writer_qos() == qos_to_set.reliable_writer_qos()) ||
-                (transport_priority != qos_to_set.transport_priority().value))
-        {
-            update_attributes = true;
-            w_att.times = qos_.reliable_writer_qos().times;
-            w_att.disable_positive_acks = qos_.reliable_writer_qos().disable_positive_acks.enabled;
-            w_att.keep_duration = qos_.reliable_writer_qos().disable_positive_acks.duration;
-            w_att.transport_priority = qos_to_set.transport_priority().value;
-        }
-
-        wqos = qos_.get_writerqos(get_publisher()->get_qos(), topic_->get_qos());
-        deadline_changed = old_qos.deadline().period != qos_.deadline().period;
-        lifespan_changed = old_qos.lifespan().duration != qos_.lifespan().duration;
+        update_attributes = true;
+        w_att.times = new_qos.reliable_writer_qos().times;
+        w_att.disable_positive_acks = new_qos.reliable_writer_qos().disable_positive_acks.enabled;
+        w_att.keep_duration = new_qos.reliable_writer_qos().disable_positive_acks.duration;
+        w_att.transport_priority = qos_to_set.transport_priority().value;
     }
+
+    wqos = new_qos.get_writerqos(get_publisher()->get_qos(), topic_->get_qos());
+    deadline_changed = old_qos.deadline().period != new_qos.deadline().period;
+    lifespan_changed = old_qos.lifespan().duration != new_qos.lifespan().duration;
 
     if (update_attributes)
     {
@@ -1336,11 +1348,11 @@ ReturnCode_t DataWriterImpl::set_qos(
     // Lifespan
     if (lifespan_changed)
     {
-        if (qos_.lifespan().duration != dds::c_TimeInfinite)
+        if (new_qos.lifespan().duration != dds::c_TimeInfinite)
         {
             lifespan_duration_us_ =
-                    duration<double, std::ratio<1, 1000000>>(qos_.lifespan().duration.to_ns() * 1e-3);
-            lifespan_timer_->update_interval_millisec(qos_.lifespan().duration.to_ns() * 1e-6);
+                    duration<double, std::ratio<1, 1000000>>(new_qos.lifespan().duration.to_ns() * 1e-3);
+            lifespan_timer_->update_interval_millisec(new_qos.lifespan().duration.to_ns() * 1e-6);
         }
         else
         {
@@ -1359,14 +1371,7 @@ const DataWriterQos& DataWriterImpl::get_qos() const
 ReturnCode_t DataWriterImpl::get_qos(
         DataWriterQos& qos) const
 {
-    std::unique_lock<std::mutex> qos_lock(qos_mutex_);
-    if (writer_ != nullptr)
-    {
-        qos_lock.unlock();
-        std::lock_guard<RecursiveTimedMutex> writer_lock(writer_->getMutex());
-        qos = qos_;
-        return RETCODE_OK;
-    }
+    std::lock_guard<std::mutex> qos_guard(qos_mutex_);
     qos = qos_;
     return RETCODE_OK;
 }
@@ -1835,11 +1840,13 @@ ReturnCode_t DataWriterImpl::get_liveliness_lost_status(
 
 ReturnCode_t DataWriterImpl::assert_liveliness()
 {
-    if (writer_ == nullptr)
     {
-        return RETCODE_NOT_ENABLED;
+        std::lock_guard<std::mutex> qos_guard(qos_mutex_);
+        if (writer_ == nullptr)
+        {
+            return RETCODE_NOT_ENABLED;
+        }
     }
-
     if (!publisher_->rtps_participant()->wlp()->assert_liveliness(
                 writer_->getGuid(),
                 writer_->get_liveliness_kind(),
@@ -1850,19 +1857,18 @@ ReturnCode_t DataWriterImpl::assert_liveliness()
     }
 
     {
-        std::lock_guard<RecursiveTimedMutex> writer_lock(writer_->getMutex());
-        if (qos_.liveliness().kind == MANUAL_BY_TOPIC_LIVELINESS_QOS)
+        std::lock_guard<std::mutex> qos_guard(qos_mutex_);
+        if (qos_.liveliness().kind != MANUAL_BY_TOPIC_LIVELINESS_QOS)
         {
-            // As described in the RTPS specification, if liveliness kind is manual a heartbeat must be sent
-            // This only applies to stateful writers, as stateless writers do not send heartbeats
-
-            StatefulWriter* stateful_writer = dynamic_cast<StatefulWriter*>(writer_);
-
-            if (stateful_writer != nullptr)
-            {
-                stateful_writer->send_periodic_heartbeat(true, true);
-            }
+            return RETCODE_OK;
         }
+    }
+    // As described in the RTPS specification, if liveliness kind is manual a heartbeat must be sent
+    // This only applies to stateful writers, as stateless writers do not send heartbeats
+    StatefulWriter* stateful_writer = dynamic_cast<StatefulWriter*>(writer_);
+    if (stateful_writer != nullptr)
+    {
+        stateful_writer->send_periodic_heartbeat(true, true);
     }
     return RETCODE_OK;
 }
@@ -1903,7 +1909,7 @@ ReturnCode_t DataWriterImpl::get_publication_builtin_topic_data(
             writer_->get_participant_impl()->network_factory().network_configuration();
 
     {
-        std::lock_guard<RecursiveTimedMutex> writer_lock(writer_->getMutex());
+        std::lock_guard<std::mutex> qos_guard(qos_mutex_);
 
         // DataWriter qos
         publication_data.durability = qos_.durability();

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -250,6 +250,8 @@ ReturnCode_t DataWriterImpl::enable()
 {
     assert(writer_ == nullptr);
 
+    std::unique_lock<std::mutex> qos_lock(qos_mutex_);
+
     auto history_att = DataWriterHistory::to_history_attributes(
         qos_.history(),
         qos_.resource_limits(),
@@ -378,6 +380,8 @@ ReturnCode_t DataWriterImpl::enable()
             || XCDR_DATA_REPRESENTATION == qos_.representation().m_value.at(0)
                     ? XCDR_DATA_REPRESENTATION : XCDR2_DATA_REPRESENTATION;
 
+    qos_lock.unlock();
+
     auto change_pool = get_change_pool();
     if (!change_pool)
     {
@@ -447,7 +451,10 @@ ReturnCode_t DataWriterImpl::enable()
         return RETCODE_ERROR;
     }
 
-    writer_ = BaseWriter::downcast(writer);
+    {
+        std::lock_guard<std::mutex> qos_lock(qos_mutex_);
+        writer_ = BaseWriter::downcast(writer);
+    }
 
     // Set DataWriterImpl as the implementer of the
     // IReaderDataFilter interface
@@ -458,19 +465,23 @@ ReturnCode_t DataWriterImpl::enable()
 
     configure_deadline_timer_();
 
-    lifespan_timer_ = new TimedEvent(publisher_->rtps_participant()->get_resource_event(),
-                    [&]() -> bool
-                    {
-                        return lifespan_expired();
-                    },
-                    qos_.lifespan().duration.to_ns() * 1e-6);
-
-    // In case it has been loaded from the persistence DB, expire old samples.
-    if (qos_.lifespan().duration != dds::c_TimeInfinite)
     {
-        if (lifespan_expired())
+        std::lock_guard<RecursiveTimedMutex> writer_lock(writer_->getMutex());
+
+        lifespan_timer_ = new TimedEvent(publisher_->rtps_participant()->get_resource_event(),
+                        [&]() -> bool
+                        {
+                            return lifespan_expired();
+                        },
+                        qos_.lifespan().duration.to_ns() * 1e-6);
+
+        // In case it has been loaded from the persistence DB, expire old samples.
+        if (qos_.lifespan().duration != dds::c_TimeInfinite)
         {
-            lifespan_timer_->restart_timer();
+            if (lifespan_expired())
+            {
+                lifespan_timer_->restart_timer();
+            }
         }
     }
 
@@ -1230,8 +1241,12 @@ void DataWriterImpl::publisher_qos_updated()
 {
     if (writer_ != nullptr)
     {
+        WriterQos wqos;
+        {
+            std::lock_guard<RecursiveTimedMutex> writer_lock(writer_->getMutex());
+            wqos = qos_.get_writerqos(get_publisher()->get_qos(), topic_->get_qos());
+        }
         // NOTIFY THE BUILTIN PROTOCOLS THAT THE WRITER HAS CHANGED
-        WriterQos wqos = qos_.get_writerqos(get_publisher()->get_qos(), topic_->get_qos());
         publisher_->rtps_participant()->update_writer(writer_, wqos);
     }
 }
@@ -1239,7 +1254,6 @@ void DataWriterImpl::publisher_qos_updated()
 ReturnCode_t DataWriterImpl::set_qos(
         const DataWriterQos& qos)
 {
-    bool enabled = writer_ != nullptr;
     const DataWriterQos& qos_to_set = (&qos == &DATAWRITER_QOS_DEFAULT) ?
             publisher_->get_default_datawriter_qos() : qos;
 
@@ -1260,56 +1274,77 @@ ReturnCode_t DataWriterImpl::set_qos(
         }
     }
 
-    if (enabled && !can_qos_be_updated(qos_, qos_to_set))
+    std::unique_lock<std::mutex> qos_lock(qos_mutex_);
+    bool enabled = writer_ != nullptr;
+
+    if (!enabled)
+    {
+        set_qos(qos_, qos_to_set, true);
+        return RETCODE_OK;
+    }
+
+    if (!can_qos_be_updated(qos_, qos_to_set))
     {
         return RETCODE_IMMUTABLE_POLICY;
     }
 
-    // Take a snapshot of the current QoS before mutating it
-    const DataWriterQos old_qos = qos_;
+    qos_lock.unlock();
 
-    set_qos(qos_, qos_to_set, !enabled);
+    DataWriterQos old_qos;
+    WriterQos wqos;
+    bool update_attributes = false;
+    WriterAttributes w_att;
+    bool deadline_changed = false;
+    bool lifespan_changed = false;
 
-    if (enabled)
     {
-        int32_t transport_priority = writer_->get_transport_priority();
+        std::lock_guard<RecursiveTimedMutex> writer_lock(writer_->getMutex());
 
+        old_qos = qos_;
+        set_qos(qos_, qos_to_set, false);
+
+        int32_t transport_priority = writer_->get_transport_priority();
         if ((qos_.reliability().kind == ReliabilityQosPolicyKind::RELIABLE_RELIABILITY_QOS &&
                 qos_.reliable_writer_qos() == qos_to_set.reliable_writer_qos()) ||
                 (transport_priority != qos_to_set.transport_priority().value))
         {
-            // Update times and positive_acks attributes on RTPS Layer
-            WriterAttributes w_att;
+            update_attributes = true;
             w_att.times = qos_.reliable_writer_qos().times;
             w_att.disable_positive_acks = qos_.reliable_writer_qos().disable_positive_acks.enabled;
             w_att.keep_duration = qos_.reliable_writer_qos().disable_positive_acks.duration;
             w_att.transport_priority = qos_to_set.transport_priority().value;
-            writer_->update_attributes(w_att);
         }
 
-        // Notify the participant that a Writer has changed its QOS
-        WriterQos wqos = qos_.get_writerqos(get_publisher()->get_qos(), topic_->get_qos());
-        publisher_->rtps_participant()->update_writer(writer_, wqos);
+        wqos = qos_.get_writerqos(get_publisher()->get_qos(), topic_->get_qos());
+        deadline_changed = old_qos.deadline().period != qos_.deadline().period;
+        lifespan_changed = old_qos.lifespan().duration != qos_.lifespan().duration;
+    }
 
-        // If the deadline period actually changed, (re)configure the timer.
-        if (old_qos.deadline().period != qos_.deadline().period)
+    if (update_attributes)
+    {
+        writer_->update_attributes(w_att);
+    }
+
+    // Notify the participant that a Writer has changed its QOS
+    publisher_->rtps_participant()->update_writer(writer_, wqos);
+
+    if (deadline_changed)
+    {
+        configure_deadline_timer_();
+    }
+
+    // Lifespan
+    if (lifespan_changed)
+    {
+        if (qos_.lifespan().duration != dds::c_TimeInfinite)
         {
-            configure_deadline_timer_();
+            lifespan_duration_us_ =
+                    duration<double, std::ratio<1, 1000000>>(qos_.lifespan().duration.to_ns() * 1e-3);
+            lifespan_timer_->update_interval_millisec(qos_.lifespan().duration.to_ns() * 1e-6);
         }
-
-        // Lifespan
-        if (old_qos.lifespan().duration != qos_.lifespan().duration)
+        else
         {
-            if (qos_.lifespan().duration != dds::c_TimeInfinite)
-            {
-                lifespan_duration_us_ =
-                        duration<double, std::ratio<1, 1000000>>(qos_.lifespan().duration.to_ns() * 1e-3);
-                lifespan_timer_->update_interval_millisec(qos_.lifespan().duration.to_ns() * 1e-6);
-            }
-            else
-            {
-                lifespan_timer_->cancel_timer();
-            }
+            lifespan_timer_->cancel_timer();
         }
     }
 
@@ -1319,6 +1354,21 @@ ReturnCode_t DataWriterImpl::set_qos(
 const DataWriterQos& DataWriterImpl::get_qos() const
 {
     return qos_;
+}
+
+ReturnCode_t DataWriterImpl::get_qos(
+        DataWriterQos& qos) const
+{
+    std::unique_lock<std::mutex> qos_lock(qos_mutex_);
+    if (writer_ != nullptr)
+    {
+        qos_lock.unlock();
+        std::lock_guard<RecursiveTimedMutex> writer_lock(writer_->getMutex());
+        qos = qos_;
+        return RETCODE_OK;
+    }
+    qos = qos_;
+    return RETCODE_OK;
 }
 
 ReturnCode_t DataWriterImpl::set_listener(
@@ -1799,16 +1849,19 @@ ReturnCode_t DataWriterImpl::assert_liveliness()
         return RETCODE_ERROR;
     }
 
-    if (qos_.liveliness().kind == MANUAL_BY_TOPIC_LIVELINESS_QOS)
     {
-        // As described in the RTPS specification, if liveliness kind is manual a heartbeat must be sent
-        // This only applies to stateful writers, as stateless writers do not send heartbeats
-
-        StatefulWriter* stateful_writer = dynamic_cast<StatefulWriter*>(writer_);
-
-        if (stateful_writer != nullptr)
+        std::lock_guard<RecursiveTimedMutex> writer_lock(writer_->getMutex());
+        if (qos_.liveliness().kind == MANUAL_BY_TOPIC_LIVELINESS_QOS)
         {
-            stateful_writer->send_periodic_heartbeat(true, true);
+            // As described in the RTPS specification, if liveliness kind is manual a heartbeat must be sent
+            // This only applies to stateful writers, as stateless writers do not send heartbeats
+
+            StatefulWriter* stateful_writer = dynamic_cast<StatefulWriter*>(writer_);
+
+            if (stateful_writer != nullptr)
+            {
+                stateful_writer->send_periodic_heartbeat(true, true);
+            }
         }
     }
     return RETCODE_OK;
@@ -1838,84 +1891,89 @@ ReturnCode_t DataWriterImpl::get_publication_builtin_topic_data(
     publication_data.type_name = topic_->get_type_name();
     publication_data.topic_kind = type_->is_compute_key_provided ? TopicKind_t::WITH_KEY : TopicKind_t::NO_KEY;
 
-    // DataWriter qos
-    publication_data.durability = qos_.durability();
-    publication_data.durability_service = qos_.durability_service();
-    publication_data.deadline = qos_.deadline();
-    publication_data.latency_budget = qos_.latency_budget();
-    publication_data.liveliness = qos_.liveliness();
-    publication_data.reliability = qos_.reliability();
-    publication_data.lifespan = qos_.lifespan();
-    publication_data.user_data = qos_.user_data();
-    publication_data.ownership = qos_.ownership();
-    publication_data.ownership_strength = qos_.ownership_strength();
-    publication_data.destination_order = qos_.destination_order();
-
     // Publisher qos
     publication_data.presentation = publisher_->qos_.presentation();
     publication_data.partition = publisher_->qos_.partition();
     publication_data.topic_data = topic_->get_qos().topic_data();
     publication_data.group_data = publisher_->qos_.group_data();
 
-    // XTypes 1.3
     publisher_->get_participant_impl()->fill_type_information(type_, publication_data.type_information);
-    publication_data.representation = qos_.representation();
 
-    // eProsima extensions
-
-    publication_data.disable_positive_acks = qos_.reliable_writer_qos().disable_positive_acks;
-    publication_data.data_sharing = qos_.data_sharing();
-
-    if (publication_data.data_sharing.kind() != OFF &&
-            publication_data.data_sharing.domain_ids().empty())
-    {
-        publication_data.data_sharing.add_domain_id(utils::default_domain_id());
-    }
-
-    publication_data.guid = guid();
-    publication_data.participant_guid = publisher_->get_participant()->guid();
-
-    const std::string* pers_guid = PropertyPolicyHelper::find_property(qos_.properties(), "dds.persistence.guid");
-    if (pers_guid)
-    {
-        // Load persistence_guid from property
-        std::istringstream(pers_guid->c_str()) >> publication_data.persistence_guid;
-    }
-
-    qos_.endpoint().unicast_locator_list.copy_to(publication_data.remote_locators.unicast);
-    qos_.endpoint().multicast_locator_list.copy_to(publication_data.remote_locators.multicast);
-    publication_data.max_serialized_size = type_->get_max_serialized_size_ctx(type_support_context_);
     publication_data.loopback_transformation =
             writer_->get_participant_impl()->network_factory().network_configuration();
 
-    if (!is_data_sharing_compatible_)
     {
-        publication_data.data_sharing.off();
-    }
+        std::lock_guard<RecursiveTimedMutex> writer_lock(writer_->getMutex());
 
-    const std::string* endpoint_partitions = PropertyPolicyHelper::find_property(qos_.properties(), "partitions");
-    if (endpoint_partitions)
-    {
-        std::istringstream partition_string(*endpoint_partitions);
-        std::string partition_name;
-        publication_data.partition.clear();
+        // DataWriter qos
+        publication_data.durability = qos_.durability();
+        publication_data.durability_service = qos_.durability_service();
+        publication_data.deadline = qos_.deadline();
+        publication_data.latency_budget = qos_.latency_budget();
+        publication_data.liveliness = qos_.liveliness();
+        publication_data.reliability = qos_.reliability();
+        publication_data.lifespan = qos_.lifespan();
+        publication_data.user_data = qos_.user_data();
+        publication_data.ownership = qos_.ownership();
+        publication_data.ownership_strength = qos_.ownership_strength();
+        publication_data.destination_order = qos_.destination_order();
 
-        while (std::getline(partition_string, partition_name, ';'))
+        // XTypes 1.3
+        publication_data.representation = qos_.representation();
+
+        // eProsima extensions
+        publication_data.disable_positive_acks = qos_.reliable_writer_qos().disable_positive_acks;
+        publication_data.data_sharing = qos_.data_sharing();
+
+        if (publication_data.data_sharing.kind() != OFF &&
+                publication_data.data_sharing.domain_ids().empty())
         {
-            publication_data.partition.push_back(partition_name.c_str());
+            publication_data.data_sharing.add_domain_id(utils::default_domain_id());
         }
+
+        publication_data.guid = guid();
+        publication_data.participant_guid = publisher_->get_participant()->guid();
+
+        const std::string* pers_guid = PropertyPolicyHelper::find_property(qos_.properties(), "dds.persistence.guid");
+        if (pers_guid)
+        {
+            // Load persistence_guid from property
+            std::istringstream(pers_guid->c_str()) >> publication_data.persistence_guid;
+        }
+
+        qos_.endpoint().unicast_locator_list.copy_to(publication_data.remote_locators.unicast);
+        qos_.endpoint().multicast_locator_list.copy_to(publication_data.remote_locators.multicast);
+        publication_data.max_serialized_size = type_->get_max_serialized_size_ctx(type_support_context_);
+
+        if (!is_data_sharing_compatible_)
+        {
+            publication_data.data_sharing.off();
+        }
+
+        const std::string* endpoint_partitions = PropertyPolicyHelper::find_property(qos_.properties(), "partitions");
+        if (endpoint_partitions)
+        {
+            std::istringstream partition_string(*endpoint_partitions);
+            std::string partition_name;
+            publication_data.partition.clear();
+
+            while (std::getline(partition_string, partition_name, ';'))
+            {
+                publication_data.partition.push_back(partition_name.c_str());
+            }
+        }
+
+        publication_data.history = qos_.history();
+
+        // Optional QoS
+        publication_data.resource_limits = qos_.resource_limits();
+        publication_data.transport_priority = qos_.transport_priority();
+        publication_data.writer_data_lifecycle = qos_.writer_data_lifecycle();
+        publication_data.publish_mode = qos_.publish_mode();
+        publication_data.rtps_reliable_writer = qos_.reliable_writer_qos();
+        publication_data.endpoint = qos_.endpoint();
+        publication_data.writer_resource_limits = qos_.writer_resource_limits();
     }
-
-    publication_data.history = qos_.history();
-
-    // Optional QoS
-    publication_data.resource_limits = qos_.resource_limits();
-    publication_data.transport_priority = qos_.transport_priority();
-    publication_data.writer_data_lifecycle = qos_.writer_data_lifecycle();
-    publication_data.publish_mode = qos_.publish_mode();
-    publication_data.rtps_reliable_writer = qos_.reliable_writer_qos();
-    publication_data.endpoint = qos_.endpoint();
-    publication_data.writer_resource_limits = qos_.writer_resource_limits();
 
     return RETCODE_OK;
 }

--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -452,7 +452,7 @@ ReturnCode_t DataWriterImpl::enable()
     }
 
     {
-        std::lock_guard<std::mutex> qos_lock(qos_mutex_);
+        std::lock_guard<std::mutex> writer_assign_lock(qos_mutex_);
         writer_ = BaseWriter::downcast(writer);
     }
 

--- a/src/cpp/fastdds/publisher/DataWriterImpl.hpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.hpp
@@ -320,6 +320,9 @@ public:
 
     const DataWriterQos& get_qos() const;
 
+    ReturnCode_t get_qos(
+            DataWriterQos& qos) const;
+
     Topic* get_topic() const;
 
     const DataWriterListener* get_listener() const;
@@ -479,6 +482,9 @@ protected:
     Topic* topic_ = nullptr;
 
     DataWriterQos qos_;
+
+    //! Mutex to protect qos_
+    mutable std::mutex qos_mutex_;
 
     //! DataWriterListener
     DataWriterListener* listener_ = nullptr;

--- a/test/unittest/dds/publisher/DataWriterTests.cpp
+++ b/test/unittest/dds/publisher/DataWriterTests.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <atomic>
 #include <chrono>
 #include <condition_variable>
 #include <cstdint>
@@ -2838,6 +2839,111 @@ TEST(DataWriterTests, set_type_support_context)
     EXPECT_EQ(RETCODE_ILLEGAL_OPERATION, datawriter->set_type_support_context(nullptr));
 
     // Tear down
+    ASSERT_TRUE(publisher->delete_datawriter(datawriter) == RETCODE_OK);
+    ASSERT_TRUE(participant->delete_topic(topic) == RETCODE_OK);
+    ASSERT_TRUE(participant->delete_publisher(publisher) == RETCODE_OK);
+    ASSERT_TRUE(DomainParticipantFactory::get_instance()->delete_participant(participant) == RETCODE_OK);
+}
+
+/*!
+ * This test checks that concurrent set_qos() and get_qos() calls on an enabled DataWriter are race-free.
+ */
+TEST(DataWriterTests, ConcurrentSetQosVsGetQos)
+{
+    DomainParticipant* participant =
+            DomainParticipantFactory::get_instance()->create_participant(0, PARTICIPANT_QOS_DEFAULT);
+    ASSERT_NE(participant, nullptr);
+
+    Publisher* publisher = participant->create_publisher(PUBLISHER_QOS_DEFAULT);
+    ASSERT_NE(publisher, nullptr);
+
+    TypeSupport type(new TopicDataTypeMock());
+    type.register_type(participant);
+
+    Topic* topic = participant->create_topic("footopic_concurrent", type.get_type_name(), TOPIC_QOS_DEFAULT);
+    ASSERT_NE(topic, nullptr);
+
+    DataWriter* datawriter = publisher->create_datawriter(topic, DATAWRITER_QOS_DEFAULT);
+    ASSERT_NE(datawriter, nullptr);
+    ASSERT_TRUE(datawriter->is_enabled());
+
+    // Two valid, mutable QoS configurations that differ in deadline period.
+    DataWriterQos qos_a = DATAWRITER_QOS_DEFAULT;
+    qos_a.deadline().period = eprosima::fastdds::dds::Duration_t(1, 0);
+
+    DataWriterQos qos_b = DATAWRITER_QOS_DEFAULT;
+    qos_b.deadline().period = eprosima::fastdds::dds::Duration_t(2, 0);
+
+    constexpr int kIterations = 5000;
+
+    std::mutex barrier_mutex;
+    std::condition_variable barrier_cv;
+    bool go = false;
+
+    std::atomic<bool> writer_error{false};
+    std::atomic<bool> reader_error{false};
+
+    std::thread writer_thread([&]()
+            {
+                {
+                    std::unique_lock<std::mutex> lk(barrier_mutex);
+                    barrier_cv.wait(lk, [&]
+                    {
+                        return go;
+                    });
+                }
+                for (int i = 0; i < kIterations; ++i)
+                {
+                    const DataWriterQos& qos_to_set = (i % 2 == 0) ? qos_a : qos_b;
+                    if (datawriter->set_qos(qos_to_set) != RETCODE_OK)
+                    {
+                        writer_error.store(true);
+                        break;
+                    }
+                }
+            });
+
+    std::thread reader_thread([&]()
+            {
+                {
+                    std::unique_lock<std::mutex> lk(barrier_mutex);
+                    barrier_cv.wait(lk, [&]
+                    {
+                        return go;
+                    });
+                }
+                DataWriterQos observed;
+                for (int i = 0; i < kIterations; ++i)
+                {
+                    if (datawriter->get_qos(observed) != RETCODE_OK)
+                    {
+                        reader_error.store(true);
+                        break;
+                    }
+                    const eprosima::fastdds::dds::Duration_t& p = observed.deadline().period;
+                    const bool valid = (p == qos_a.deadline().period) ||
+                    (p == qos_b.deadline().period) ||
+                    (p == DATAWRITER_QOS_DEFAULT.deadline().period);
+                    if (!valid)
+                    {
+                        reader_error.store(true);
+                        break;
+                    }
+                }
+            });
+
+    {
+        std::lock_guard<std::mutex> lk(barrier_mutex);
+        go = true;
+    }
+    barrier_cv.notify_all();
+
+    writer_thread.join();
+    reader_thread.join();
+
+    EXPECT_FALSE(writer_error.load()) << "set_qos() returned an unexpected error code during concurrent run";
+    EXPECT_FALSE(reader_error.load()) << "get_qos() returned a torn or unexpected QoS value during concurrent run";
+
     ASSERT_TRUE(publisher->delete_datawriter(datawriter) == RETCODE_OK);
     ASSERT_TRUE(participant->delete_topic(topic) == RETCODE_OK);
     ASSERT_TRUE(participant->delete_publisher(publisher) == RETCODE_OK);

--- a/test/unittest/statistics/dds/StatisticsDomainParticipantStatusQueryableTests/mock/fastdds/publisher/DataWriterImpl.hpp
+++ b/test/unittest/statistics/dds/StatisticsDomainParticipantStatusQueryableTests/mock/fastdds/publisher/DataWriterImpl.hpp
@@ -286,6 +286,13 @@ public:
         return qos_;
     }
 
+    ReturnCode_t get_qos(
+            DataWriterQos& qos) const
+    {
+        qos = qos_;
+        return RETCODE_OK;
+    }
+
     Topic* get_topic() const
     {
         return topic_;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
This PR attempts to fix data races on `DataWriterImpl::qos_`, where mainly the `enable()` and `set_qos` functions accessed the element simultaneously.

Added a new `qos_mutex_` that guards `qos_` and `writer_`. A concurrency regression test has also been included.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.2.x 2.14.x

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- _N/A_: If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
