### PR TITLE
[24372] Assert liveliness with periodic heartbeats in secure participants

### DIFF
--- a/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
@@ -303,6 +303,18 @@ void PDPSimple::announceParticipantState(
         if (!(dispose || new_change))
         {
             endpoints->writer.writer_->send_periodic_announcement();
+
+#if HAVE_SECURITY
+            if (mp_RTPSParticipant->is_secure())
+            {
+                // PDP non-secure endpoints are unmatched after participant authentication succeeds (and secure PDP
+                // endpoints are matched), and since the secure ones are TRANSIENT_LOCAL, we send periodic heartbeats
+                // to assert liveliness on remote participants
+                auto secure = dynamic_cast<fastdds::rtps::SimplePDPEndpointsSecure*>(builtin_endpoints_.get());
+                assert(nullptr != secure);
+                secure->secure_writer.writer_->send_periodic_heartbeat(true, true);
+            }
+#endif // HAVE_SECURITY
         }
     }
 }

--- a/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPSimple.cpp
@@ -291,7 +291,6 @@ void PDPSimple::announceParticipantState(
 
         auto endpoints = dynamic_cast<fastdds::rtps::SimplePDPEndpoints*>(builtin_endpoints_.get());
         assert(endpoints && endpoints->writer.history_);
-
         if (!endpoints || !endpoints->writer.history_)
         {
             FASTDDS_UNREACHABLE();       // “cannot happen” invariant
@@ -311,7 +310,11 @@ void PDPSimple::announceParticipantState(
                 // endpoints are matched), and since the secure ones are TRANSIENT_LOCAL, we send periodic heartbeats
                 // to assert liveliness on remote participants
                 auto secure = dynamic_cast<fastdds::rtps::SimplePDPEndpointsSecure*>(builtin_endpoints_.get());
-                assert(nullptr != secure);
+                assert(secure && secure->secure_writer.writer_);
+                if (!secure || !secure->secure_writer.writer_)
+                {
+                    FASTDDS_UNREACHABLE();   // “cannot happen” invariant
+                }
                 secure->secure_writer.writer_->send_periodic_heartbeat(true, true);
             }
 #endif // HAVE_SECURITY

--- a/src/cpp/rtps/security/SecurityManager.cpp
+++ b/src/cpp/rtps/security/SecurityManager.cpp
@@ -758,7 +758,7 @@ bool SecurityManager::discovered_participant(
         notify_participant_authorized(*remote_participant_data);
     }
 
-    return undiscovered ? returnedValue : false;
+    return returnedValue;
 }
 
 void SecurityManager::remove_participant(

--- a/src/cpp/rtps/security/SecurityManager.cpp
+++ b/src/cpp/rtps/security/SecurityManager.cpp
@@ -758,7 +758,7 @@ bool SecurityManager::discovered_participant(
         notify_participant_authorized(*remote_participant_data);
     }
 
-    return returnedValue;
+    return undiscovered ? returnedValue : false;
 }
 
 void SecurityManager::remove_participant(

--- a/test/blackbox/common/BlackboxTestsSecurity.cpp
+++ b/test/blackbox/common/BlackboxTestsSecurity.cpp
@@ -1315,6 +1315,98 @@ TEST_P(Security, RemoveParticipantProxyDataonSecurityManagerLeaseExpired_validat
 
 }
 
+// Regression test for secure PDP liveliness maintenance without user traffic.
+TEST(Security, SecureParticipantsDoNotLoseDiscoveryWithoutUserTraffic)
+{
+    PubSubReader<HelloWorldPubSubType> reader("HelloWorldTopic_secure_participant_liveliness");
+    PubSubWriter<HelloWorldPubSubType> writer("HelloWorldTopic_secure_participant_liveliness");
+    const auto idle_timeout = std::chrono::seconds(6);
+    const auto data_timeout = std::chrono::seconds(10);
+    // Keep the lease short so loss of secure PDP liveliness shows up quickly
+    const auto lease_duration = eprosima::fastdds::dds::Duration_t(3, 0);
+    const auto announcement_period = eprosima::fastdds::dds::Duration_t(1, 0);
+    // Use UDP transport to later block the fallback participant DATA(P) traffic
+    auto reader_transport = std::make_shared<test_UDPv4TransportDescriptor>();
+    auto writer_transport = std::make_shared<test_UDPv4TransportDescriptor>();
+
+    const std::string governance_file("governance_helloworld_all_enable.smime");
+    const std::string permissions_file("permissions_helloworld.smime");
+
+    CommonPermissionsConfigure(reader, writer, governance_file, permissions_file);
+    // Force the test through UDP to avoid local shortcuts masking the secure discovery behavior
+    reader.disable_builtin_transport().add_user_transport_to_pparams(reader_transport);
+    writer.disable_builtin_transport().add_user_transport_to_pparams(writer_transport);
+
+    // Two secure participants that authenticate, discover each other, and exchange user data
+    reader.lease_duration(lease_duration, announcement_period)
+            .history_depth(10)
+            .reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS)
+            .init();
+    ASSERT_TRUE(reader.isInitialized());
+
+    writer.lease_duration(lease_duration, announcement_period)
+            .history_depth(10)
+            .reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS)
+            .init();
+    ASSERT_TRUE(writer.isInitialized());
+
+    reader.wait_authorized();
+    writer.wait_authorized();
+
+    // Wait until both endpoints are matched
+    reader.wait_discovery();
+    writer.wait_discovery();
+
+    // Verify discovery state stayed stable
+    auto assert_still_discovered = [&reader, &writer]()
+            {                
+                ASSERT_TRUE(reader.is_matched());
+                ASSERT_TRUE(writer.is_matched());
+                ASSERT_EQ(reader.get_matched(), 1u);
+                ASSERT_EQ(writer.get_matched(), 1u);
+
+                const auto reader_status = reader.get_subscription_matched_status();
+                const auto writer_status = writer.get_publication_matched_status();
+                ASSERT_EQ(reader_status.total_count, 1);
+                ASSERT_EQ(writer_status.total_count, 1);
+            };
+
+    // Check the secure participants must not be undiscovered just because user traffic stops
+    auto assert_idle_period_keeps_discovery = [&reader, &writer, &idle_timeout, &assert_still_discovered]()
+            {                
+                ASSERT_FALSE(reader.wait_participant_undiscovery(idle_timeout));
+                ASSERT_FALSE(writer.wait_participant_undiscovery(idle_timeout));
+
+                assert_still_discovered();
+            };
+
+    // Discovery is only useful if data can still flow after the idle window
+    auto assert_data_flow = [&reader, &writer, &data_timeout, &assert_still_discovered]()
+            {                
+                auto data = default_helloworld_data_generator(2);
+
+                reader.startReception(data);
+                writer.send(data);
+                
+                ASSERT_TRUE(data.empty());
+                ASSERT_EQ(reader.block_for_all(data_timeout), 2u);
+                assert_still_discovered();
+            };
+
+    ASSERT_NO_FATAL_FAILURE(assert_still_discovered());
+
+    // After the secure PDP endpoints are established, stop the unprotected participant DATA(P)
+    // traffic, to depend on the secure liveliness maintenance path
+    reader_transport->test_transport_options->always_drop_participant_builtin_topic_data = true;
+    writer_transport->test_transport_options->always_drop_participant_builtin_topic_data = true;
+
+    // Exercise the idle scenario twice to catch both immediate loss and unstable recovery/rematch behavior
+    ASSERT_NO_FATAL_FAILURE(assert_idle_period_keeps_discovery());
+    ASSERT_NO_FATAL_FAILURE(assert_data_flow());
+    ASSERT_NO_FATAL_FAILURE(assert_idle_period_keeps_discovery());
+    ASSERT_NO_FATAL_FAILURE(assert_data_flow());
+}
+
 TEST(Security, AllowUnauthenticatedParticipants_EntityCreationFailsIfRTPSProtectionIsNotNONE)
 {
     PubSubReader<HelloWorldPubSubType> reader("HelloWorldTopic");

--- a/test/blackbox/common/BlackboxTestsSecurity.cpp
+++ b/test/blackbox/common/BlackboxTestsSecurity.cpp
@@ -1359,7 +1359,7 @@ TEST(Security, SecureParticipantsDoNotLoseDiscoveryWithoutUserTraffic)
 
     // Verify discovery state stayed stable
     auto assert_still_discovered = [&reader, &writer]()
-            {                
+            {
                 ASSERT_TRUE(reader.is_matched());
                 ASSERT_TRUE(writer.is_matched());
                 ASSERT_EQ(reader.get_matched(), 1u);
@@ -1373,7 +1373,7 @@ TEST(Security, SecureParticipantsDoNotLoseDiscoveryWithoutUserTraffic)
 
     // Check the secure participants must not be undiscovered just because user traffic stops
     auto assert_idle_period_keeps_discovery = [&reader, &writer, &idle_timeout, &assert_still_discovered]()
-            {                
+            {
                 ASSERT_FALSE(reader.wait_participant_undiscovery(idle_timeout));
                 ASSERT_FALSE(writer.wait_participant_undiscovery(idle_timeout));
 
@@ -1382,12 +1382,12 @@ TEST(Security, SecureParticipantsDoNotLoseDiscoveryWithoutUserTraffic)
 
     // Discovery is only useful if data can still flow after the idle window
     auto assert_data_flow = [&reader, &writer, &data_timeout, &assert_still_discovered]()
-            {                
+            {
                 auto data = default_helloworld_data_generator(2);
 
                 reader.startReception(data);
                 writer.send(data);
-                
+
                 ASSERT_TRUE(data.empty());
                 ASSERT_EQ(reader.block_for_all(data_timeout), 2u);
                 assert_still_discovered();


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
When two secure participants discover each other, they drop the non-secure channel used for PDP, and establish instead a secure connection through their SimplePDPEndpointsSecure. But since in the secure case TRANSIENT_LOCAL durability is used to share data Ps, there is no periodic data transmission which can be used to assert liveliness. As a consequence, liveliness is lost if there is no (user) data traffic between the participants.

With changes introduced in this PR, it is attempted to solve the issue by sending heartbeats periodically, with the same period data Ps are sent in the non-secure case.
<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.4.x 3.2.x 2.14.x

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
