### PR TITLE
[#24584] Fix TypeObjectRegistry null pass to a callee

### DIFF
--- a/src/cpp/fastdds/xtypes/type_representation/TypeObjectRegistry.cpp
+++ b/src/cpp/fastdds/xtypes/type_representation/TypeObjectRegistry.cpp
@@ -2617,7 +2617,7 @@ ReturnCode_t TypeObjectRegistry::set_annotation_parameter_value(
                 TypeValueConverter::sto(value) : 0));
             break;
         case TK_CHAR8:
-            param_value = TypeObjectUtils::build_annotation_parameter_value(!value.empty() ? value : 0);
+            param_value = TypeObjectUtils::build_annotation_parameter_value(!value.empty() ? value[0] : '\0');
             break;
         case TK_ENUM:
         {

--- a/src/cpp/fastdds/xtypes/type_representation/TypeObjectRegistry.hpp
+++ b/src/cpp/fastdds/xtypes/type_representation/TypeObjectRegistry.hpp
@@ -83,6 +83,10 @@ struct TypeRegistryEntry
 // Class which holds the TypeObject registry, including every TypeIdentifier (plain and non-plain types), every
 // non-plain TypeObject and the non-plain TypeObject serialized sizes.
 // Exported so shared-library test targets can instantiate thin helper subclasses on Windows.
+#ifdef _MSC_VER
+#pragma warning(push)
+#pragma warning(disable:4251)
+#endif // _MSC_VER
 class FASTDDS_EXPORTED_API TypeObjectRegistry : public ITypeObjectRegistry
 {
 
@@ -1119,6 +1123,9 @@ protected:
     std::mutex type_object_registry_mutex_;
 
 };
+#ifdef _MSC_VER
+#pragma warning(pop)
+#endif // _MSC_VER
 
 } // namespace xtypes
 } // namespace dds

--- a/src/cpp/fastdds/xtypes/type_representation/TypeObjectRegistry.hpp
+++ b/src/cpp/fastdds/xtypes/type_representation/TypeObjectRegistry.hpp
@@ -82,7 +82,8 @@ struct TypeRegistryEntry
 
 // Class which holds the TypeObject registry, including every TypeIdentifier (plain and non-plain types), every
 // non-plain TypeObject and the non-plain TypeObject serialized sizes.
-class TypeObjectRegistry : public ITypeObjectRegistry
+// Exported so shared-library test targets can instantiate thin helper subclasses on Windows.
+class FASTDDS_EXPORTED_API TypeObjectRegistry : public ITypeObjectRegistry
 {
 
 public:

--- a/src/cpp/utils/collections/FixedSizeQueue.hpp
+++ b/src/cpp/utils/collections/FixedSizeQueue.hpp
@@ -47,6 +47,7 @@ class FixedSizeQueue
 public:
 
     using allocator_type = _Alloc;
+    using allocator_traits = std::allocator_traits<allocator_type>;
     using value_type = _Ty;
     using pointer = _Ty*;
     using const_pointer = const _Ty*;
@@ -346,7 +347,7 @@ public:
             return false;
         }
         --head_;
-        allocator_.construct(&(*head_), val);
+        allocator_traits::construct(allocator_, &(*head_), val);
         ++size_;
         return true;
     }
@@ -386,7 +387,7 @@ public:
             return false;
         }
         --head_;
-        allocator_.construct(&(*head_), std::forward<Args &&>(args)...);
+        allocator_traits::construct(allocator_, &(*head_), std::forward<Args &&>(args)...);
         ++size_;
         return true;
     }
@@ -406,7 +407,7 @@ public:
         {
             return false;
         }
-        allocator_.construct(&(*tail_), val);
+        allocator_traits::construct(allocator_, &(*tail_), val);
         ++tail_;
         ++size_;
         return true;
@@ -446,7 +447,7 @@ public:
         {
             return false;
         }
-        allocator_.construct(&(*tail_), std::forward<Args &&>(args)...);
+        allocator_traits::construct(allocator_, &(*tail_), std::forward<Args &&>(args)...);
         ++tail_;
         ++size_;
         return true;
@@ -464,7 +465,7 @@ public:
         {
             return false;
         }
-        allocator_.destroy(&(*head_));
+        allocator_traits::destroy(allocator_, &(*head_));
         ++head_;
         --size_;
         return true;
@@ -483,7 +484,7 @@ public:
             return false;
         }
         --tail_;
-        allocator_.destroy(&(*tail_));
+        allocator_traits::destroy(allocator_, &(*tail_));
         --size_;
         return true;
     }
@@ -652,7 +653,7 @@ public:
             ++head_;
             memmove(&(*head_), &(*old_head), (pos - old_head) * sizeof(value_type));
 
-            allocator_.destroy(&(*old_head));
+            allocator_traits::destroy(allocator_, &(*old_head));
             --size_;
             iterator next = pos;
             return ++next;
@@ -664,7 +665,7 @@ public:
             memmove(&(*pos), &(*next), (tail_ - pos) * sizeof(value_type));
 
             --tail_;
-            allocator_.destroy(&(*tail_));
+            allocator_traits::destroy(allocator_, &(*tail_));
             --size_;
             return pos;
         }

--- a/test/blackbox/common/BlackboxTestsTransportTCP.cpp
+++ b/test/blackbox/common/BlackboxTestsTransportTCP.cpp
@@ -498,7 +498,7 @@ TEST_P(TransportTCP, send_resource_cleanup)
                 }
                 return tcp_send_resources;
             };
-    EXPECT_EQ(tcp_send_resources(send_resource_list), 1);
+    EXPECT_EQ(tcp_send_resources(send_resource_list), 1u);
 
     // Release TCP client resources.
     client.reset();
@@ -519,7 +519,7 @@ TEST_P(TransportTCP, send_resource_cleanup)
     // Check that the send_resource_list has size 0. This means that the send resource
     // for the  client has been removed.
     send_resource_list = server_chaining_transport->get_send_resource_list();
-    EXPECT_EQ(tcp_send_resources(send_resource_list), 0);
+    EXPECT_EQ(tcp_send_resources(send_resource_list), 0u);
     send_resource_list.clear();
 }
 
@@ -642,7 +642,7 @@ TEST_P(TransportTCP, send_resource_cleanup_initial_peer)
                 }
                 return tcp_send_resources;
             };
-    EXPECT_EQ(tcp_send_resources(send_resource_list), 1);
+    EXPECT_EQ(tcp_send_resources(send_resource_list), 1u);
 
     // Release TCP client resources.
     server.reset();
@@ -663,7 +663,7 @@ TEST_P(TransportTCP, send_resource_cleanup_initial_peer)
     // Check that the send_resource_list has size 1. This means that the send resource
     // for the first client hasn't been removed because it was created from an initial_peer.
     send_resource_list = client_chaining_transport->get_send_resource_list();
-    EXPECT_EQ(tcp_send_resources(send_resource_list), 1);
+    EXPECT_EQ(tcp_send_resources(send_resource_list), 1u);
     send_resource_list.clear();
 
     // If relaunching the server, the client should connect again.
@@ -1090,8 +1090,8 @@ TEST_P(TransportTCP, tcp_unique_network_flows_init)
 
         EXPECT_TRUE(locators == locators2);
         // LocatorList size depends on the number of interfaces. Different address but same port.
-        ASSERT_GT(locators.size(), 0);
-        ASSERT_GT(locators2.size(), 0);
+        ASSERT_GT(locators.size(), 0u);
+        ASSERT_GT(locators2.size(), 0u);
         auto locator1 = locators.begin();
         auto locator2 = locators2.begin();
         EXPECT_EQ(IPLocator::getPhysicalPort(*locator1), IPLocator::getPhysicalPort(*locator2));
@@ -1120,8 +1120,8 @@ TEST_P(TransportTCP, tcp_unique_network_flows_init)
 
         EXPECT_FALSE(locators == locators2);
         // LocatorList size depends on the number of interfaces. Different address but same port.
-        ASSERT_GT(locators.size(), 0);
-        ASSERT_GT(locators2.size(), 0);
+        ASSERT_GT(locators.size(), 0u);
+        ASSERT_GT(locators2.size(), 0u);
         auto locator1 = locators.begin();
         auto locator2 = locators2.begin();
         EXPECT_EQ(IPLocator::getPhysicalPort(*locator1), IPLocator::getPhysicalPort(*locator2));
@@ -1300,3 +1300,4 @@ GTEST_INSTANTIATE_TEST_MACRO(TransportTCP,
             }
 
         });
+

--- a/test/blackbox/common/DDSBlackboxTestsContentFilter.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsContentFilter.cpp
@@ -339,7 +339,7 @@ protected:
             // Ensure writer is in clean state
             drop_data_on_all_readers();
             EXPECT_TRUE(writer.waitForAllAcked(std::chrono::seconds(5)));
-            EXPECT_EQ(reader->get_unread_count(), 0);
+            EXPECT_EQ(reader->get_unread_count(), 0ull);
 
             // Send 10 samples with index 1 to 10
             auto data = default_helloworld_data_generator();
@@ -371,7 +371,7 @@ protected:
             ReturnCode_t expected_ret;
             expected_ret = expected_samples == 0 ? RETCODE_NO_DATA : RETCODE_OK;
             EXPECT_EQ(expected_ret, reader->take(recv_data, recv_info));
-            EXPECT_EQ(recv_data.length(), expected_samples);
+            EXPECT_EQ(static_cast<uint64_t>(recv_data.length()), expected_samples);
             for (HelloWorldSeq::size_type i = 0;
                     i < recv_data.length() && static_cast<uint32_t>(i) < expected_samples;
                     ++i)
@@ -1282,3 +1282,4 @@ GTEST_INSTANTIATE_TEST_MACRO(DDSContentFilter,
 } // namespace dds
 } // namespace fastdds
 } // namespace eprosima
+

--- a/test/blackbox/common/DDSBlackboxTestsMonitorService.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsMonitorService.cpp
@@ -1541,9 +1541,9 @@ TEST(DDSMonitorServiceTest, monitor_service_simple_connection_list)
     StatisticsGUIDList w_guids, r_guids;
     endpoint_connections_msg.status_kind(eprosima::fastdds::statistics::StatusKind::CONNECTION_LIST);
     w_guids = MSP1.get_writer_guids();
