### PR TITLE
[24365] Revert ABI extension to protect UBSan error

### DIFF
--- a/include/fastdds/statistics/dds/domain/DomainParticipant.hpp
+++ b/include/fastdds/statistics/dds/domain/DomainParticipant.hpp
@@ -26,9 +26,7 @@
 #include <fastdds/dds/builtin/topic/PublicationBuiltinTopicData.hpp>
 #include <fastdds/dds/builtin/topic/SubscriptionBuiltinTopicData.hpp>
 #include <fastdds/dds/core/ReturnCode.hpp>
-#include <fastdds/dds/core/status/StatusMask.hpp>
 #include <fastdds/dds/domain/DomainParticipant.hpp>
-#include <fastdds/dds/domain/DomainParticipantFactory.hpp>
 #include <fastdds/dds/publisher/qos/DataWriterQos.hpp>
 #include <fastdds/fastdds_dll.hpp>
 
@@ -48,13 +46,6 @@ namespace dds {
 class DomainParticipant : public eprosima::fastdds::dds::DomainParticipant
 {
     DomainParticipant() = delete;
-
-protected:
-
-    DomainParticipant(
-            const eprosima::fastdds::dds::StatusMask& mask);
-
-    friend class eprosima::fastdds::dds::DomainParticipantFactory;
 
 public:
 

--- a/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
+++ b/src/cpp/fastdds/domain/DomainParticipantFactory.cpp
@@ -39,10 +39,6 @@
 #include <xmlparser/XMLEndpointParser.h>
 #include <xmlparser/XMLProfileManager.h>
 
-#ifdef FASTDDS_STATISTICS
-#include <fastdds/statistics/dds/domain/DomainParticipant.hpp>
-#endif // ifdef FASTDDS_STATISTICS
-
 using namespace eprosima::fastdds::xmlparser;
 
 using eprosima::fastdds::rtps::RTPSDomain;
@@ -161,13 +157,12 @@ DomainParticipant* DomainParticipantFactory::create_participant(
 
     const DomainParticipantQos& pqos = (&qos == &PARTICIPANT_QOS_DEFAULT) ? default_participant_qos_ : qos;
 
-#ifndef FASTDDS_STATISTICS
     DomainParticipant* dom_part = new DomainParticipant(mask);
+#ifndef FASTDDS_STATISTICS
     DomainParticipantImpl* dom_part_impl = new DomainParticipantImpl(dom_part, did, pqos, listener);
 #else
-    statistics::dds::DomainParticipant* dom_part = new statistics::dds::DomainParticipant(mask);
-    statistics::dds::DomainParticipantImpl* dom_part_impl =
-            new statistics::dds::DomainParticipantImpl(dom_part, did, pqos, listener);
+    statistics::dds::DomainParticipantImpl* dom_part_impl = new statistics::dds::DomainParticipantImpl(dom_part, did,
+                    pqos, listener);
 #endif // FASTDDS_STATISTICS
 
     if (fastdds::rtps::GUID_t::unknown() != dom_part_impl->guid())

--- a/src/cpp/statistics/fastdds/domain/DomainParticipant.cpp
+++ b/src/cpp/statistics/fastdds/domain/DomainParticipant.cpp
@@ -31,12 +31,6 @@ namespace fastdds {
 namespace statistics {
 namespace dds {
 
-DomainParticipant::DomainParticipant(
-        const eprosima::fastdds::dds::StatusMask& mask)
-    : eprosima::fastdds::dds::DomainParticipant(mask)
-{
-}
-
 fastdds::dds::ReturnCode_t DomainParticipant::enable_statistics_datawriter(
         const std::string& topic_name,
         const eprosima::fastdds::dds::DataWriterQos& dwqos)

--- a/src/cpp/statistics/fastdds/domain/DomainParticipant.cpp
+++ b/src/cpp/statistics/fastdds/domain/DomainParticipant.cpp
@@ -82,7 +82,7 @@ DomainParticipant* DomainParticipant::narrow(
         eprosima::fastdds::dds::DomainParticipant* domain_participant)
 {
 #ifdef FASTDDS_STATISTICS
-    return static_cast<DomainParticipant*>(domain_participant);
+    return reinterpret_cast<DomainParticipant*>(domain_participant);
 #else
     (void)domain_participant;
     return nullptr;
@@ -93,7 +93,7 @@ const DomainParticipant* DomainParticipant::narrow(
         const eprosima::fastdds::dds::DomainParticipant* domain_participant)
 {
 #ifdef FASTDDS_STATISTICS
-    return static_cast<const DomainParticipant*>(domain_participant);
+    return reinterpret_cast<const DomainParticipant*>(domain_participant);
 #else
     (void)domain_participant;
     return nullptr;

--- a/test/blackbox/CMakeLists.txt
+++ b/test/blackbox/CMakeLists.txt
@@ -143,6 +143,17 @@ set(DDS_BLACKBOXTESTS_SOURCE
     ${CMAKE_CURRENT_SOURCE_DIR}/../../src/cpp/rtps/messages/CDRMessage.cpp
     )
 
+# These statistics tests narrow a base DomainParticipant to statistics::dds::DomainParticipant
+# and call members on it. That is intentional UB (the object is never constructed as the derived
+# type, to avoid emitting its vtable and breaking ABI), so disable the vptr (bad-downcast) check
+# for just these translation units
+if(SANITIZER STREQUAL "UNDEFINED")
+    set_source_files_properties(
+        ${CMAKE_CURRENT_SOURCE_DIR}/common/DDSBlackboxTestsStatistics.cpp
+        ${CMAKE_CURRENT_SOURCE_DIR}/common/DDSBlackboxTestsMonitorService.cpp
+        PROPERTIES COMPILE_OPTIONS "-fno-sanitize=vptr")
+endif()
+
 # Prepare static discovery xml file for blackbox tests.
 string(RANDOM LENGTH 4 ALPHABET 0123456789 TOPIC_RANDOM_NUMBER)
 math(EXPR TOPIC_RANDOM_NUMBER "${TOPIC_RANDOM_NUMBER} + 0") # Remove extra leading 0s.

--- a/test/unittest/statistics/dds/CMakeLists.txt
+++ b/test/unittest/statistics/dds/CMakeLists.txt
@@ -22,6 +22,19 @@ if(TINYXML2_INCLUDE_DIR)
     include_directories(${TINYXML2_INCLUDE_DIR})
 endif(TINYXML2_INCLUDE_DIR)
 
+# These tests narrow a base DomainParticipant to statistics::dds::DomainParticipant and call members
+# on it. That is intentional UB (the object is never constructed as the derived type, to avoid
+# emitting its vtable and breaking ABI), so disable the vptr (bad-downcast) check for just these
+# translation units
+if(SANITIZER STREQUAL "UNDEFINED")
+    set_source_files_properties(
+        StatisticsDomainParticipantTests.cpp
+        StatisticsQosTests.cpp
+        StatisticsDomainParticipantStatusQueryableTests.cpp
+        StatisticsDomainParticipantMockTests.cpp
+        PROPERTIES COMPILE_OPTIONS "-fno-sanitize=vptr")
+endif()
+
 ## StatisticsDomainParticipantTests
 set(STATISTICS_DOMAINPARTICIPANT_TESTS_SOURCE
     StatisticsDomainParticipantTests.cpp


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

PR https://github.com/eProsima/Fast-DDS/pull/6386 introduced an ABI extension to solve an UBSan issue with the `statistics::dds::DomainParticipant`. This PR reverts that change in order to prevent any ABI modification. To avoid UBSan errors, tests relying on the `narrow` operation of the `statistics::dds::DomainParticipant` will be compiled disabling the `-vptr` option that detects this specific issue.  

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.4.x 3.2.x 2.14.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_: Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- _N/A_: Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- _N/A_: Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
