### PR TITLE
[24549] Remove stale tcp channels

### DIFF
--- a/src/cpp/rtps/transport/TCPTransportInterface.cpp
+++ b/src/cpp/rtps/transport/TCPTransportInterface.cpp
@@ -1144,6 +1144,55 @@ void TCPTransportInterface::perform_listen_operation(
     }
 
     EPROSIMA_LOG_INFO(RTCP, "End PerformListenOperation " << channel->locator());
+
+    // If we get here, the channel has been disconnected. We might need to clean it up if
+    // the remote endpoint is the one that initiated the disconnection.
+    // We only delete acceptor channels, as connect channels need to be kept in channel_resources_ to restart the connection
+    if (channel && channel->tcp_connection_type() == TCPChannelResource::TCPConnectionType::TCP_ACCEPT_TYPE)
+    {
+        // Defer the erase to io_context_ so the TCPChannelResource destructor runs off the listener thread that is about to exit.
+        // Weak_ptr is used to avoid keeping the channel alive if it has already been removed from the maps by another thread.
+        asio::post(io_context_, [this, channel_weak]()
+                {
+                    auto ch = channel_weak.lock();
+                    if (!ch)
+                    {
+                        return;
+                    }
+                    {
+                        // Channel resources map case
+                        std::unique_lock<std::mutex> scoped_lock(sockets_map_mutex_);
+                        bool erased = false;
+                        // There might be multiple entries with the same channel. Delete them all
+                        for (auto it = channel_resources_.begin(); it != channel_resources_.end(); )
+                        {
+                            if (it->second == ch)
+                            {
+                                it = channel_resources_.erase(it);
+                                erased = true;
+                            }
+                            else
+                            {
+                                ++it;
+                            }
+                        }
+                        if (erased)
+                        {
+                            return;
+                        }
+                    }
+                    // Unbound channel resources map case
+                    std::unique_lock<std::mutex> unbound_lock(unbound_map_mutex_);
+                    auto it = std::find(unbound_channel_resources_.begin(),
+                    unbound_channel_resources_.end(), ch);
+                    if (it != unbound_channel_resources_.end())
+                    {
+                        unbound_channel_resources_.erase(it);
+                    }
+                });
+        // Drop the listener's reference so the destructor cannot run on this thread
+        channel.reset();
+    }
 }
 
 bool TCPTransportInterface::read_body(

--- a/test/unittest/transport/TCPv4Tests.cpp
+++ b/test/unittest/transport/TCPv4Tests.cpp
@@ -2461,7 +2461,7 @@ TEST_F(TCPv4Tests, remove_stale_channel_resources_of_server)
 
         // Wait for the server to finish the BindConnectionRequest handshake
         auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
-        while (server.get_channel_resources().empty() &&
+        while (server.get_channel_resources_size() != 0 &&
                 std::chrono::steady_clock::now() < deadline)
         {
             std::this_thread::sleep_for(std::chrono::milliseconds(20));
@@ -2476,7 +2476,7 @@ TEST_F(TCPv4Tests, remove_stale_channel_resources_of_server)
 
     // Check that the server correctly removes the channel resource of type ACCEPT after the client disconnection
     auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
-    while (!server.get_channel_resources().empty() &&
+    while (server.get_channel_resources_size() != 0 &&
             std::chrono::steady_clock::now() < deadline)
     {
         std::this_thread::sleep_for(std::chrono::milliseconds(100));

--- a/test/unittest/transport/TCPv4Tests.cpp
+++ b/test/unittest/transport/TCPv4Tests.cpp
@@ -2469,7 +2469,8 @@ TEST_F(TCPv4Tests, remove_stale_channel_resources_of_server)
         // Ensure there are channel resources in the server. Bind socket adds an entry per interface available, so there could be more than one.
         ASSERT_GT(server.get_channel_resources().size(), 0u);
 
-        // Tear down the client: closes the TCP socket
+        // Tear down the client: clean send_resource_list and then close the TCP socket.
+        send_resource_list.clear();
         client.reset();
     }
 

--- a/test/unittest/transport/TCPv4Tests.cpp
+++ b/test/unittest/transport/TCPv4Tests.cpp
@@ -2439,8 +2439,6 @@ TEST_F(TCPv4Tests, remove_stale_channel_resources_of_server)
     // Server
     TCPv4TransportDescriptor serverDescriptor;
     serverDescriptor.add_listener_port(g_default_port);
-    serverDescriptor.keep_alive_frequency_ms = 1000;
-    serverDescriptor.keep_alive_timeout_ms    = 2000;
     MockTCPv4Transport server(serverDescriptor);
     ASSERT_TRUE(server.init());
 
@@ -2461,13 +2459,13 @@ TEST_F(TCPv4Tests, remove_stale_channel_resources_of_server)
 
         // Wait for the server to finish the BindConnectionRequest handshake
         auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
-        while (server.get_channel_resources_size() != 0 &&
+        while (server.get_channel_resources_size() == 0 &&
                 std::chrono::steady_clock::now() < deadline)
         {
             std::this_thread::sleep_for(std::chrono::milliseconds(20));
         }
         // Ensure there are channel resources in the server. Bind socket adds an entry per interface available, so there could be more than one.
-        ASSERT_GT(server.get_channel_resources().size(), 0u);
+        ASSERT_GT(server.get_channel_resources_size(), 0u);
 
         // Tear down the client: clean send_resource_list and then close the TCP socket.
         send_resource_list.clear();
@@ -2481,8 +2479,8 @@ TEST_F(TCPv4Tests, remove_stale_channel_resources_of_server)
     {
         std::this_thread::sleep_for(std::chrono::milliseconds(100));
     }
-    EXPECT_TRUE(server.get_channel_resources().empty());
-    EXPECT_TRUE(server.get_unbound_channel_resources().empty());
+    EXPECT_EQ(server.get_channel_resources_size(), 0u);
+    EXPECT_EQ(server.get_unbound_channel_resources_size(), 0u);
 }
 
 

--- a/test/unittest/transport/TCPv4Tests.cpp
+++ b/test/unittest/transport/TCPv4Tests.cpp
@@ -2430,6 +2430,61 @@ TEST_F(TCPv4Tests, add_logical_port_on_send_resource_creation)
     }
 }
 
+// This test verifies that TCP channels of type ACCEPT are correctly removed from the channel resources map when
+// the channel is disabled by asio. This is the case when a client disconnects from the server. There is no need
+// maintain the channel resource of a disconnected client because new connections will generate new channel resources
+// and no unbind operation is needed at destruction time for a removed participant (eDisconnected channel).
+TEST_F(TCPv4Tests, remove_stale_channel_resources_of_server)
+{
+    // Server
+    TCPv4TransportDescriptor serverDescriptor;
+    serverDescriptor.add_listener_port(g_default_port);
+    serverDescriptor.keep_alive_frequency_ms = 1000;
+    serverDescriptor.keep_alive_timeout_ms    = 2000;
+    MockTCPv4Transport server(serverDescriptor);
+    ASSERT_TRUE(server.init());
+
+    // Client
+    {
+        TCPv4TransportDescriptor clientDescriptor;
+        auto client = std::unique_ptr<TCPv4Transport>(new TCPv4Transport(clientDescriptor));
+        ASSERT_TRUE(client->init());
+
+        Locator_t outputLocator;
+        outputLocator.kind = LOCATOR_KIND_TCPv4;
+        IPLocator::setIPv4(outputLocator, 127, 0, 0, 1);
+        IPLocator::setPhysicalPort(outputLocator, g_default_port);
+        IPLocator::setLogicalPort(outputLocator, 7410);
+
+        SendResourceList send_resource_list;
+        ASSERT_TRUE(client->OpenOutputChannel(send_resource_list, outputLocator));
+
+        // Wait for the server to finish the BindConnectionRequest handshake
+        auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(5);
+        while (server.get_channel_resources().empty() &&
+                std::chrono::steady_clock::now() < deadline)
+        {
+            std::this_thread::sleep_for(std::chrono::milliseconds(20));
+        }
+        // Ensure there are channel resources in the server. Bind socket adds an entry per interface available, so there could be more than one.
+        ASSERT_GT(server.get_channel_resources().size(), 0u);
+
+        // Tear down the client: closes the TCP socket
+        client.reset();
+    }
+
+    // Check that the server correctly removes the channel resource of type ACCEPT after the client disconnection
+    auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+    while (!server.get_channel_resources().empty() &&
+            std::chrono::steady_clock::now() < deadline)
+    {
+        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+    }
+    EXPECT_TRUE(server.get_channel_resources().empty());
+    EXPECT_TRUE(server.get_unbound_channel_resources().empty());
+}
+
+
 void TCPv4Tests::HELPER_SetDescriptorDefaults()
 {
     descriptor.add_listener_port(g_default_port);

--- a/test/unittest/transport/mock/MockTCPv4Transport.h
+++ b/test/unittest/transport/mock/MockTCPv4Transport.h
@@ -40,6 +40,12 @@ public:
         return channel_resources_;
     }
 
+    size_t get_channel_resources_size() const
+    {
+        std::lock_guard<std::mutex> lock(sockets_map_mutex_);
+        return unbound_channel_resources_.size();
+    }
+
     const std::vector<std::shared_ptr<TCPChannelResource>> get_unbound_channel_resources() const
     {
         return unbound_channel_resources_;

--- a/test/unittest/transport/mock/MockTCPv4Transport.h
+++ b/test/unittest/transport/mock/MockTCPv4Transport.h
@@ -43,12 +43,18 @@ public:
     size_t get_channel_resources_size() const
     {
         std::lock_guard<std::mutex> lock(sockets_map_mutex_);
-        return unbound_channel_resources_.size();
+        return channel_resources_.size();
     }
 
     const std::vector<std::shared_ptr<TCPChannelResource>> get_unbound_channel_resources() const
     {
         return unbound_channel_resources_;
+    }
+
+    size_t get_unbound_channel_resources_size() const
+    {
+        std::lock_guard<std::mutex> lock(unbound_map_mutex_);
+        return unbound_channel_resources_.size();
     }
 
     const std::vector<asio::ip::address_v4>& get_interface_whitelist() const


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description
This PR introduces logic to remove stale TCP ACCEPT type channels when the listening operation ends (Asio detects and closes the socket). We can only perform this action on ACCEPT type channels because the re-connection mechanism of the CONNECT type channels rely on detecting stale channels and try to re-establish the connection when data needs to be sent. 

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.2.x 2.14.x
<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_: Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