-    ASSERT_EQ(w_guids.size(), 1);
+    ASSERT_EQ(w_guids.size(), 1u);
     r_guids = MSP2.get_reader_guids();
-    ASSERT_EQ(r_guids.size(), 1);
+    ASSERT_EQ(r_guids.size(), 1u);
 
     //! dw and dr have one connection only (with each other)
     endpoint_connections_msg.local_entity(w_guids.back());
@@ -1616,7 +1616,7 @@ TEST(DDSMonitorServiceTest, monitor_service_simple_qos_incompatibility_status)
 
     endpoint_qos_msg.status_kind(eprosima::fastdds::statistics::StatusKind::INCOMPATIBLE_QOS);
     w_guids = MSP.get_writer_guids();
-    ASSERT_EQ(w_guids.size(), 1);
+    ASSERT_EQ(w_guids.size(), 1u);
     endpoint_qos_msg.local_entity(w_guids.back());
 
     statistics::IncompatibleQoSStatus_s incompatible_qos;
@@ -1629,7 +1629,7 @@ TEST(DDSMonitorServiceTest, monitor_service_simple_qos_incompatibility_status)
 
     endpoint_qos_msg.status_kind(eprosima::fastdds::statistics::StatusKind::INCOMPATIBLE_QOS);
     r_guids = MSP.get_reader_guids();
-    ASSERT_EQ(r_guids.size(), 1);
+    ASSERT_EQ(r_guids.size(), 1u);
     endpoint_qos_msg.local_entity(r_guids.back());
 
     expected_msgs.push_back(endpoint_qos_msg);
@@ -1689,7 +1689,7 @@ TEST(DDSMonitorServiceTest, monitor_service_simple_liveliness_lost_status)
 
     endpoint_liveliness_msg.status_kind(eprosima::fastdds::statistics::StatusKind::LIVELINESS_LOST);
     w_guids = MSP.get_writer_guids();
-    ASSERT_EQ(w_guids.size(), 1);
+    ASSERT_EQ(w_guids.size(), 1u);
     endpoint_liveliness_msg.local_entity(w_guids.back());
 
     statistics::LivelinessLostStatus_s liv_lost_status;
@@ -1753,7 +1753,7 @@ TEST(DDSMonitorServiceTest, monitor_service_simple_liveliness_changed_status)
 
     endpoint_liveliness_msg.status_kind(eprosima::fastdds::statistics::StatusKind::LIVELINESS_CHANGED);
     r_guids = MSP.get_reader_guids();
-    ASSERT_EQ(r_guids.size(), 1);
+    ASSERT_EQ(r_guids.size(), 1u);
     endpoint_liveliness_msg.local_entity(r_guids.back());
 
     statistics::LivelinessChangedStatus_s liv_changed_status;
@@ -1809,7 +1809,7 @@ TEST(DDSMonitorServiceTest, monitor_service_simple_deadline_missed_status)
 
     endpoint_deadline_msg.status_kind(eprosima::fastdds::statistics::StatusKind::DEADLINE_MISSED);
     r_guids = MSP.get_reader_guids();
-    ASSERT_EQ(r_guids.size(), 1);
+    ASSERT_EQ(r_guids.size(), 1u);
     endpoint_deadline_msg.local_entity(r_guids.back());
 
     statistics::DeadlineMissedStatus_s deadline_missed_status;
@@ -1819,7 +1819,7 @@ TEST(DDSMonitorServiceTest, monitor_service_simple_deadline_missed_status)
     expected_msgs.push_back(endpoint_deadline_msg);
 
     w_guids = MSP.get_writer_guids();
-    ASSERT_EQ(w_guids.size(), 1);
+    ASSERT_EQ(w_guids.size(), 1u);
     endpoint_deadline_msg.local_entity(w_guids.back());
 
     expected_msgs.push_back(endpoint_deadline_msg);
@@ -1916,7 +1916,7 @@ TEST(DDSMonitorServiceTest, monitor_service_simple_sample_lost_status)
 
     endpoint_sample_lost_msg.status_kind(eprosima::fastdds::statistics::StatusKind::SAMPLE_LOST);
     r_guids = MSP2.get_reader_guids();
-    ASSERT_EQ(r_guids.size(), 1);
+    ASSERT_EQ(r_guids.size(), 1u);
     endpoint_sample_lost_msg.local_entity(r_guids.back());
 
     expected_msgs.push_back(endpoint_sample_lost_msg);
@@ -2034,7 +2034,7 @@ TEST(DDSMonitorServiceTest, monitor_service_simple_late_joiner)
     entity_proxy_msg.status_kind(eprosima::fastdds::statistics::StatusKind::PROXY);
     StatisticsGUIDList w_guids = MSP.get_writer_guids();
 
-    ASSERT_EQ(w_guids.size(), 1);
+    ASSERT_EQ(w_guids.size(), 1u);
     entity_proxy_msg.local_entity(w_guids.back());
 
     expected_msgs.push_back(entity_proxy_msg);
@@ -2042,7 +2042,7 @@ TEST(DDSMonitorServiceTest, monitor_service_simple_late_joiner)
     entity_proxy_msg.status_kind(eprosima::fastdds::statistics::StatusKind::PROXY);
     StatisticsGUIDList r_guids = MSP.get_reader_guids();
 
-    ASSERT_EQ(r_guids.size(), 1);
+    ASSERT_EQ(r_guids.size(), 1u);
     entity_proxy_msg.local_entity(r_guids.back());
 
     expected_msgs.push_back(entity_proxy_msg);
@@ -2102,13 +2102,13 @@ TEST(DDSMonitorServiceTest, monitor_service_simple_enable_disable_enable)
     StatisticsGUIDList w_guids = MSP.get_writer_guids();
     StatisticsGUIDList r_guids = MSP.get_reader_guids();
 
-    ASSERT_EQ(w_guids.size(), 2);
+    ASSERT_EQ(w_guids.size(), 2u);
     entity_proxy_msg.local_entity(w_guids.front());
     expected_msgs.push_back(entity_proxy_msg);
     entity_proxy_msg.local_entity(w_guids.back());
     expected_msgs.push_back(entity_proxy_msg);
 
-    ASSERT_EQ(r_guids.size(), 1);
+    ASSERT_EQ(r_guids.size(), 1u);
     entity_proxy_msg.local_entity(r_guids.back());
 
     expected_msgs.push_back(entity_proxy_msg);
@@ -2178,11 +2178,11 @@ TEST(DDSMonitorServiceTest, monitor_service_simple_extended_incompatible_qos)
     StatisticsGUIDList w_guids = MSP.get_writer_guids();
     StatisticsGUIDList r_guids = MSP.get_reader_guids();
 
-    ASSERT_EQ(w_guids.size(), 1);
+    ASSERT_EQ(w_guids.size(), 1u);
     entity_proxy_msg.local_entity(w_guids.back());
     expected_msgs.push_back(entity_proxy_msg);
 
-    ASSERT_EQ(r_guids.size(), 1);
+    ASSERT_EQ(r_guids.size(), 1u);
     entity_proxy_msg.local_entity(r_guids.back());
     expected_msgs.push_back(entity_proxy_msg);
 
@@ -2204,7 +2204,7 @@ TEST(DDSMonitorServiceTest, monitor_service_simple_extended_incompatible_qos)
 
     // Reader extended incompatibility for reliability
     r_guids = MSP.get_reader_guids();
-    ASSERT_EQ(r_guids.size(), 1);
+    ASSERT_EQ(r_guids.size(), 1u);
     endpoint_ext_incmpqos_msg.local_entity(r_guids.back());
     ext_incompatible_qos_seq.at(0).remote_guid(w_guids.back());
     endpoint_ext_incmpqos_msg.value().extended_incompatible_qos_status(ext_incompatible_qos_seq);
@@ -2242,7 +2242,7 @@ TEST(DDSMonitorServiceTest, monitor_service_simple_extended_incompatible_qos)
 
     // Expect only the new reader's discovery proxy one
     r_guids = MSP.get_reader_guids();
-    ASSERT_EQ(r_guids.size(), 1);
+    ASSERT_EQ(r_guids.size(), 1u);
     entity_proxy_msg.local_entity(r_guids.back());
     expected_msgs.push_back(entity_proxy_msg);
 
@@ -2299,11 +2299,11 @@ TEST(DDSMonitorServiceTest, monitor_service_advanced_proxy)
         StatisticsGUIDList w_guids = MSP.get_writer_guids();
         StatisticsGUIDList r_guids = MSP.get_reader_guids();
 
-        ASSERT_EQ(w_guids.size(), 1);
+        ASSERT_EQ(w_guids.size(), 1u);
         entity_proxy_msg.local_entity(w_guids.back());
         expected_msgs.push_back(entity_proxy_msg);
 
-        ASSERT_EQ(r_guids.size(), 1);
+        ASSERT_EQ(r_guids.size(), 1u);
         entity_proxy_msg.local_entity(r_guids.back());
 
         expected_msgs.push_back(entity_proxy_msg);
@@ -2365,7 +2365,7 @@ TEST(DDSMonitorServiceTest, monitor_service_advanced_instance_disposals)
         expected_msgs.push_back(msg);
     }
 
-    ASSERT_EQ(3, MSPs.size());
+    ASSERT_EQ(3u, MSPs.size());
 
     //! Expect 6 empty proxies (disposals) (3 entities per each)
     for (auto& MSP : MSPs)
@@ -2450,7 +2450,7 @@ TEST(DDSMonitorServiceTest, monitor_service_advanced_single_late_joiner)
 
         endpoint_qos_msg.status_kind(eprosima::fastdds::statistics::StatusKind::INCOMPATIBLE_QOS);
         w_guids = MSP.get_writer_guids();
-        ASSERT_EQ(w_guids.size(), 1);
+        ASSERT_EQ(w_guids.size(), 1u);
         endpoint_qos_msg.local_entity(w_guids.back());
 
         statistics::IncompatibleQoSStatus_s incompatible_qos;
@@ -2461,7 +2461,7 @@ TEST(DDSMonitorServiceTest, monitor_service_advanced_single_late_joiner)
 
         endpoint_qos_msg.status_kind(eprosima::fastdds::statistics::StatusKind::INCOMPATIBLE_QOS);
         r_guids = MSP.get_reader_guids();
-        ASSERT_EQ(r_guids.size(), 1);
+        ASSERT_EQ(r_guids.size(), 1u);
         endpoint_qos_msg.local_entity(r_guids.back());
 
         expected_msgs.push_back(endpoint_qos_msg);
@@ -2509,7 +2509,7 @@ TEST(DDSMonitorServiceTest, monitor_service_advanced_multiple_late_joiners)
 
     endpoint_qos_msg.status_kind(eprosima::fastdds::statistics::StatusKind::INCOMPATIBLE_QOS);
     w_guids = MSP.get_writer_guids();
-    ASSERT_EQ(w_guids.size(), 1);
+    ASSERT_EQ(w_guids.size(), 1u);
     endpoint_qos_msg.local_entity(w_guids.back());
 
     statistics::IncompatibleQoSStatus_s incompatible_qos;
@@ -2520,7 +2520,7 @@ TEST(DDSMonitorServiceTest, monitor_service_advanced_multiple_late_joiners)
 
     endpoint_qos_msg.status_kind(eprosima::fastdds::statistics::StatusKind::INCOMPATIBLE_QOS);
     r_guids = MSP.get_reader_guids();
-    ASSERT_EQ(r_guids.size(), 1);
+    ASSERT_EQ(r_guids.size(), 1u);
     endpoint_qos_msg.local_entity(r_guids.back());
 
     expected_msgs.push_back(endpoint_qos_msg);
@@ -2618,7 +2618,7 @@ TEST(DDSMonitorServiceTest, monitor_service_advanced_extended_incompatible_qos)
 
                 MSP.create_and_add_writer(dw_qos);
 
-                ASSERT_EQ(MSP.get_writer_guids().size(), 1);
+                ASSERT_EQ(MSP.get_writer_guids().size(), 1u);
                 w_guid = MSP.get_writer_guids().back();
 
                 break;
@@ -2840,7 +2840,7 @@ TEST(DDSMonitorServiceTest,  monitor_service_late_joiner_consumer_receives_only_
     // That will prove that only the last update of the instance is being received and, in turn,
     // verify that the monitor service datawriter is not holding past samples of the same instance.
     r_guids = MSP.get_reader_guids();
-    ASSERT_EQ(r_guids.size(), 1);
+    ASSERT_EQ(r_guids.size(), 1u);
     endpoint_deadline_msg.local_entity(r_guids.back());
 
     statistics::DeadlineMissedStatus_s deadline_missed_status;
@@ -2850,7 +2850,7 @@ TEST(DDSMonitorServiceTest,  monitor_service_late_joiner_consumer_receives_only_
     non_expected_msgs.push_back(endpoint_deadline_msg);
 
     w_guids = MSP.get_writer_guids();
-    ASSERT_EQ(w_guids.size(), 1);
+    ASSERT_EQ(w_guids.size(), 1u);
     endpoint_deadline_msg.local_entity(w_guids.back());
 
     non_expected_msgs.push_back(endpoint_deadline_msg);
@@ -3025,3 +3025,4 @@ TEST(DDSMonitorServiceTest, monitor_service_proxy_optional_qos)
     ASSERT_EQ(MSC.block_for_all(std::chrono::seconds(5)), expected_msgs.size());
 #endif //FASTDDS_STATISTICS
 }
+

--- a/test/blackbox/common/RTPSBlackboxTestsDiscovery.cpp
+++ b/test/blackbox/common/RTPSBlackboxTestsDiscovery.cpp
@@ -888,11 +888,11 @@ TEST_P(RTPSDiscovery, ContentFilterRegistrationWithoutCFPButUpdate)
                     return Iterations::DISCOVERED_READER == iteration || Iterations::WITH_ERROR == iteration;
                 });
         ASSERT_EQ(Iterations::DISCOVERED_READER, iteration);
-        ASSERT_EQ(0, content_filter_property.content_filtered_topic_name.size());
-        ASSERT_EQ(0, content_filter_property.related_topic_name.size());
-        ASSERT_EQ(0, content_filter_property.filter_class_name.size());
-        ASSERT_EQ(0, content_filter_property.filter_expression.size());
-        ASSERT_EQ(0, content_filter_property.expression_parameters.size());
+        ASSERT_EQ(0u, content_filter_property.content_filtered_topic_name.size());
+        ASSERT_EQ(0u, content_filter_property.related_topic_name.size());
+        ASSERT_EQ(0u, content_filter_property.filter_class_name.size());
+        ASSERT_EQ(0u, content_filter_property.filter_expression.size());
+        ASSERT_EQ(0u, content_filter_property.expression_parameters.size());
     }
 
     // Test second iteration: expect ReaderDiscoveryStatus::CHANGED_QOS_READER.
@@ -943,3 +943,4 @@ GTEST_INSTANTIATE_TEST_MACRO(RTPS,
             }
 
         });
+

--- a/test/dds/communication/security/CMakeLists.txt
+++ b/test/dds/communication/security/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-find_package(PythonInterp 3)
+find_package(Python3 COMPONENTS Interpreter)
 
 add_definitions(
     -DBOOST_ASIO_STANDALONE
@@ -121,10 +121,10 @@ if(SECURITY)
     configure_file(${FASTDDS_BASIC_DIR}/test/certs/permissions_helloworld_securehelloworld.smime
         ${CMAKE_CURRENT_BINARY_DIR}/permissions_helloworld_securehelloworld.smime COPYONLY)
 
-    if(PYTHONINTERP_FOUND)
+    if(Python3_Interpreter_FOUND)
 
         add_test(NAME SimpleCommunicationSecureBestEffort
-            COMMAND ${CMAKE_COMMAND} -DACTUAL_TEST=${PYTHON_EXECUTABLE} -DACTUAL_ARGS=${CMAKE_CURRENT_BINARY_DIR}/simple_communication.py -P ${CMAKE_CURRENT_BINARY_DIR}/test_wrapper.cmake)
+            COMMAND ${CMAKE_COMMAND} -DACTUAL_TEST=${Python3_EXECUTABLE} -DACTUAL_ARGS=${CMAKE_CURRENT_BINARY_DIR}/simple_communication.py -P ${CMAKE_CURRENT_BINARY_DIR}/test_wrapper.cmake)
 
         # Set test with label NoMemoryCheck
         set_property(TEST SimpleCommunicationSecureBestEffort PROPERTY LABELS "NoMemoryCheck")
@@ -146,7 +146,7 @@ if(SECURITY)
         endif()
 
         add_test(NAME SimpleCommunicationSecureMsgCryptoBestEffort
-            COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/multiple_subs_secure_crypto_communication.py
+            COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/multiple_subs_secure_crypto_communication.py
             --pub $<TARGET_FILE:CommunicationPublisher>
             --xml-pub secure_msg_crypto_besteffort_pub_profile.xml
             --sub $<TARGET_FILE:CommunicationSubscriber>
@@ -163,7 +163,7 @@ if(SECURITY)
         endif()
 
         add_test(NAME SimpleCommunicationSecureMsgSubmsgCryptoBestEffort
-            COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/multiple_subs_secure_crypto_communication.py
+            COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/multiple_subs_secure_crypto_communication.py
             --pub $<TARGET_FILE:CommunicationPublisher>
             --xml-pub secure_msg_submsg_crypto_besteffort_pub_profile.xml
             --sub $<TARGET_FILE:CommunicationSubscriber>
@@ -180,7 +180,7 @@ if(SECURITY)
         endif()
 
         add_test(NAME SimpleCommunicationSecureSubmsgCryptoBestEffort
-            COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/multiple_subs_secure_crypto_communication.py
+            COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/multiple_subs_secure_crypto_communication.py
             --pub $<TARGET_FILE:CommunicationPublisher>
             --xml-pub secure_submsg_crypto_besteffort_pub_profile.xml
             --sub $<TARGET_FILE:CommunicationSubscriber>
@@ -197,7 +197,7 @@ if(SECURITY)
         endif()
 
         add_test(NAME AllowUnauthenticatedSimplePubSecureNoRTPSProtectionSubNonSecure
-            COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/multiple_subs_secure_crypto_communication.py
+            COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/multiple_subs_secure_crypto_communication.py
             --n-subs 1
             --pub $<TARGET_FILE:CommunicationPublisher>
             --xml-pub simple_secure_allow_unauthenticated_pub_profile.xml
@@ -215,7 +215,7 @@ if(SECURITY)
         endif()
 
         add_test(NAME SecureDiscoverServerDisabled
-            COMMAND ${PYTHON_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/test_secure_ds_disabled.py
+            COMMAND ${Python3_EXECUTABLE} ${CMAKE_CURRENT_BINARY_DIR}/test_secure_ds_disabled.py
             --ds-server $<TARGET_FILE:fast-discovery-server>
             --xml-ds secure_simple_ds_server_profile.xml
             --server-id 0
@@ -233,3 +233,4 @@ if(SECURITY)
     endif()
 
 endif()
+

--- a/test/dds/xtypes/CMakeLists.txt
+++ b/test/dds/xtypes/CMakeLists.txt
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-find_package(PythonInterp 3)
+find_package(Python3 COMPONENTS Interpreter)
 
 add_definitions(
     -DBOOST_ASIO_STANDALONE
@@ -114,7 +114,7 @@ file(GLOB TEST_DEFINITIONS
     "TypesTestsCases/Cases*"
 )
 
-if(PYTHONINTERP_FOUND)
+if(Python3_Interpreter_FOUND)
     # Standard types test
     set(TEST_BUILDER ${BINARY_TEST_DIR}test_build.py)
 
@@ -123,7 +123,7 @@ if(PYTHONINTERP_FOUND)
         add_test(
             NAME ${TEST_NAME}
             COMMAND
-            ${PYTHON_EXECUTABLE}
+            ${Python3_EXECUTABLE}
             ${CMAKE_CURRENT_BINARY_DIR}/${TEST_BUILDER}
             --app $<TARGET_FILE:DDSXtypesCommunication>
             ${TEST_DEFINITION}
@@ -136,3 +136,4 @@ if(PYTHONINTERP_FOUND)
         endif()
     endforeach()
 endif()
+

--- a/test/feature/dynamic_types/DynamicTypesTests.cpp
+++ b/test/feature/dynamic_types/DynamicTypesTests.cpp
@@ -524,7 +524,7 @@ TEST_F(DynamicTypesTests, DynamicType_basic)
     //    + indexing by id
     DynamicTypeMembersById members_by_id;
     EXPECT_EQ(RETCODE_OK, struct_type_builder->get_all_members(members_by_id));
-    EXPECT_EQ(2, members_by_id.size());
+    EXPECT_EQ(2u, members_by_id.size());
 
     auto dm3 = members_by_id[3];
     ASSERT_TRUE(dm3);
@@ -543,7 +543,7 @@ TEST_F(DynamicTypesTests, DynamicType_basic)
     //    + indexing by name
     DynamicTypeMembersByName members_by_name;
     EXPECT_EQ(RETCODE_OK, struct_type_builder->get_all_members_by_name(members_by_name));
-    EXPECT_EQ(2, members_by_name.size());
+    EXPECT_EQ(2u, members_by_name.size());
 
     dm3 = members_by_name["int32"];
     ASSERT_EQ(RETCODE_OK, dm3->get_descriptor(md));
@@ -565,7 +565,7 @@ TEST_F(DynamicTypesTests, DynamicType_basic)
     ASSERT_EQ(RETCODE_OK, struct_type_builder->add_member(md));
 
     EXPECT_EQ(RETCODE_OK, struct_type_builder->get_all_members(members_by_id));
-    ASSERT_EQ(3, members_by_id.size());
+    ASSERT_EQ(3u, members_by_id.size());
 
     MemberDescriptor::_ref_type tmp = traits<MemberDescriptor>::make_shared();
     auto dm = members_by_id[3];
@@ -950,7 +950,7 @@ TEST_F(DynamicTypesTests, DynamicType_uint32)
 
     uint64_t uTest64;
     EXPECT_EQ(data->get_uint64_value(uTest64, MEMBER_ID_INVALID), RETCODE_OK);
-    EXPECT_EQ(uTest64, 1);
+    EXPECT_EQ(uTest64, 1ull);
 
     double fTest64;
     EXPECT_EQ(data->get_float64_value(fTest64, MEMBER_ID_INVALID), RETCODE_OK);
@@ -1794,7 +1794,7 @@ TEST_F(DynamicTypesTests, DynamicType_uint16)
 
     uint64_t uTest64;
     EXPECT_EQ(data->get_uint64_value(uTest64, MEMBER_ID_INVALID), RETCODE_OK);
-    EXPECT_EQ(1, uTest64);
+    EXPECT_EQ(1ull, uTest64);
 
     float fTest32;
     EXPECT_EQ(data->get_float32_value(fTest32, MEMBER_ID_INVALID), RETCODE_OK);
@@ -3740,7 +3740,7 @@ TEST_F(DynamicTypesTests, DynamicType_boolean)
 
     uint64_t uTest64 {1};
     EXPECT_EQ(data->get_uint64_value(uTest64, MEMBER_ID_INVALID), RETCODE_OK);
-    EXPECT_EQ(0, uTest64);
+    EXPECT_EQ(0ull, uTest64);
 
     float fTest32 {1};
     EXPECT_EQ(data->get_float32_value(fTest32, MEMBER_ID_INVALID), RETCODE_OK);
@@ -4868,7 +4868,7 @@ TEST_F(DynamicTypesTests, DynamicType_alias)
 
     uint64_t uTest64;
     EXPECT_EQ(data->get_uint64_value(uTest64, MEMBER_ID_INVALID), RETCODE_OK);
-    EXPECT_EQ(uTest64, 2);
+    EXPECT_EQ(uTest64, 2ull);
 
     double fTest64;
     EXPECT_EQ(data->get_float64_value(fTest64, MEMBER_ID_INVALID), RETCODE_OK);
@@ -8016,15 +8016,15 @@ TEST_F(DynamicTypesTests, DynamicType_sequence_uint64)
     EXPECT_EQ(data->set_uint64_value(4, 5), RETCODE_OK);
     uint64_t test1 {0};
     EXPECT_EQ(data->get_uint64_value(test1, 0), RETCODE_OK);
-    EXPECT_EQ(1, test1);
+    EXPECT_EQ(1ull, test1);
     EXPECT_EQ(data->get_uint64_value(test1, 1), RETCODE_OK);
-    EXPECT_EQ(2, test1);
+    EXPECT_EQ(2ull, test1);
     EXPECT_EQ(data->get_uint64_value(test1, 2), RETCODE_OK);
-    EXPECT_EQ(3, test1);
+    EXPECT_EQ(3ull, test1);
     EXPECT_EQ(data->get_uint64_value(test1, 3), RETCODE_OK);
-    EXPECT_EQ(4, test1);
+    EXPECT_EQ(4ull, test1);
     EXPECT_EQ(data->get_uint64_value(test1, 4), RETCODE_OK);
-    EXPECT_EQ(5, test1);
+    EXPECT_EQ(5ull, test1);
 
     UInt64Seq test_all {{1, 2, 3, 4, 5}};
     UInt64Seq test_less {{3, 4, 5}};
@@ -14395,3 +14395,4 @@ int main(
     testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }
+

--- a/test/feature/dynamic_types/DynamicTypesTests.cpp
+++ b/test/feature/dynamic_types/DynamicTypesTests.cpp
@@ -14395,4 +14395,3 @@ int main(
     testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }
-

--- a/test/feature/dynamic_types/dds_types_tests/DynamicTypesSequencesDDSTypesTests.cpp
+++ b/test/feature/dynamic_types/dds_types_tests/DynamicTypesSequencesDDSTypesTests.cpp
@@ -1545,7 +1545,7 @@ TEST_F(DynamicTypesDDSTypesTest, DDSTypesTest_My_Structure)
         NoCommon_Module::My_Structure struct_data;
         TypeSupport static_pubsubType {new NoCommon_Module::My_StructurePubSubType()};
         check_serialization_deserialization(struct_type, data, encoding, struct_data, static_pubsubType);
-        EXPECT_EQ(1, struct_data.list().size());
+        EXPECT_EQ(1u, struct_data.list().size());
         EXPECT_EQ(struct_data.list().at(0), test_char_value);
     }
 

--- a/test/mock/rtps/StatefulWriter/rtps/writer/StatefulWriter.hpp
+++ b/test/mock/rtps/StatefulWriter/rtps/writer/StatefulWriter.hpp
@@ -56,11 +56,11 @@ public:
         delete mp_history;
     }
 
-    MOCK_METHOD1(matched_reader_add_edp, bool(const ReaderProxyData&));
+    MOCK_METHOD(bool, matched_reader_add_edp, (const ReaderProxyData&), (override));
 
-    MOCK_METHOD1(matched_reader_remove, bool(const GUID_t&));
+    MOCK_METHOD(bool, matched_reader_remove, (const GUID_t&), (override));
 
-    MOCK_METHOD1 (matched_reader_is_matched, bool(const GUID_t& reader_guid));
+    MOCK_METHOD(bool, matched_reader_is_matched, (const GUID_t& reader_guid), (override));
 
     MOCK_METHOD1(unsent_change_added_to_history_mock, void(CacheChange_t*));
 
@@ -139,3 +139,4 @@ private:
 } // namespace eprosima
 
 #endif // FASTDDS_RTPS_WRITER__STATEFULWRITER_HPP
+

--- a/test/mock/rtps/StatelessWriter/rtps/writer/StatelessWriter.hpp
+++ b/test/mock/rtps/StatelessWriter/rtps/writer/StatelessWriter.hpp
@@ -42,11 +42,11 @@ public:
 
     virtual ~StatelessWriter() = default;
 
-    MOCK_METHOD1(matched_reader_add_edp, bool(const ReaderProxyData&));
+    MOCK_METHOD(bool, matched_reader_add_edp, (const ReaderProxyData&), (override));
 
-    MOCK_METHOD1(matched_reader_remove, bool(const GUID_t&));
+    MOCK_METHOD(bool, matched_reader_remove, (const GUID_t&), (override));
 
-    MOCK_METHOD1 (matched_reader_is_matched, bool(const GUID_t& reader_guid));
+    MOCK_METHOD(bool, matched_reader_is_matched, (const GUID_t& reader_guid), (override));
 
     MOCK_METHOD1(unsent_change_added_to_history_mock, void(CacheChange_t*));
 
@@ -65,3 +65,4 @@ private:
 } // namespace eprosima
 
 #endif // _FASTDDS_RTPS_STATELESSWRITER_H_
+

--- a/test/system/tools/fds/CliDiscoveryManagerTests.cpp
+++ b/test/system/tools/fds/CliDiscoveryManagerTests.cpp
@@ -505,7 +505,7 @@ TEST_F(CliDiscoveryManagerTest, GetRemoteServersWithDomainParam)
     LocatorList_t serverList;
     load_environment_server_info(servers, serverList);
 
-    EXPECT_EQ(serverList.size(), 2);
+    EXPECT_EQ(serverList.size(), 2u);
     PortParameters port_params;
     std::vector<uint16_t> expected_ports({7402, port_params.get_discovery_server_port(1)});
     for (Locator_t& locator : serverList)
@@ -532,14 +532,14 @@ TEST_F(CliDiscoveryManagerTest, SetServerQos)
 {
     manager.set_server_qos(7402);
     DomainParticipantQos qos = manager.getServerQos();
-    EXPECT_EQ(qos.wire_protocol().builtin.metatrafficUnicastLocatorList.size(), 1);
+    EXPECT_EQ(qos.wire_protocol().builtin.metatrafficUnicastLocatorList.size(), 1u);
     for (const Locator_t& locator : qos.wire_protocol().builtin.metatrafficUnicastLocatorList)
     {
         compareLocator(locator, "0.0.0.0", 7402, false, false);
     }
     EXPECT_FALSE(qos.transport().use_builtin_transports);
     EXPECT_EQ(qos.wire_protocol().builtin.discovery_config.discoveryProtocol, DiscoveryProtocol::SERVER);
-    ASSERT_EQ(qos.transport().user_transports.size(), 1);
+    ASSERT_EQ(qos.transport().user_transports.size(), 1u);
     EXPECT_TRUE(nullptr != dynamic_cast<UDPv4TransportDescriptor*>(qos.transport().user_transports[0].get()));
 }
 
@@ -773,8 +773,8 @@ TEST_F(CliDiscoveryManagerTest, GetLocalServers)
                     }
                     EXPECT_TRUE(manager.is_server_running(server.domain_id));
                 }
-                EXPECT_EQ(expected_ports.size(), 0);
-                EXPECT_EQ(expected_domains.size(), 0);
+                EXPECT_EQ(expected_ports.size(), 0u);
+                EXPECT_EQ(expected_domains.size(), 0u);
             };
 
     // Use MockCliDiscoveryManager overwritten method to get the listening ports
@@ -790,7 +790,7 @@ TEST_F(CliDiscoveryManagerTest, GetLocalServers)
         // Simulate the creation of the DS with the mocked listening port
         manager.mocked_ports.push_back(7402);
         servers = manager.get_local_servers();
-        EXPECT_EQ(servers.size(), 1);
+        EXPECT_EQ(servers.size(), 1u);
         verify_servers(servers, {port}, {domain});
     }
 
@@ -810,7 +810,7 @@ TEST_F(CliDiscoveryManagerTest, GetLocalServers)
         manager.mocked_ports.push_back(7402);
         manager.mocked_ports.push_back(7652);
         servers = manager.get_local_servers();
-        EXPECT_EQ(servers.size(), 2);
+        EXPECT_EQ(servers.size(), 2u);
         verify_servers(servers, {p0, p1}, {d0, d1});
     }
 }
@@ -823,3 +823,4 @@ int main(
     testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }
+

--- a/test/system/tools/fds/CliDiscoveryManagerTests.cpp
+++ b/test/system/tools/fds/CliDiscoveryManagerTests.cpp
@@ -823,4 +823,3 @@ int main(
     testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }
-

--- a/test/unittest/dds/core/duration/DurationTests.cpp
+++ b/test/unittest/dds/core/duration/DurationTests.cpp
@@ -27,15 +27,15 @@ TEST(DurationTests, duration_constructor)
 {
     Duration_t duration_default;
     EXPECT_EQ(duration_default.seconds, 0);
-    EXPECT_EQ(duration_default.nanosec, 0);
+    EXPECT_EQ(duration_default.nanosec, 0u);
 
     Duration_t duration_user(1, 500000000);
     EXPECT_EQ(duration_user.seconds, 1);
-    EXPECT_EQ(duration_user.nanosec, 500000000);
+    EXPECT_EQ(duration_user.nanosec, 500000000u);
 
     Duration_t duration_float(1.5);
     EXPECT_EQ(duration_float.seconds, 1);
-    EXPECT_EQ(duration_float.nanosec, 500000000);
+    EXPECT_EQ(duration_float.nanosec, 500000000u);
 }
 
 TEST(DurationTests, conversion_methods)
@@ -43,7 +43,7 @@ TEST(DurationTests, conversion_methods)
     {
         Duration_t duration(2, 250000000);
         EXPECT_EQ(duration.to_ns(), 2250000000);
-        EXPECT_EQ(duration.fraction(), 1073741824);  // 1/4 of a second in fractions
+        EXPECT_EQ(duration.fraction(), 1073741824u);  // 1/4 of a second in fractions
     }
 
     {
@@ -55,7 +55,7 @@ TEST(DurationTests, conversion_methods)
     {
         Duration_t duration(1, 999999999);
         EXPECT_EQ(duration.to_ns(), 1999999999);
-        EXPECT_EQ(duration.fraction(), 4294967292);
+        EXPECT_EQ(duration.fraction(), 4294967292u);
     }
 }
 

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -5206,4 +5206,3 @@ int main(
     testing::InitGoogleMock(&argc, argv);
     return RUN_ALL_TESTS();
 }
-

--- a/test/unittest/dds/participant/ParticipantTests.cpp
+++ b/test/unittest/dds/participant/ParticipantTests.cpp
@@ -1226,7 +1226,7 @@ TEST(ParticipantTests, NoBuiltinMetatrafficMulticastForClients)
 
     fastdds::rtps::RTPSParticipantAttributes attributes = get_rtps_attributes(participant);
     EXPECT_EQ(attributes.builtin.discovery_config.discoveryProtocol, fastdds::rtps::DiscoveryProtocol::CLIENT);
-    EXPECT_EQ(attributes.builtin.metatrafficMulticastLocatorList.size(), 0);
+    EXPECT_EQ(attributes.builtin.metatrafficMulticastLocatorList.size(), 0u);
 
     DomainParticipantQos result_qos = participant->get_qos();
     EXPECT_EQ(RETCODE_OK, participant->set_qos(result_qos));
@@ -1583,7 +1583,7 @@ TEST(ParticipantTests, EasyModeParticipantCheckConfigurationPriority)
     // Verify that the localhost Discovery Server is created and the configured remote IP
     // is the one set by the QoS (i.e., ROS2_EASY_MODE environment variable is ignored).
     rtps::RTPSParticipantAttributes rtps_attr = get_rtps_attributes(participant);
-    ASSERT_EQ(rtps_attr.builtin.discovery_config.m_DiscoveryServers.size(), 1);
+    ASSERT_EQ(rtps_attr.builtin.discovery_config.m_DiscoveryServers.size(), 1u);
 
     rtps::Locator_t expected_locator;
     rtps::IPLocator::setIPv4(expected_locator, "127.0.0.1");
@@ -1618,7 +1618,7 @@ TEST(ParticipantTests, EasyModeIPConfigFromXML)
     // Verify that the localhost Discovery Server is created and the configured remote IP
     // is the one set by the QoS
     rtps::RTPSParticipantAttributes rtps_attr = get_rtps_attributes(participant);
-    ASSERT_EQ(rtps_attr.builtin.discovery_config.m_DiscoveryServers.size(), 1);
+    ASSERT_EQ(rtps_attr.builtin.discovery_config.m_DiscoveryServers.size(), 1u);
 
     rtps::Locator_t expected_locator;
     rtps::IPLocator::setIPv4(expected_locator, "127.0.0.1");
@@ -5206,3 +5206,4 @@ int main(
     testing::InitGoogleMock(&argc, argv);
     return RUN_ALL_TESTS();
 }
+

--- a/test/unittest/dds/publisher/PublisherTests.cpp
+++ b/test/unittest/dds/publisher/PublisherTests.cpp
@@ -910,4 +910,3 @@ int main(
     testing::InitGoogleMock(&argc, argv);
     return RUN_ALL_TESTS();
 }
-

--- a/test/unittest/dds/publisher/PublisherTests.cpp
+++ b/test/unittest/dds/publisher/PublisherTests.cpp
@@ -312,7 +312,7 @@ TEST(PublisherTests, ChangeDefaultDataWriterQos)
     // .reliability
     EXPECT_EQ(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS, wqos.reliability().kind);
     EXPECT_EQ(100, wqos.reliability().max_blocking_time.seconds);
-    EXPECT_EQ(1, wqos.reliability().max_blocking_time.nanosec);
+    EXPECT_EQ(1u, wqos.reliability().max_blocking_time.nanosec);
     // .destination_order
     EXPECT_EQ(eprosima::fastdds::dds::BY_RECEPTION_TIMESTAMP_DESTINATIONORDER_QOS, wqos.destination_order().kind);
     // .history
@@ -397,9 +397,9 @@ TEST(PublisherTests, ChangeDefaultDataWriterQos)
     EXPECT_EQ(2, wqos.endpoint().entity_id);
     EXPECT_EQ(eprosima::fastdds::rtps::PREALLOCATED_WITH_REALLOC_MEMORY_MODE, wqos.endpoint().history_memory_policy);
     // . writer_resource_limits
-    EXPECT_EQ(30, wqos.writer_resource_limits().matched_subscriber_allocation.initial);
-    EXPECT_EQ(300, wqos.writer_resource_limits().matched_subscriber_allocation.maximum);
-    EXPECT_EQ(400, wqos.writer_resource_limits().matched_subscriber_allocation.increment);
+    EXPECT_EQ(30ul, wqos.writer_resource_limits().matched_subscriber_allocation.initial);
+    EXPECT_EQ(300ul, wqos.writer_resource_limits().matched_subscriber_allocation.maximum);
+    EXPECT_EQ(400ul, wqos.writer_resource_limits().matched_subscriber_allocation.increment);
     // . data_sharing
     EXPECT_EQ(eprosima::fastdds::dds::ON, wqos.data_sharing().kind());
     EXPECT_EQ(0, wqos.data_sharing().shm_directory().compare("/"));
@@ -910,3 +910,4 @@ int main(
     testing::InitGoogleMock(&argc, argv);
     return RUN_ALL_TESTS();
 }
+

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -1684,9 +1684,9 @@ TEST_F(DataReaderTests, get_unread_count)
     ASSERT_EQ(SampleStateKind::READ_SAMPLE_STATE, sample_info.sample_state);
 
     // All variants should then return 0
-    EXPECT_EQ(0, data_reader_->get_unread_count(true));
-    EXPECT_EQ(0, data_reader_->get_unread_count(false));
-    EXPECT_EQ(0, data_reader_->get_unread_count());
+    EXPECT_EQ(0ull, data_reader_->get_unread_count(true));
+    EXPECT_EQ(0ull, data_reader_->get_unread_count(false));
+    EXPECT_EQ(0ull, data_reader_->get_unread_count());
 }
 
 template<typename DataType>
@@ -2950,7 +2950,7 @@ TEST_F(DataReaderTests, read_conditions_wait_on_SampleStateMask)
     bw.join();
 
     // Check the data is there
-    EXPECT_EQ(data_reader.get_unread_count(), 1);
+    EXPECT_EQ(data_reader.get_unread_count(), 1ull);
 
     // Check the conditions triggered were the expected ones
     ASSERT_FALSE(read_cond->get_trigger_value());
@@ -3062,7 +3062,7 @@ TEST_F(DataReaderTests, read_conditions_wait_on_ViewStateMask)
     bw.join();
 
     // Check the data is there
-    EXPECT_EQ(data_reader.get_unread_count(), 1);
+    EXPECT_EQ(data_reader.get_unread_count(), 1ull);
 
     // Check the conditions triggered were the expected ones
     ASSERT_TRUE(view_cond->get_trigger_value());
@@ -3167,7 +3167,7 @@ TEST_F(DataReaderTests, read_conditions_wait_on_InstanceStateMask)
     bw.join();
 
     // Check the data is there
-    EXPECT_EQ(data_reader.get_unread_count(), 1);
+    EXPECT_EQ(data_reader.get_unread_count(), 1ull);
 
     // Check the conditions triggered were the expected ones
     ASSERT_TRUE(alive_cond->get_trigger_value());
@@ -3938,3 +3938,4 @@ int main(
     testing::InitGoogleMock(&argc, argv);
     return RUN_ALL_TESTS();
 }
+

--- a/test/unittest/dds/subscriber/DataReaderTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderTests.cpp
@@ -3938,4 +3938,3 @@ int main(
     testing::InitGoogleMock(&argc, argv);
     return RUN_ALL_TESTS();
 }
-

--- a/test/unittest/dds/xtypes/type_lookup_service/TypeLookupServiceTests.cpp
+++ b/test/unittest/dds/xtypes/type_lookup_service/TypeLookupServiceTests.cpp
@@ -994,4 +994,3 @@ int main(
     testing::InitGoogleMock(&argc, argv);
     return RUN_ALL_TESTS();
 }
-

--- a/test/unittest/dds/xtypes/type_lookup_service/TypeLookupServiceTests.cpp
+++ b/test/unittest/dds/xtypes/type_lookup_service/TypeLookupServiceTests.cpp
@@ -228,7 +228,7 @@ public:
         cv_.notify_all();
     }
 
-    size_t wait_for_entries(
+    int wait_for_entries(
             uint32_t amount,
             int max_wait)
     {
@@ -237,7 +237,7 @@ public:
                 {
                     return mEntriesConsumed.size() >= amount;
                 });
-        return mEntriesConsumed.size();
+        return static_cast<int>(mEntriesConsumed.size());
     }
 
 private:
@@ -453,7 +453,7 @@ TEST_F(TypeLookupServiceTests, TypeLookupReplyListener_wrong_EntityId)
 
     reply_listener_->on_new_cache_change_added(&stateful_reader_, change);
 
-    EXPECT_EQ(reply_listener_->get_replies_queue()->size(), 0);
+    EXPECT_EQ(reply_listener_->get_replies_queue()->size(), 0u);
 
     Log::Flush();
     EXPECT_EQ(log_consumer->wait_for_entries(1, 1), 1);
@@ -473,7 +473,7 @@ TEST_F(TypeLookupServiceTests, TypeLookupReplyListener_malformed_Reply)
 
     reply_listener_->on_new_cache_change_added(&stateful_reader_, change);
 
-    EXPECT_EQ(reply_listener_->get_replies_queue()->size(), 0);
+    EXPECT_EQ(reply_listener_->get_replies_queue()->size(), 0u);
 }
 
 TEST_F(TypeLookupServiceTests, TypeLookupReplyListener_REMOTE_EX_UNSUPPORTED)
@@ -497,7 +497,7 @@ TEST_F(TypeLookupServiceTests, TypeLookupReplyListener_REMOTE_EX_UNSUPPORTED)
 
     reply_listener_->on_new_cache_change_added(&stateful_reader_, &change);
 
-    EXPECT_EQ(reply_listener_->get_replies_queue()->size(), 0);
+    EXPECT_EQ(reply_listener_->get_replies_queue()->size(), 0u);
 
     Log::Flush();
     EXPECT_EQ(log_consumer->wait_for_entries(1, 1), 1);
@@ -524,7 +524,7 @@ TEST_F(TypeLookupServiceTests, TypeLookupReplyListener_REMOTE_EX_INVALID_ARGUMEN
 
     reply_listener_->on_new_cache_change_added(&stateful_reader_, &change);
 
-    EXPECT_EQ(reply_listener_->get_replies_queue()->size(), 0);
+    EXPECT_EQ(reply_listener_->get_replies_queue()->size(), 0u);
 
     Log::Flush();
     EXPECT_EQ(log_consumer->wait_for_entries(1, 1), 1);
@@ -550,7 +550,7 @@ TEST_F(TypeLookupServiceTests, TypeLookupReplyListener_REMOTE_EX_OUT_OF_RESOURCE
             .WillOnce(testing::DoAll(testing::SetArgReferee<1>(expectedReply), testing::Return(true)));
 
     reply_listener_->on_new_cache_change_added(&stateful_reader_, &change);
-    EXPECT_EQ(reply_listener_->get_replies_queue()->size(), 0);
+    EXPECT_EQ(reply_listener_->get_replies_queue()->size(), 0u);
 
     Log::Flush();
     EXPECT_EQ(log_consumer->wait_for_entries(1, 1), 1);
@@ -576,7 +576,7 @@ TEST_F(TypeLookupServiceTests, TypeLookupReplyListener_REMOTE_EX_UNKNOWN_OPERATI
             .WillOnce(testing::DoAll(testing::SetArgReferee<1>(expectedReply), testing::Return(true)));
 
     reply_listener_->on_new_cache_change_added(&stateful_reader_, &change);
-    EXPECT_EQ(reply_listener_->get_replies_queue()->size(), 0);
+    EXPECT_EQ(reply_listener_->get_replies_queue()->size(), 0u);
 
     Log::Flush();
     EXPECT_EQ(log_consumer->wait_for_entries(1, 1), 1);
@@ -602,7 +602,7 @@ TEST_F(TypeLookupServiceTests, TypeLookupReplyListener_REMOTE_EX_UNKNOWN_EXCEPTI
             .WillOnce(testing::DoAll(testing::SetArgReferee<1>(expectedReply), testing::Return(true)));
 
     reply_listener_->on_new_cache_change_added(&stateful_reader_, &change);
-    EXPECT_EQ(reply_listener_->get_replies_queue()->size(), 0);
+    EXPECT_EQ(reply_listener_->get_replies_queue()->size(), 0u);
 
     Log::Flush();
     EXPECT_EQ(log_consumer->wait_for_entries(1, 1), 1);
@@ -806,7 +806,7 @@ TEST_F(TypeLookupServiceTests, TypeLookupRequestListener_wrong_EntityId)
 
     request_listener_->on_new_cache_change_added(&stateful_reader_, change);
 
-    EXPECT_EQ(reply_listener_->get_replies_queue()->size(), 0);
+    EXPECT_EQ(reply_listener_->get_replies_queue()->size(), 0u);
 
     Log::Flush();
     EXPECT_EQ(log_consumer->wait_for_entries(1, 1), 1);
@@ -825,7 +825,7 @@ TEST_F(TypeLookupServiceTests, TypeLookupRequestListener_malformed_Request)
 
     request_listener_->on_new_cache_change_added(&stateful_reader_, change);
 
-    EXPECT_EQ(request_listener_->get_requests_queue()->size(), 0);
+    EXPECT_EQ(request_listener_->get_requests_queue()->size(), 0u);
 }
 
 TEST_F(TypeLookupServiceTests, TypeLookupRequestListener_wrong_requestid)
@@ -994,3 +994,4 @@ int main(
     testing::InitGoogleMock(&argc, argv);
     return RUN_ALL_TESTS();
 }
+

--- a/test/unittest/dds/xtypes/type_representation/TypeObjectRegistryTests.cpp
+++ b/test/unittest/dds/xtypes/type_representation/TypeObjectRegistryTests.cpp
@@ -21,13 +21,24 @@
 
 #include <fastdds/dds/domain/DomainParticipantFactory.hpp>
 #include <fastdds/dds/xtypes/common.hpp>
+#include <fastdds/dds/xtypes/dynamic_types/DynamicTypeBuilderFactory.hpp>
 #include <fastdds/dds/xtypes/type_representation/TypeObject.hpp>
 #include <fastdds/dds/xtypes/type_representation/TypeObjectUtils.hpp>
+
+#include <fastdds/xtypes/type_representation/TypeObjectRegistry.hpp>
 
 namespace eprosima {
 namespace fastdds {
 namespace dds {
 namespace xtypes {
+
+class TestTypeObjectRegistry : public TypeObjectRegistry
+{
+
+public:
+
+    using TypeObjectRegistry::set_annotation_parameter_value;
+};
 
 // Test TypeObjectRegistry::register_type_object
 TEST(TypeObjectRegistryTests, register_type_object)
@@ -330,6 +341,42 @@ TEST(TypeObjectRegistryTests, get_type_information)
     EXPECT_EQ(RETCODE_OK, registry.get_type_information(type_ids, type_info, false));
 }
 
+// (MacOS) Regression test for clang/libc++ builds: empty char8 annotation 
+// parameters must not route through the string overload 
+// and must produce a null character default value instead
+TEST(TypeObjectRegistryTests, set_annotation_parameter_value_empty_char8)
+{
+    TestTypeObjectRegistry registry;
+    AnnotationParameterValue param_value;
+    // Build the primitive char8 type explicitly so the conversion logic is exercised on the
+    // single-character annotation path instead of the string one
+    auto char8_type = DynamicTypeBuilderFactory::get_instance()->get_primitive_type(TK_CHAR8);
+
+    ASSERT_NE(nullptr, char8_type);
+    // An empty value for a char8 annotation must still succeed and yield the default
+    // null character rather than being treated as a string payload
+    EXPECT_EQ(RETCODE_OK, registry.set_annotation_parameter_value(char8_type, "", param_value));
+    EXPECT_EQ(TK_CHAR8, param_value._d());
+    EXPECT_EQ('\0', param_value.char_value());
+}
+
+// (MacOS) Regression test for clang/libc++ builds: non empty char8 annotation 
+TEST(TypeObjectRegistryTests, set_annotation_parameter_value_non_empty_char8_uses_first_character)
+{
+    TestTypeObjectRegistry registry;
+    AnnotationParameterValue param_value;
+    // Use the same primitive char8 path to verify how 
+    // text input is narrowed into a single annotation character
+    auto char8_type = DynamicTypeBuilderFactory::get_instance()->get_primitive_type(TK_CHAR8);
+
+    ASSERT_NE(nullptr, char8_type);
+    // For char8 annotations only the first character is significant, 
+    // even if the provided text contains more bytes
+    EXPECT_EQ(RETCODE_OK, registry.set_annotation_parameter_value(char8_type, "FastDDS", param_value));
+    EXPECT_EQ(TK_CHAR8, param_value._d());
+    EXPECT_EQ('F', param_value.char_value());
+}
+
 } // xtypes
 } // dds
 } // fastdds
@@ -342,3 +389,4 @@ int main(
     testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }
+

--- a/test/unittest/dds/xtypes/type_representation/TypeObjectRegistryTests.cpp
+++ b/test/unittest/dds/xtypes/type_representation/TypeObjectRegistryTests.cpp
@@ -341,8 +341,8 @@ TEST(TypeObjectRegistryTests, get_type_information)
     EXPECT_EQ(RETCODE_OK, registry.get_type_information(type_ids, type_info, false));
 }
 
-// (MacOS) Regression test for clang/libc++ builds: empty char8 annotation 
-// parameters must not route through the string overload 
+// (MacOS) Regression test for clang/libc++ builds: empty char8 annotation
+// parameters must not route through the string overload
 // and must produce a null character default value instead
 TEST(TypeObjectRegistryTests, set_annotation_parameter_value_empty_char8)
 {
@@ -353,25 +353,25 @@ TEST(TypeObjectRegistryTests, set_annotation_parameter_value_empty_char8)
     auto char8_type = DynamicTypeBuilderFactory::get_instance()->get_primitive_type(TK_CHAR8);
 
     ASSERT_NE(nullptr, char8_type);
-    // An empty value for a char8 annotation must still succeed and yield the default
-    // null character rather than being treated as a string payload
+    // An empty textual value for a char8 annotation must still succeed and yield the default
+    // null character rather than being treated as a string payload.
     EXPECT_EQ(RETCODE_OK, registry.set_annotation_parameter_value(char8_type, "", param_value));
     EXPECT_EQ(TK_CHAR8, param_value._d());
     EXPECT_EQ('\0', param_value.char_value());
 }
 
-// (MacOS) Regression test for clang/libc++ builds: non empty char8 annotation 
+// (MacOS) Regression test for clang/libc++ builds: non empty char8 annotation
 TEST(TypeObjectRegistryTests, set_annotation_parameter_value_non_empty_char8_uses_first_character)
 {
     TestTypeObjectRegistry registry;
     AnnotationParameterValue param_value;
-    // Use the same primitive char8 path to verify how 
-    // text input is narrowed into a single annotation character
+    // Use the same primitive char8 path to verify how textual input is narrowed into a single
+    // annotation character
     auto char8_type = DynamicTypeBuilderFactory::get_instance()->get_primitive_type(TK_CHAR8);
 
     ASSERT_NE(nullptr, char8_type);
-    // For char8 annotations only the first character is significant, 
-    // even if the provided text contains more bytes
+    // For char8 annotations only the first character is significant, even if the provided text
+    // contains more bytes
     EXPECT_EQ(RETCODE_OK, registry.set_annotation_parameter_value(char8_type, "FastDDS", param_value));
     EXPECT_EQ(TK_CHAR8, param_value._d());
     EXPECT_EQ('F', param_value.char_value());
@@ -389,4 +389,3 @@ int main(
     testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }
-

--- a/test/unittest/dds/xtypes/type_representation/TypeObjectUtilsTests.cpp
+++ b/test/unittest/dds/xtypes/type_representation/TypeObjectUtilsTests.cpp
@@ -3140,7 +3140,7 @@ TEST(TypeObjectUtilsTests, add_to_applied_annotation_parameter_seq)
             InvalidArgumentError);
     EXPECT_NO_THROW(TypeObjectUtils::add_applied_annotation_parameter(param_seq, color_param));
     EXPECT_THROW(TypeObjectUtils::add_applied_annotation_parameter(param_seq, color_param), InvalidArgumentError);
-    EXPECT_EQ(3, param_seq.size());
+    EXPECT_EQ(3u, param_seq.size());
     EXPECT_EQ(get_dependencies_param, param_seq[0]);
     EXPECT_EQ(color_param, param_seq[1]);
     EXPECT_EQ(shapesize_param, param_seq[2]);
@@ -3230,7 +3230,7 @@ TEST(TypeObjectUtilsTests, add_to_applied_annotation_seq)
     EXPECT_NO_THROW(TypeObjectUtils::add_applied_annotation(applied_annotation_seq, second_annotation));
     EXPECT_THROW(TypeObjectUtils::add_applied_annotation(applied_annotation_seq, second_annotation),
             InvalidArgumentError);
-    EXPECT_EQ(3, applied_annotation_seq.size());
+    EXPECT_EQ(3u, applied_annotation_seq.size());
     // Ordered by Annotation TypeIdentifier
     EXPECT_TRUE(applied_annotation_seq[0].annotation_typeid().equivalence_hash() <
             applied_annotation_seq[1].annotation_typeid().equivalence_hash());
@@ -3273,7 +3273,7 @@ TEST(TypeObjectUtilsTests, add_to_complete_struct_member_seq)
             InvalidArgumentError);
     EXPECT_NO_THROW(TypeObjectUtils::add_complete_struct_member(member_seq, second));
     EXPECT_THROW(TypeObjectUtils::add_complete_struct_member(member_seq, second), InvalidArgumentError);
-    EXPECT_EQ(3, member_seq.size());
+    EXPECT_EQ(3u, member_seq.size());
     EXPECT_EQ(third, member_seq[0]);
     EXPECT_EQ(first, member_seq[1]);
     EXPECT_EQ(second, member_seq[2]);
@@ -3284,12 +3284,12 @@ TEST(TypeObjectUtilsTests, add_to_union_case_label_seq)
 {
     UnionCaseLabelSeq labels;
     EXPECT_NO_THROW(TypeObjectUtils::add_union_case_label(labels, 3));
-    EXPECT_EQ(1, labels.size());
+    EXPECT_EQ(1u, labels.size());
     EXPECT_NO_THROW(TypeObjectUtils::add_union_case_label(labels, 3));
-    EXPECT_EQ(1, labels.size());
+    EXPECT_EQ(1u, labels.size());
     EXPECT_NO_THROW(TypeObjectUtils::add_union_case_label(labels, 1));
     EXPECT_NO_THROW(TypeObjectUtils::add_union_case_label(labels, 2));
-    EXPECT_EQ(3, labels.size());
+    EXPECT_EQ(3u, labels.size());
     EXPECT_EQ(1, labels[0]);
     EXPECT_EQ(2, labels[1]);
     EXPECT_EQ(3, labels[2]);
@@ -3331,7 +3331,7 @@ TEST(TypeObjectUtilsTests, add_to_complete_union_member_seq)
             InvalidArgumentError);
     EXPECT_NO_THROW(TypeObjectUtils::add_complete_union_member(member_seq, second_member));
     EXPECT_THROW(TypeObjectUtils::add_complete_union_member(member_seq, second_member), InvalidArgumentError);
-    EXPECT_EQ(3, member_seq.size());
+    EXPECT_EQ(3u, member_seq.size());
     EXPECT_EQ(third_member, member_seq[0]);
     EXPECT_EQ(first_member, member_seq[1]);
     EXPECT_EQ(second_member, member_seq[2]);
@@ -3361,7 +3361,7 @@ TEST(TypeObjectUtilsTests, add_to_complete_annotation_parameter_seq)
             InvalidArgumentError);
     EXPECT_NO_THROW(TypeObjectUtils::add_complete_annotation_parameter(param_seq, second_param));
     EXPECT_THROW(TypeObjectUtils::add_complete_annotation_parameter(param_seq, second_param), InvalidArgumentError);
-    EXPECT_EQ(3, param_seq.size());
+    EXPECT_EQ(3u, param_seq.size());
     EXPECT_EQ(first_param, param_seq[0]);
     EXPECT_EQ(second_param, param_seq[1]);
     EXPECT_EQ(third_param, param_seq[2]);
@@ -3395,7 +3395,7 @@ TEST(TypeObjectUtils, add_to_complete_enumerated_literal_seq)
             InvalidArgumentError);
     EXPECT_NO_THROW(TypeObjectUtils::add_complete_enumerated_literal(literal_seq, second_literal));
     EXPECT_THROW(TypeObjectUtils::add_complete_enumerated_literal(literal_seq, second_literal), InvalidArgumentError);
-    EXPECT_EQ(3, literal_seq.size());
+    EXPECT_EQ(3u, literal_seq.size());
     EXPECT_EQ(first_literal, literal_seq[0]);
     EXPECT_EQ(second_literal, literal_seq[1]);
     EXPECT_EQ(third_literal, literal_seq[2]);
@@ -3427,7 +3427,7 @@ TEST(TypeObjectUtilsTests, add_to_complete_bitflag_seq)
             InvalidArgumentError);
     EXPECT_NO_THROW(TypeObjectUtils::add_complete_bitflag(bitflag_seq, second_bitflag));
     EXPECT_THROW(TypeObjectUtils::add_complete_bitflag(bitflag_seq, second_bitflag), InvalidArgumentError);
-    EXPECT_EQ(3, bitflag_seq.size());
+    EXPECT_EQ(3u, bitflag_seq.size());
     EXPECT_EQ(first_bitflag, bitflag_seq[0]);
     EXPECT_EQ(second_bitflag, bitflag_seq[1]);
     EXPECT_EQ(third_bitflag, bitflag_seq[2]);
@@ -3459,7 +3459,7 @@ TEST(TypeObjectUtilsTests, add_to_complete_bitfield_seq)
             InvalidArgumentError);
     EXPECT_NO_THROW(TypeObjectUtils::add_complete_bitfield(bitfield_seq, second_bitfield));
     EXPECT_THROW(TypeObjectUtils::add_complete_bitfield(bitfield_seq, second_bitfield), InvalidArgumentError);
-    EXPECT_EQ(3, bitfield_seq.size());
+    EXPECT_EQ(3u, bitfield_seq.size());
     EXPECT_EQ(first_bitfield, bitfield_seq[0]);
     EXPECT_EQ(second_bitfield, bitfield_seq[1]);
     EXPECT_EQ(third_bitfield, bitfield_seq[2]);
@@ -3479,3 +3479,4 @@ int main(
     eprosima::fastdds::dds::Log::KillThread();
     return ret_value;
 }
+

--- a/test/unittest/dds/xtypes/type_representation/TypeObjectUtilsTests.cpp
+++ b/test/unittest/dds/xtypes/type_representation/TypeObjectUtilsTests.cpp
@@ -3479,4 +3479,3 @@ int main(
     eprosima::fastdds::dds::Log::KillThread();
     return ret_value;
 }
-

--- a/test/unittest/rtps/builtin/BuiltinDataSerializationTests.cpp
+++ b/test/unittest/rtps/builtin/BuiltinDataSerializationTests.cpp
@@ -2141,7 +2141,7 @@ TEST(BuiltinDataSerializationTests, contentfilterproperty_interoperability)
     ASSERT_EQ("Square", out.content_filter.related_topic_name.to_string());
     ASSERT_EQ("DDSSQL", out.content_filter.filter_class_name.to_string());
     ASSERT_EQ("x > %0 and x < %1 and y > %2 and y < %3", out.content_filter.filter_expression);
-    ASSERT_EQ(4, out.content_filter.expression_parameters.size());
+    ASSERT_EQ(4u, out.content_filter.expression_parameters.size());
     ASSERT_EQ("100", out.content_filter.expression_parameters[0].to_string());
     ASSERT_EQ("200", out.content_filter.expression_parameters[1].to_string());
     ASSERT_EQ("100", out.content_filter.expression_parameters[2].to_string());
@@ -2206,7 +2206,7 @@ TEST(BuiltinDataSerializationTests, contentfilterproperty_max_parameter_check)
         msg.pos = 0;
         EXPECT_TRUE(out.read_from_cdr_message(&msg));
 
-        ASSERT_EQ(100, out.content_filter.expression_parameters.size());
+        ASSERT_EQ(100u, out.content_filter.expression_parameters.size());
 
         CDRMessage_t msg_fault(5000);
         EXPECT_TRUE(fastdds::dds::ParameterList::writeEncapsulationToCDRMsg(&msg_fault));
@@ -3572,3 +3572,4 @@ int main(
     testing::InitGoogleMock(&argc, argv);
     return RUN_ALL_TESTS();
 }
+

--- a/test/unittest/rtps/builtin/BuiltinDataSerializationTests.cpp
+++ b/test/unittest/rtps/builtin/BuiltinDataSerializationTests.cpp
@@ -3572,4 +3572,3 @@ int main(
     testing::InitGoogleMock(&argc, argv);
     return RUN_ALL_TESTS();
 }
-

--- a/test/unittest/rtps/history/ReaderHistoryTests.cpp
+++ b/test/unittest/rtps/history/ReaderHistoryTests.cpp
@@ -293,4 +293,3 @@ int main(
     testing::InitGoogleMock(&argc, argv);
     return RUN_ALL_TESTS();
 }
-

--- a/test/unittest/rtps/history/ReaderHistoryTests.cpp
+++ b/test/unittest/rtps/history/ReaderHistoryTests.cpp
@@ -229,7 +229,7 @@ TEST_F(ReaderHistoryTests, change_order)
 
         // Prepare for next iteration
         history->remove_all_changes();
-        ASSERT_EQ(history->getHistorySize(), 0);
+        ASSERT_EQ(history->getHistorySize(), 0u);
     }
 
     // Clean-up
@@ -293,3 +293,4 @@ int main(
     testing::InitGoogleMock(&argc, argv);
     return RUN_ALL_TESTS();
 }
+

--- a/test/unittest/rtps/security/SecurityInitializationTests.cpp
+++ b/test/unittest/rtps/security/SecurityInitializationTests.cpp
@@ -237,7 +237,7 @@ TEST_F(SecurityTest, initialization_logging_error)
     eprosima::fastdds::dds::Log::Flush();
 
     auto log_entries = mockConsumer->ConsumedEntries();
-    ASSERT_GE(log_entries.size(), 1);
+    ASSERT_GE(log_entries.size(), 1u);
     bool found = false;
     for (auto entry : log_entries)
     {

--- a/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
+++ b/test/unittest/statistics/rtps/RTPSStatisticsTests.cpp
@@ -1400,8 +1400,8 @@ TEST_F(RTPSStatisticsTests, iconnections_queryable_get_entity_connections)
     part_impl->get_entity_connections(reader_->getGuid(), conns_reader);
     part_impl->get_entity_connections(writer_->getGuid(), conns_writer);
 
-    ASSERT_EQ(1, conns_writer.size());
-    ASSERT_EQ(1, conns_writer.size());
+    ASSERT_EQ(1u, conns_writer.size());
+    ASSERT_EQ(1u, conns_writer.size());
     ASSERT_EQ(conns_reader[0].guid(), statistics::to_statistics_type(writer_->getGuid()));
     ASSERT_EQ(conns_writer[0].guid(), statistics::to_statistics_type(reader_->getGuid()));
 

--- a/test/unittest/transport/TCPv4Tests.cpp
+++ b/test/unittest/transport/TCPv4Tests.cpp
@@ -2301,7 +2301,7 @@ TEST_F(TCPv4Tests, remove_from_send_resource_list)
             send_resource_list,
             wrong_remote_participant_physical_locators,
             initial_peer_list);
-        ASSERT_EQ(send_resource_list.size(), 2);
+        ASSERT_EQ(send_resource_list.size(), 2u);
 
         // Using the correct locator should remove the channel resource
         LocatorList_t remote_participant_physical_locators;
@@ -2310,7 +2310,7 @@ TEST_F(TCPv4Tests, remove_from_send_resource_list)
             send_resource_list,
             remote_participant_physical_locators,
             initial_peer_list);
-        ASSERT_EQ(send_resource_list.size(), 1);
+        ASSERT_EQ(send_resource_list.size(), 1u);
 
         // Using the initial peer locator should not remove the channel resource
         remote_participant_physical_locators.clear();
@@ -2325,7 +2325,7 @@ TEST_F(TCPv4Tests, remove_from_send_resource_list)
             send_resource_list,
             remote_participant_physical_locators,
             initial_peer_list);
-        ASSERT_EQ(send_resource_list.size(), 1);
+        ASSERT_EQ(send_resource_list.size(), 1u);
     }
 }
 
@@ -2387,8 +2387,8 @@ TEST_F(TCPv4Tests, add_logical_port_on_send_resource_creation)
         ASSERT_FALSE(server_resource_list.empty());
         ASSERT_TRUE(serverTransportUnderTest->get_channel_resources().empty());
         auto channel_pending_logical_ports = serverTransportUnderTest->get_channel_pending_logical_ports();
-        ASSERT_EQ(channel_pending_logical_ports.size(), 1);
-        ASSERT_EQ(channel_pending_logical_ports.begin()->second.size(), 2);
+        ASSERT_EQ(channel_pending_logical_ports.size(), 1u);
+        ASSERT_EQ(channel_pending_logical_ports.begin()->second.size(), std::size_t{2});
         ASSERT_TRUE(channel_pending_logical_ports.begin()->second.find(
                     7410) != channel_pending_logical_ports.begin()->second.end());
         ASSERT_TRUE(channel_pending_logical_ports.begin()->second.find(

--- a/test/unittest/utils/RefCountedPointerTests.cpp
+++ b/test/unittest/utils/RefCountedPointerTests.cpp
@@ -164,7 +164,7 @@ TEST_F(RefCountedPointerTests, refcountedpointer_inactive)
     }
 
     // The entity should have been processed only once
-    ASSERT_EQ(1, entity_.n_times_data_processed);
+    ASSERT_EQ(std::size_t{1}, entity_.n_times_data_processed.load());
 }
 
 TEST_F(RefCountedPointerTests, refcounterpointer_deactivate_waits_for_no_references)
@@ -224,7 +224,7 @@ TEST_F(RefCountedPointerTests, refcounterpointer_deactivate_waits_for_no_referen
 
     std::cout << "Elapsed time: " << elapsed << " ms" << std::endl;
     ASSERT_GT(elapsed, 50); // destroy should have taken at least 50 ms. Being strict it should be 100, but we allow some margin
-    ASSERT_EQ(entity_.n_times_data_processed, 5);
+    ASSERT_EQ(std::size_t{5}, entity_.n_times_data_processed.load());
 }
 
 } // namespace fastdds
@@ -237,3 +237,4 @@ int main(
     testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }
+

--- a/test/unittest/utils/RefCountedPointerTests.cpp
+++ b/test/unittest/utils/RefCountedPointerTests.cpp
@@ -237,4 +237,3 @@ int main(
     testing::InitGoogleTest(&argc, argv);
     return RUN_ALL_TESTS();
 }
-


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->


Issues when building natively on macOS (aarch64-darwin) with clang 21 + libc++ from Nix.

- TypeObjectRegistry.cpp:2620error: null passed to a callee that requires a non-null argument [-Werror,-Wnonnull].
...build_annotation_parameter_value(!value.empty() ? value : 0);


I was able to patch this by replacing 0 with empty str literal.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.4.x 3.2.x 2.14.x -->

@Mergifyio backport 3.2.x 2.14.x

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [x] Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [x] New feature has been added to the `versions.md` file (if applicable).
- [x] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
