### PR TITLE
[24604] Fix minor dataraces

### DIFF
--- a/src/cpp/fastdds/core/condition/StatusConditionImpl.cpp
+++ b/src/cpp/fastdds/core/condition/StatusConditionImpl.cpp
@@ -67,12 +67,15 @@ ReturnCode_t StatusConditionImpl::set_enabled_statuses(
 const StatusMask& StatusConditionImpl::get_enabled_statuses() const
 {
     std::lock_guard<std::mutex> guard(mutex_);
+    // TODO: same issue as get_raw_status, reference escapes the lock.
     return mask_;
 }
 
 const StatusMask& StatusConditionImpl::get_raw_status() const
 {
     std::lock_guard<std::mutex> guard(mutex_);
+    // TODO: returning a reference to a mutex-protected member that escapes the lock is a data race.
+    // Fix requires changing the return type to StatusMask (by value), which is an API break.
     return status_;
 }
 

--- a/src/cpp/fastdds/core/condition/StatusConditionImpl.cpp
+++ b/src/cpp/fastdds/core/condition/StatusConditionImpl.cpp
@@ -67,15 +67,16 @@ ReturnCode_t StatusConditionImpl::set_enabled_statuses(
 const StatusMask& StatusConditionImpl::get_enabled_statuses() const
 {
     std::lock_guard<std::mutex> guard(mutex_);
-    // TODO: same issue as get_raw_status, reference escapes the lock.
+    FASTDDS_TODO_BEFORE(4, 0, "Same issue as get_raw_status, reference escapes the lock.");
     return mask_;
 }
 
 const StatusMask& StatusConditionImpl::get_raw_status() const
 {
     std::lock_guard<std::mutex> guard(mutex_);
-    // TODO: returning a reference to a mutex-protected member that escapes the lock is a data race.
-    // Fix requires changing the return type to StatusMask (by value), which is an API break.
+    FASTDDS_TODO_BEFORE(4, 0,
+            "Returning a reference to a member protected by a mutex that escapes the lock is a data race. "
+            "Fix requires changing the return type to StatusMask (by value), which is an API break.");
     return status_;
 }
 

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -445,11 +445,14 @@ bool StatefulWriter::intraprocess_heartbeat(
         bool liveliness)
 {
     bool returned_value = false;
+    std::unique_lock<RecursiveTimedMutex> lockW(mp_mutex);
     LocalReaderPointer::Instance local_reader = reader_proxy->local_reader();
+    lockW.unlock();
 
     if (local_reader)
     {
-        std::unique_lock<RecursiveTimedMutex> lockW(mp_mutex);
+        // std::unique_lock<RecursiveTimedMutex> lockW(mp_mutex);
+        lockW.lock();
         SequenceNumber_t first_seq = get_seq_num_min();
         SequenceNumber_t last_seq = get_seq_num_max();
 

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -451,7 +451,6 @@ bool StatefulWriter::intraprocess_heartbeat(
 
     if (local_reader)
     {
-        // std::unique_lock<RecursiveTimedMutex> lockW(mp_mutex);
         lockW.lock();
         SequenceNumber_t first_seq = get_seq_num_min();
         SequenceNumber_t last_seq = get_seq_num_max();

--- a/src/cpp/rtps/writer/StatelessWriter.cpp
+++ b/src/cpp/rtps/writer/StatelessWriter.cpp
@@ -317,6 +317,7 @@ bool StatelessWriter::intraprocess_delivery(
         CacheChange_t* change,
         ReaderLocator& reader_locator)
 {
+    std::lock_guard<RecursiveTimedMutex> guard(mp_mutex);
     LocalReaderPointer::Instance local_reader = reader_locator.local_reader();
 
     if (local_reader &&

--- a/src/cpp/security/accesscontrol/PermissionsParser.cpp
+++ b/src/cpp/security/accesscontrol/PermissionsParser.cpp
@@ -17,9 +17,15 @@
 
 #include <cstring>
 #include <cassert>
+#include <ctime>
 #include <iostream>
+#include <mutex>
 #include <sstream>
 #include <iomanip>
+
+namespace {
+std::mutex mktime_mutex;
+} // namespace
 
 #if TIXML2_MAJOR_VERSION >= 6
 #define PRINTLINE(node) node->GetLineNum()
@@ -339,7 +345,10 @@ bool PermissionsParser::parse_validity(
 
                 if (!stream.fail())
                 {
-                    validity.not_before = std::mktime(&time);
+                    {
+                        std::lock_guard<std::mutex> lock(mktime_mutex);
+                        validity.not_before = std::mktime(&time);
+                    }
 #endif // if _MSC_VER != 1800
 
                 tinyxml2::XMLElement* old_node = node;
@@ -360,7 +369,10 @@ bool PermissionsParser::parse_validity(
 
                             if (!stream.fail())
                             {
-                                validity.not_after = std::mktime(&time);
+                                {
+                                    std::lock_guard<std::mutex> lock(mktime_mutex);
+                                    validity.not_after = std::mktime(&time);
+                                }
 #endif // if _MSC_VER != 1800
                             returned_value = true;
                         }

--- a/src/cpp/utils/SystemInfo.cpp
+++ b/src/cpp/utils/SystemInfo.cpp
@@ -139,10 +139,12 @@ fastdds::dds::ReturnCode_t SystemInfo::get_username(
     return fastdds::dds::RETCODE_OK;
 #else
     uid_t user_id = geteuid();
-    struct passwd* pwd = getpwuid(user_id);
-    if (pwd != nullptr)
+    struct passwd pwd {};
+    struct passwd* result = nullptr;
+    char buf[1024];
+    if (getpwuid_r(user_id, &pwd, buf, sizeof(buf), &result) == 0 && result != nullptr)
     {
-        username = pwd->pw_name;
+        username = pwd.pw_name;
         if (!username.empty())
         {
             return fastdds::dds::RETCODE_OK;

--- a/test/blackbox/api/dds-pim/CustomPayloadPool.hpp
+++ b/test/blackbox/api/dds-pim/CustomPayloadPool.hpp
@@ -20,6 +20,7 @@
 #define DDS_CUSTOM_PAYLOAD_POOL_HPP
 
 #include <assert.h>
+#include <atomic>
 #include <cstdint>
 #include <stdio.h>
 #include <string.h>
@@ -95,8 +96,8 @@ public:
         return true;
     }
 
-    uint32_t requested_payload_count = 0;
-    uint32_t returned_payload_count = 0;
+    std::atomic<uint32_t> requested_payload_count {0};
+    std::atomic<uint32_t> returned_payload_count {0};
 
 };
 

--- a/test/blackbox/api/dds-pim/PubSubParticipant.hpp
+++ b/test/blackbox/api/dds-pim/PubSubParticipant.hpp
@@ -846,47 +846,47 @@ public:
 
     void pub_liveliness_lost()
     {
-        std::unique_lock<std::mutex> lock(pub_liveliness_mutex_);
+        std::lock_guard<std::mutex> lock(pub_liveliness_mutex_);
         pub_times_liveliness_lost_++;
         pub_liveliness_cv_.notify_one();
     }
 
     void sub_liveliness_lost()
     {
-        std::unique_lock<std::mutex> lock(sub_liveliness_mutex_);
+        std::lock_guard<std::mutex> lock(sub_liveliness_mutex_);
         sub_times_liveliness_lost_++;
         sub_liveliness_cv_.notify_one();
     }
 
     void sub_liveliness_recovered()
     {
-        std::unique_lock<std::mutex> lock(sub_liveliness_mutex_);
+        std::lock_guard<std::mutex> lock(sub_liveliness_mutex_);
         sub_times_liveliness_recovered_++;
         sub_liveliness_cv_.notify_one();
     }
 
     void data_received()
     {
-        std::unique_lock<std::mutex> lock(sub_data_mutex_);
+        std::lock_guard<std::mutex> lock(sub_data_mutex_);
         sub_times_data_received_++;
         sub_data_cv_.notify_one();
     }
 
     unsigned int pub_times_liveliness_lost()
     {
-        std::unique_lock<std::mutex> lock(pub_liveliness_mutex_);
+        std::lock_guard<std::mutex> lock(pub_liveliness_mutex_);
         return pub_times_liveliness_lost_;
     }
 
     unsigned int sub_times_liveliness_lost()
     {
-        std::unique_lock<std::mutex> lock(sub_liveliness_mutex_);
+        std::lock_guard<std::mutex> lock(sub_liveliness_mutex_);
         return sub_times_liveliness_lost_;
     }
 
     unsigned int sub_times_liveliness_recovered()
     {
-        std::unique_lock<std::mutex> lock(sub_liveliness_mutex_);
+        std::lock_guard<std::mutex> lock(sub_liveliness_mutex_);
         return sub_times_liveliness_recovered_;
     }
 
@@ -954,28 +954,28 @@ private:
 
     void pub_matched()
     {
-        std::unique_lock<std::mutex> lock(pub_mutex_);
+        std::lock_guard<std::mutex> lock(pub_mutex_);
         ++pub_matched_;
         pub_cv_.notify_one();
     }
 
     void pub_unmatched()
     {
-        std::unique_lock<std::mutex> lock(pub_mutex_);
+        std::lock_guard<std::mutex> lock(pub_mutex_);
         --pub_matched_;
         pub_cv_.notify_one();
     }
 
     void sub_matched()
     {
-        std::unique_lock<std::mutex> lock(sub_mutex_);
+        std::lock_guard<std::mutex> lock(sub_mutex_);
         ++sub_matched_;
         sub_cv_.notify_one();
     }
 
     void sub_unmatched()
     {
-        std::unique_lock<std::mutex> lock(sub_mutex_);
+        std::lock_guard<std::mutex> lock(sub_mutex_);
         --sub_matched_;
         sub_cv_.notify_one();
     }

--- a/test/blackbox/api/dds-pim/PubSubReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubReader.hpp
@@ -1965,7 +1965,7 @@ public:
         return status;
     }
 
-    const eprosima::fastdds::dds::LivelinessChangedStatus& liveliness_changed_status()
+    eprosima::fastdds::dds::LivelinessChangedStatus liveliness_changed_status()
     {
         std::unique_lock<std::mutex> lock(liveliness_mutex_);
 

--- a/test/blackbox/api/dds-pim/PubSubReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubReader.hpp
@@ -2643,6 +2643,7 @@ public:
 
     ~PubSubReaderWithWaitsets() override
     {
+        waitset_thread_.stop();
     }
 
     void createSubscriber() override

--- a/test/blackbox/api/dds-pim/PubSubReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubReader.hpp
@@ -2014,6 +2014,7 @@ public:
 
     unsigned int get_participants_matched() const
     {
+        std::unique_lock<std::mutex> lock(mutexDiscovery_);
         return participant_matched_;
     }
 
@@ -2314,7 +2315,7 @@ protected:
     std::list<type> total_msgs_;
     std::mutex mutex_;
     std::condition_variable cv_;
-    std::mutex mutexDiscovery_;
+    mutable std::mutex mutexDiscovery_;
     std::condition_variable cvDiscovery_;
     std::atomic<unsigned int> matched_;
     unsigned int participant_matched_;

--- a/test/blackbox/api/dds-pim/PubSubReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubReader.hpp
@@ -2619,7 +2619,7 @@ protected:
         eprosima::fastdds::dds::GuardCondition guard_condition_;
 
         //! Number of times deadline was missed
-        unsigned int times_deadline_missed_ = 0;
+        std::atomic<unsigned int> times_deadline_missed_ {0};
 
         //! The timeout for the wait operation
         eprosima::fastdds::dds::Duration_t timeout_;

--- a/test/blackbox/api/dds-pim/PubSubReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubReader.hpp
@@ -609,7 +609,7 @@ public:
 
     std::list<type> data_not_received()
     {
-        std::unique_lock<std::mutex> lock(mutex_);
+        std::lock_guard<std::mutex> lock(mutex_);
         return total_msgs_;
     }
 
@@ -639,7 +639,7 @@ public:
             size_t expected_samples)
     {
         {
-            std::unique_lock<std::mutex> lock(mutex_);
+            std::lock_guard<std::mutex> lock(mutex_);
             current_processed_count_ = 0;
             number_samples_expected_ = expected_samples;
             last_seq.clear();
@@ -2014,7 +2014,7 @@ public:
 
     unsigned int get_participants_matched() const
     {
-        std::unique_lock<std::mutex> lock(mutexDiscovery_);
+        std::lock_guard<std::mutex> lock(mutexDiscovery_);
         return participant_matched_;
     }
 
@@ -2139,7 +2139,7 @@ protected:
         {
             returnedValue = true;
 
-            std::unique_lock<std::mutex> lock(mutex_);
+            std::lock_guard<std::mutex> lock(mutex_);
 
             // Check order of changes.
             LastSeqInfo seq_info{ info.instance_handle, info.sample_identity.writer_guid() };
@@ -2183,7 +2183,7 @@ protected:
         }
 
         // Traverse the collection
-        std::unique_lock<std::mutex> lock(mutex_);
+        std::lock_guard<std::mutex> lock(mutex_);
         for (int32_t i = 0; i < datas.length(); ++i)
         {
             type& data = datas[i];
@@ -2249,28 +2249,28 @@ protected:
 
     void participant_matched()
     {
-        std::unique_lock<std::mutex> lock(mutexDiscovery_);
+        std::lock_guard<std::mutex> lock(mutexDiscovery_);
         ++participant_matched_;
         cvDiscovery_.notify_one();
     }
 
     void participant_unmatched()
     {
-        std::unique_lock<std::mutex> lock(mutexDiscovery_);
+        std::lock_guard<std::mutex> lock(mutexDiscovery_);
         --participant_matched_;
         cvDiscovery_.notify_one();
     }
 
     void matched()
     {
-        std::unique_lock<std::mutex> lock(mutexDiscovery_);
+        std::lock_guard<std::mutex> lock(mutexDiscovery_);
         ++matched_;
         cvDiscovery_.notify_one();
     }
 
     void unmatched()
     {
-        std::unique_lock<std::mutex> lock(mutexDiscovery_);
+        std::lock_guard<std::mutex> lock(mutexDiscovery_);
         --matched_;
         cvDiscovery_.notify_one();
     }
@@ -2427,7 +2427,7 @@ protected:
             waitset_.attach_condition(reader_.subscriber_->get_statuscondition());
             waitset_.attach_condition(guard_condition_);
 
-            std::unique_lock<std::mutex> lock(mutex_);
+            std::lock_guard<std::mutex> lock(mutex_);
             if (nullptr == thread_)
             {
                 running_ = true;

--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -20,6 +20,7 @@
 #ifndef _TEST_BLACKBOX_PUBSUBWRITER_HPP_
 #define _TEST_BLACKBOX_PUBSUBWRITER_HPP_
 
+#include <atomic>
 #include <condition_variable>
 #include <list>
 #include <map>
@@ -2455,10 +2456,10 @@ protected:
         eprosima::fastdds::dds::GuardCondition guard_condition_;
 
         //! The number of times deadline was missed
-        unsigned int times_deadline_missed_ = 0;
+        std::atomic<unsigned int> times_deadline_missed_ {0};
 
         //! The number of times liveliness was lost
-        unsigned int times_liveliness_lost_ = 0;
+        std::atomic<unsigned int> times_liveliness_lost_ {0};
 
         //! The timeout for the wait operation
         eprosima::fastdds::dds::Duration_t timeout_;

--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -1820,6 +1820,7 @@ public:
 
     unsigned int get_participants_matched() const
     {
+        std::unique_lock<std::mutex> lock(mutexDiscovery_);
         return participant_matched_;
     }
 
@@ -2242,7 +2243,7 @@ protected:
     eprosima::fastdds::rtps::GUID_t datawriter_guid_;
     bool initialized_;
     bool use_domain_id_from_profile_;
-    std::mutex mutexDiscovery_;
+    mutable std::mutex mutexDiscovery_;
     std::condition_variable cv_;
     std::atomic<unsigned int> matched_;
     unsigned int participant_matched_;

--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -1821,7 +1821,7 @@ public:
 
     unsigned int get_participants_matched() const
     {
-        std::unique_lock<std::mutex> lock(mutexDiscovery_);
+        std::lock_guard<std::mutex> lock(mutexDiscovery_);
         return participant_matched_;
     }
 
@@ -1985,28 +1985,28 @@ protected:
 
     void participant_matched()
     {
-        std::unique_lock<std::mutex> lock(mutexDiscovery_);
+        std::lock_guard<std::mutex> lock(mutexDiscovery_);
         ++participant_matched_;
         cv_.notify_one();
     }
 
     void participant_unmatched()
     {
-        std::unique_lock<std::mutex> lock(mutexDiscovery_);
+        std::lock_guard<std::mutex> lock(mutexDiscovery_);
         --participant_matched_;
         cv_.notify_one();
     }
 
     void matched()
     {
-        std::unique_lock<std::mutex> lock(mutexDiscovery_);
+        std::lock_guard<std::mutex> lock(mutexDiscovery_);
         ++matched_;
         cv_.notify_one();
     }
 
     void unmatched()
     {
-        std::unique_lock<std::mutex> lock(mutexDiscovery_);
+        std::lock_guard<std::mutex> lock(mutexDiscovery_);
         --matched_;
         cv_.notify_one();
     }
@@ -2324,7 +2324,7 @@ protected:
             waitset_.attach_condition(writer_.datawriter_->get_statuscondition());
             waitset_.attach_condition(guard_condition_);
 
-            std::unique_lock<std::mutex> lock(mutex_);
+            std::lock_guard<std::mutex> lock(mutex_);
             if (nullptr == thread_)
             {
                 running_ = true;

--- a/test/blackbox/api/dds-pim/PubSubWriterReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriterReader.hpp
@@ -570,7 +570,7 @@ public:
 
     std::list<type> data_not_received()
     {
-        std::unique_lock<std::mutex> lock(mutex_);
+        std::lock_guard<std::mutex> lock(mutex_);
         return total_msgs_;
     }
 
@@ -920,7 +920,7 @@ private:
         {
             returnedValue = true;
 
-            std::unique_lock<std::mutex> lock(mutex_);
+            std::lock_guard<std::mutex> lock(mutex_);
 
             // Check order of changes.
             if (datareader == datareader_)

--- a/test/blackbox/common/BlackboxTestsTransportCustom.cpp
+++ b/test/blackbox/common/BlackboxTestsTransportCustom.cpp
@@ -14,6 +14,7 @@
 
 #include "BlackboxTests.hpp"
 
+#include <atomic>
 #include <string>
 
 #include <gtest/gtest.h>
@@ -371,12 +372,12 @@ const std::string BuiltinTransportsTest::env_var_name_ = "FASTDDS_BUILTIN_TRANSP
 
 TEST(ChainingTransportTests, basic_test)
 {
-    bool writer_init_function_called = false;
-    bool writer_receive_function_called = false;
-    bool writer_send_function_called = false;
-    bool reader_init_function_called = false;
-    bool reader_receive_function_called = false;
-    bool reader_send_function_called = false;
+    std::atomic<bool> writer_init_function_called {false};
+    std::atomic<bool> writer_receive_function_called {false};
+    std::atomic<bool> writer_send_function_called {false};
+    std::atomic<bool> reader_init_function_called {false};
+    std::atomic<bool> reader_receive_function_called {false};
+    std::atomic<bool> reader_send_function_called {false};
     eprosima::fastdds::rtps::PropertyPolicy test_property_policy;
     test_property_policy.properties().push_back({test_property_name, test_property_value});
     std::shared_ptr<UDPv4TransportDescriptor> udp_transport = std::make_shared<UDPv4TransportDescriptor>();

--- a/test/blackbox/common/DDSBlackboxTestsDataReader.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDataReader.cpp
@@ -1421,6 +1421,9 @@ TEST(DDSDataReader, reception_timestamp_for_resent_samples)
     // Wait for the reception of all samples
     ASSERT_EQ(reader.block_for_all(std::chrono::seconds(5)), 3u);
 
+    // Avoid data race between the destructor and on_data_available
+    reader.destroy();
+
     // Check timestamps. reception_timestamps map is accesed by index of HelloWorld data
     ASSERT_EQ(reader.reception_timestamps.size(), 3u);
     auto reception_ts_1 = reader.reception_timestamps[1];

--- a/test/blackbox/common/DDSBlackboxTestsListeners.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsListeners.cpp
@@ -1306,57 +1306,59 @@ TEST(DDSStatus, sample_lost_re_dw_re_persistence_dr)
  */
 TEST(DDSStatus, sample_lost_waitset_be_dw_be_dr)
 {
-    PubSubReaderWithWaitsets<HelloWorldPubSubType> reader(TEST_TOPIC_NAME);
-    PubSubWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
-
     std::mutex test_step_mtx;
     std::condition_variable test_step_cv;
     uint8_t test_step = 0;
 
-    writer.reliability(eprosima::fastdds::dds::BEST_EFFORT_RELIABILITY_QOS);
-    reader.reliability(eprosima::fastdds::dds::BEST_EFFORT_RELIABILITY_QOS);
+    {
+        PubSubReaderWithWaitsets<HelloWorldPubSubType> reader(TEST_TOPIC_NAME);
+        PubSubWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
 
-    sample_lost_test_init(reader, writer, [&test_step_mtx, &test_step_cv, &test_step](
-                const eprosima::fastdds::dds::SampleLostStatus& status)
-            {
+        writer.reliability(eprosima::fastdds::dds::BEST_EFFORT_RELIABILITY_QOS);
+        reader.reliability(eprosima::fastdds::dds::BEST_EFFORT_RELIABILITY_QOS);
+
+        sample_lost_test_init(reader, writer, [&test_step_mtx, &test_step_cv, &test_step](
+                    const eprosima::fastdds::dds::SampleLostStatus& status)
                 {
-                    std::unique_lock<std::mutex> lock(test_step_mtx);
-                    if (0 == test_step && 3 == status.total_count && 3 == status.total_count_change)
                     {
-                        ++test_step;
+                        std::unique_lock<std::mutex> lock(test_step_mtx);
+                        if (0 == test_step && 3 == status.total_count && 3 == status.total_count_change)
+                        {
+                            ++test_step;
+                        }
+                        else if (1 == test_step && 4 == status.total_count && 1 == status.total_count_change)
+                        {
+                            ++test_step;
+                        }
+                        else if (2 == test_step && 5 == status.total_count && 1 == status.total_count_change)
+                        {
+                            ++test_step;
+                        }
+                        else if (3 == test_step && 7 == status.total_count && 2 == status.total_count_change)
+                        {
+                            ++test_step;
+                        }
+                        else
+                        {
+                            test_step = 0;
+                        }
                     }
-                    else if (1 == test_step && 4 == status.total_count && 1 == status.total_count_change)
-                    {
-                        ++test_step;
-                    }
-                    else if (2 == test_step && 5 == status.total_count && 1 == status.total_count_change)
-                    {
-                        ++test_step;
-                    }
-                    else if (3 == test_step && 7 == status.total_count && 2 == status.total_count_change)
-                    {
-                        ++test_step;
-                    }
-                    else
-                    {
-                        test_step = 0;
-                    }
-                }
 
-                test_step_cv.notify_all();
-            });
+                    test_step_cv.notify_all();
+                });
 
 
-    auto data = default_helloworld_data_generator(13);
+        auto data = default_helloworld_data_generator(13);
 
-    reader.startReception(data);
-    writer.send(data, 100);
+        reader.startReception(data);
+        writer.send(data, 100);
 
-    std::unique_lock<std::mutex> lock(test_step_mtx);
-    test_step_cv.wait(lock, [&test_step]()
-            {
-                return 4 == test_step;
-            });
+        std::unique_lock<std::mutex> lock(test_step_mtx);
+        test_step_cv.wait(lock, [&test_step]()
+                {
+                    return 4 == test_step;
+                });
+    }
 }
 
 /*!
@@ -1365,60 +1367,62 @@ TEST(DDSStatus, sample_lost_waitset_be_dw_be_dr)
  */
 TEST(DDSStatus, sample_lost_waitset_be_dw_lj_be_dr)
 {
-    PubSubReaderWithWaitsets<HelloWorldPubSubType> reader(TEST_TOPIC_NAME);
-    PubSubWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
-
-    writer.reliability(eprosima::fastdds::dds::BEST_EFFORT_RELIABILITY_QOS);
-    sample_lost_test_dw_init(writer);
-
-    auto data = default_helloworld_data_generator(4);
-    writer.send(data, 50);
-
     std::mutex test_step_mtx;
     std::condition_variable test_step_cv;
     uint8_t test_step = 0;
 
-    reader.reliability(eprosima::fastdds::dds::BEST_EFFORT_RELIABILITY_QOS);
-    sample_lost_test_dr_init(reader, [&test_step_mtx, &test_step_cv, &test_step](
-                const eprosima::fastdds::dds::SampleLostStatus& status)
-            {
+    {
+        PubSubReaderWithWaitsets<HelloWorldPubSubType> reader(TEST_TOPIC_NAME);
+        PubSubWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
+
+        writer.reliability(eprosima::fastdds::dds::BEST_EFFORT_RELIABILITY_QOS);
+        sample_lost_test_dw_init(writer);
+
+        auto data = default_helloworld_data_generator(4);
+        writer.send(data, 50);
+
+        reader.reliability(eprosima::fastdds::dds::BEST_EFFORT_RELIABILITY_QOS);
+        sample_lost_test_dr_init(reader, [&test_step_mtx, &test_step_cv, &test_step](
+                    const eprosima::fastdds::dds::SampleLostStatus& status)
                 {
-                    std::unique_lock<std::mutex> lock(test_step_mtx);
-                    if (0 == test_step && 1 == status.total_count && 1 == status.total_count_change)
                     {
-                        ++test_step;
+                        std::unique_lock<std::mutex> lock(test_step_mtx);
+                        if (0 == test_step && 1 == status.total_count && 1 == status.total_count_change)
+                        {
+                            ++test_step;
+                        }
+                        else if (1 == test_step && 2 == status.total_count && 1 == status.total_count_change)
+                        {
+                            ++test_step;
+                        }
+                        else if (2 == test_step && 4 == status.total_count && 2 == status.total_count_change)
+                        {
+                            ++test_step;
+                        }
+                        else
+                        {
+                            test_step = 0;
+                        }
                     }
-                    else if (1 == test_step && 2 == status.total_count && 1 == status.total_count_change)
-                    {
-                        ++test_step;
-                    }
-                    else if (2 == test_step && 4 == status.total_count && 2 == status.total_count_change)
-                    {
-                        ++test_step;
-                    }
-                    else
-                    {
-                        test_step = 0;
-                    }
-                }
 
-                test_step_cv.notify_all();
-            });
+                    test_step_cv.notify_all();
+                });
 
-    // Wait for discovery.
-    writer.wait_discovery();
-    reader.wait_discovery();
+        // Wait for discovery.
+        writer.wait_discovery();
+        reader.wait_discovery();
 
-    data = default_helloworld_data_generator(9);
+        data = default_helloworld_data_generator(9);
 
-    reader.startReception(data);
-    writer.send(data, 100);
+        reader.startReception(data);
+        writer.send(data, 100);
 
-    std::unique_lock<std::mutex> lock(test_step_mtx);
-    test_step_cv.wait(lock, [&test_step]()
-            {
-                return 3 == test_step;
-            });
+        std::unique_lock<std::mutex> lock(test_step_mtx);
+        test_step_cv.wait(lock, [&test_step]()
+                {
+                    return 3 == test_step;
+                });
+    }
 }
 
 /*!
@@ -1426,39 +1430,41 @@ TEST(DDSStatus, sample_lost_waitset_be_dw_lj_be_dr)
  */
 TEST(DDSStatus, sample_lost_waitset_re_dw_re_dr)
 {
-    PubSubReaderWithWaitsets<HelloWorldPubSubType> reader(TEST_TOPIC_NAME);
-    PubSubWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
-
-    writer.reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS);
-    reader.reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS);
-
     std::mutex test_step_mtx;
     std::condition_variable test_step_cv;
     int32_t test_count = 0;
     int32_t test_count_change_accum = 0;
 
-    sample_lost_test_init(reader, writer, [&test_step_mtx, &test_step_cv, &test_count, &test_count_change_accum](
-                const eprosima::fastdds::dds::SampleLostStatus& status)
-            {
+    {
+        PubSubReaderWithWaitsets<HelloWorldPubSubType> reader(TEST_TOPIC_NAME);
+        PubSubWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
+
+        writer.reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS);
+        reader.reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS);
+
+        sample_lost_test_init(reader, writer, [&test_step_mtx, &test_step_cv, &test_count, &test_count_change_accum](
+                    const eprosima::fastdds::dds::SampleLostStatus& status)
                 {
-                    std::unique_lock<std::mutex> lock(test_step_mtx);
-                    test_count = status.total_count;
-                    test_count_change_accum += status.total_count_change;
-                }
+                    {
+                        std::unique_lock<std::mutex> lock(test_step_mtx);
+                        test_count = status.total_count;
+                        test_count_change_accum += status.total_count_change;
+                    }
 
-                test_step_cv.notify_all();
-            });
+                    test_step_cv.notify_all();
+                });
 
-    auto data = default_helloworld_data_generator(13);
+        auto data = default_helloworld_data_generator(13);
 
-    reader.startReception(data);
-    writer.send(data, 100);
+        reader.startReception(data);
+        writer.send(data, 100);
 
-    std::unique_lock<std::mutex> lock(test_step_mtx);
-    test_step_cv.wait(lock, [&test_count, &test_count_change_accum]()
-            {
-                return 7 == test_count && 7 == test_count_change_accum;
-            });
+        std::unique_lock<std::mutex> lock(test_step_mtx);
+        test_step_cv.wait(lock, [&test_count, &test_count_change_accum]()
+                {
+                    return 7 == test_count && 7 == test_count_change_accum;
+                });
+    }
 }
 
 /*!
@@ -1467,48 +1473,50 @@ TEST(DDSStatus, sample_lost_waitset_re_dw_re_dr)
  */
 TEST(DDSStatus, sample_lost_waitset_re_dw_lj_re_dr)
 {
-    PubSubReaderWithWaitsets<HelloWorldPubSubType> reader(TEST_TOPIC_NAME);
-    PubSubWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
-
-    writer.reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS);
-    sample_lost_test_dw_init(writer);
-
-    auto data = default_helloworld_data_generator(4);
-    writer.send(data, 50);
-
     std::mutex test_step_mtx;
     std::condition_variable test_step_cv;
     int32_t test_count = 0;
     int32_t test_count_change_accum = 0;
 
-    reader.reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS);
-    sample_lost_test_dr_init(reader, [&test_step_mtx, &test_step_cv, &test_count, &test_count_change_accum](
-                const eprosima::fastdds::dds::SampleLostStatus& status)
-            {
+    {
+        PubSubReaderWithWaitsets<HelloWorldPubSubType> reader(TEST_TOPIC_NAME);
+        PubSubWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
+
+        writer.reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS);
+        sample_lost_test_dw_init(writer);
+
+        auto data = default_helloworld_data_generator(4);
+        writer.send(data, 50);
+
+        reader.reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS);
+        sample_lost_test_dr_init(reader, [&test_step_mtx, &test_step_cv, &test_count, &test_count_change_accum](
+                    const eprosima::fastdds::dds::SampleLostStatus& status)
                 {
-                    std::unique_lock<std::mutex> lock(test_step_mtx);
-                    test_count = status.total_count;
-                    test_count_change_accum += status.total_count_change;
-                }
+                    {
+                        std::unique_lock<std::mutex> lock(test_step_mtx);
+                        test_count = status.total_count;
+                        test_count_change_accum += status.total_count_change;
+                    }
 
-                test_step_cv.notify_all();
-            });
+                    test_step_cv.notify_all();
+                });
 
-    // Wait for discovery.
-    writer.wait_discovery();
-    reader.wait_discovery();
-    std::this_thread::sleep_for(std::chrono::seconds(1)); // Make sure the GAP message are received for the fourth sample.
+        // Wait for discovery.
+        writer.wait_discovery();
+        reader.wait_discovery();
+        std::this_thread::sleep_for(std::chrono::seconds(1)); // Make sure the GAP message are received for the fourth sample.
 
-    data = default_helloworld_data_generator(9);
+        data = default_helloworld_data_generator(9);
 
-    reader.startReception(data);
-    writer.send(data, 100);
+        reader.startReception(data);
+        writer.send(data, 100);
 
-    std::unique_lock<std::mutex> lock(test_step_mtx);
-    test_step_cv.wait(lock, [&test_count, &test_count_change_accum]()
-            {
-                return 4 == test_count && 4 == test_count_change_accum;
-            });
+        std::unique_lock<std::mutex> lock(test_step_mtx);
+        test_step_cv.wait(lock, [&test_count, &test_count_change_accum]()
+                {
+                    return 4 == test_count && 4 == test_count_change_accum;
+                });
+    }
 }
 
 /*!
@@ -1516,56 +1524,58 @@ TEST(DDSStatus, sample_lost_waitset_re_dw_lj_re_dr)
  */
 TEST(DDSStatus, sample_lost_waitset_re_dw_be_dr)
 {
-    PubSubReaderWithWaitsets<HelloWorldPubSubType> reader(TEST_TOPIC_NAME);
-    PubSubWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
-
-    writer.reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS);
-    reader.reliability(eprosima::fastdds::dds::BEST_EFFORT_RELIABILITY_QOS);
-
     std::mutex test_step_mtx;
     std::condition_variable test_step_cv;
     uint8_t test_step = 0;
 
-    sample_lost_test_init(reader, writer, [&test_step_mtx, &test_step_cv, &test_step](
-                const eprosima::fastdds::dds::SampleLostStatus& status)
-            {
+    {
+        PubSubReaderWithWaitsets<HelloWorldPubSubType> reader(TEST_TOPIC_NAME);
+        PubSubWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
+
+        writer.reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS);
+        reader.reliability(eprosima::fastdds::dds::BEST_EFFORT_RELIABILITY_QOS);
+
+        sample_lost_test_init(reader, writer, [&test_step_mtx, &test_step_cv, &test_step](
+                    const eprosima::fastdds::dds::SampleLostStatus& status)
                 {
-                    std::unique_lock<std::mutex> lock(test_step_mtx);
-                    if (0 == test_step && 3 == status.total_count && 3 == status.total_count_change)
                     {
-                        ++test_step;
+                        std::unique_lock<std::mutex> lock(test_step_mtx);
+                        if (0 == test_step && 3 == status.total_count && 3 == status.total_count_change)
+                        {
+                            ++test_step;
+                        }
+                        else if (1 == test_step && 4 == status.total_count && 1 == status.total_count_change)
+                        {
+                            ++test_step;
+                        }
+                        else if (2 == test_step && 5 == status.total_count && 1 == status.total_count_change)
+                        {
+                            ++test_step;
+                        }
+                        else if (3 == test_step && 7 == status.total_count && 2 == status.total_count_change)
+                        {
+                            ++test_step;
+                        }
+                        else
+                        {
+                            test_step = 0;
+                        }
                     }
-                    else if (1 == test_step && 4 == status.total_count && 1 == status.total_count_change)
-                    {
-                        ++test_step;
-                    }
-                    else if (2 == test_step && 5 == status.total_count && 1 == status.total_count_change)
-                    {
-                        ++test_step;
-                    }
-                    else if (3 == test_step && 7 == status.total_count && 2 == status.total_count_change)
-                    {
-                        ++test_step;
-                    }
-                    else
-                    {
-                        test_step = 0;
-                    }
-                }
 
-                test_step_cv.notify_all();
-            });
+                    test_step_cv.notify_all();
+                });
 
-    auto data = default_helloworld_data_generator(13);
+        auto data = default_helloworld_data_generator(13);
 
-    reader.startReception(data);
-    writer.send(data, 100);
+        reader.startReception(data);
+        writer.send(data, 100);
 
-    std::unique_lock<std::mutex> lock(test_step_mtx);
-    test_step_cv.wait(lock, [&test_step]()
-            {
-                return 4 == test_step;
-            });
+        std::unique_lock<std::mutex> lock(test_step_mtx);
+        test_step_cv.wait(lock, [&test_step]()
+                {
+                    return 4 == test_step;
+                });
+    }
 }
 
 /*!
@@ -1574,60 +1584,62 @@ TEST(DDSStatus, sample_lost_waitset_re_dw_be_dr)
  */
 TEST(DDSStatus, sample_lost_waitset_re_dw_lj_be_dr)
 {
-    PubSubReaderWithWaitsets<HelloWorldPubSubType> reader(TEST_TOPIC_NAME);
-    PubSubWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
-
-    writer.reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS);
-    sample_lost_test_dw_init(writer);
-
-    auto data = default_helloworld_data_generator(4);
-    writer.send(data, 50);
-
     std::mutex test_step_mtx;
     std::condition_variable test_step_cv;
     uint8_t test_step = 0;
 
-    reader.reliability(eprosima::fastdds::dds::BEST_EFFORT_RELIABILITY_QOS);
-    sample_lost_test_dr_init(reader, [&test_step_mtx, &test_step_cv, &test_step](
-                const eprosima::fastdds::dds::SampleLostStatus& status)
-            {
+    {
+        PubSubReaderWithWaitsets<HelloWorldPubSubType> reader(TEST_TOPIC_NAME);
+        PubSubWriter<HelloWorldPubSubType> writer(TEST_TOPIC_NAME);
+
+        writer.reliability(eprosima::fastdds::dds::RELIABLE_RELIABILITY_QOS);
+        sample_lost_test_dw_init(writer);
+
+        auto data = default_helloworld_data_generator(4);
+        writer.send(data, 50);
+
+        reader.reliability(eprosima::fastdds::dds::BEST_EFFORT_RELIABILITY_QOS);
+        sample_lost_test_dr_init(reader, [&test_step_mtx, &test_step_cv, &test_step](
+                    const eprosima::fastdds::dds::SampleLostStatus& status)
                 {
-                    std::unique_lock<std::mutex> lock(test_step_mtx);
-                    if (0 == test_step && 1 == status.total_count && 1 == status.total_count_change)
                     {
-                        ++test_step;
+                        std::unique_lock<std::mutex> lock(test_step_mtx);
+                        if (0 == test_step && 1 == status.total_count && 1 == status.total_count_change)
+                        {
+                            ++test_step;
+                        }
+                        else if (1 == test_step && 2 == status.total_count && 1 == status.total_count_change)
+                        {
+                            ++test_step;
+                        }
+                        else if (2 == test_step && 4 == status.total_count && 2 == status.total_count_change)
+                        {
+                            ++test_step;
+                        }
+                        else
+                        {
+                            test_step = 0;
+                        }
                     }
-                    else if (1 == test_step && 2 == status.total_count && 1 == status.total_count_change)
-                    {
-                        ++test_step;
-                    }
-                    else if (2 == test_step && 4 == status.total_count && 2 == status.total_count_change)
-                    {
-                        ++test_step;
-                    }
-                    else
-                    {
-                        test_step = 0;
-                    }
-                }
 
-                test_step_cv.notify_all();
-            });
+                    test_step_cv.notify_all();
+                });
 
-    // Wait for discovery.
-    writer.wait_discovery();
-    reader.wait_discovery();
+        // Wait for discovery.
+        writer.wait_discovery();
+        reader.wait_discovery();
 
-    data = default_helloworld_data_generator(9);
+        data = default_helloworld_data_generator(9);
 
-    reader.startReception(data);
-    writer.send(data, 100);
+        reader.startReception(data);
+        writer.send(data, 100);
 
-    std::unique_lock<std::mutex> lock(test_step_mtx);
-    test_step_cv.wait(lock, [&test_step]()
-            {
-                return 3 == test_step;
-            });
+        std::unique_lock<std::mutex> lock(test_step_mtx);
+        test_step_cv.wait(lock, [&test_step]()
+                {
+                    return 3 == test_step;
+                });
+    }
 }
 
 /*

--- a/test/blackbox/common/DDSBlackboxTestsMonitorService.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsMonitorService.cpp
@@ -686,6 +686,7 @@ public:
 
     unsigned int get_participants_matched()
     {
+        std::unique_lock<std::mutex> lock(mutexDiscovery_);
         return participant_matched_;
     }
 

--- a/test/blackbox/common/DDSBlackboxTestsMonitorService.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsMonitorService.cpp
@@ -183,7 +183,7 @@ public:
         return statistics_part_->disable_monitor_service();
     }
 
-    const uint32_t& get_cb_count(
+    uint32_t get_cb_count(
             CallbackIndex cb_idx)
     {
         return listener_.get_cb_count_of(cb_idx);
@@ -460,7 +460,7 @@ protected:
             std::cout << "on_sample_lost " << reader->guid() << " total_count " << status.total_count << std::endl;
         }
 
-        const uint32_t& get_cb_count_of(
+        uint32_t get_cb_count_of(
                 CallbackIndex cb_idx)
         {
             std::unique_lock<std::mutex> lock(mtx_);

--- a/test/blackbox/common/DDSBlackboxTestsMonitorService.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsMonitorService.cpp
@@ -686,7 +686,7 @@ public:
 
     unsigned int get_participants_matched()
     {
-        std::unique_lock<std::mutex> lock(mutexDiscovery_);
+        std::lock_guard<std::mutex> lock(mutexDiscovery_);
         return participant_matched_;
     }
 

--- a/test/unittest/dds/core/condition/WaitSetImplTests.cpp
+++ b/test/unittest/dds/core/condition/WaitSetImplTests.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include <algorithm>
+#include <atomic>
 #include <future>
 #include <thread>
 
@@ -35,7 +36,7 @@ class TestCondition : public Condition
 {
 public:
 
-    volatile bool trigger_value = false;
+    std::atomic<bool> trigger_value {false};
 
     bool get_trigger_value() const override
     {

--- a/test/unittest/logging/LogTests.cpp
+++ b/test/unittest/logging/LogTests.cpp
@@ -218,7 +218,7 @@ TEST_F(LogTests, validate_single_flush_call)
           the back queue will grow so large while the front one is cleared, that the test will probably timeout.
      */
 
-    bool done = false;
+    std::atomic<bool> done {false};
     int commited_before_flush = 0;
     // std::atomic<int> committed = 0; // only works on msvc and icc
     std::atomic<int> committed;
@@ -291,7 +291,7 @@ TEST_F(LogTests, validate_multithread_flush_calls)
           the back queue will grow so large while the front one is cleared, that the test will probably timeout.
      */
 
-    bool done = false;
+    std::atomic<bool> done {false};
     // std::atomic<int> committed = 0; // only works on msvc and icc
     std::atomic<int> committed;
     committed = 0;

--- a/test/unittest/transport/UDPv4Tests.cpp
+++ b/test/unittest/transport/UDPv4Tests.cpp
@@ -240,6 +240,7 @@ TEST_F(UDPv4Tests, send_and_receive_between_ports)
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
     senderThread->join();
     sem.wait();
+    msg_recv->setCallback(nullptr);
 }
 
 TEST_F(UDPv4Tests, send_to_loopback)
@@ -305,6 +306,7 @@ TEST_F(UDPv4Tests, send_to_loopback)
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
     senderThread->join();
     sem.wait();
+    msg_recv->setCallback(nullptr);
 }
 #endif // ifndef __APPLE__
 
@@ -551,6 +553,7 @@ TEST_F(UDPv4Tests, send_and_receive_between_allowed_sockets_using_localhost)
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
     senderThread->join();
     sem.wait();
+    msg_recv->setCallback(nullptr);
 }
 
 TEST_F(UDPv4Tests, send_and_receive_between_allowed_sockets_using_unicast)
@@ -617,6 +620,7 @@ TEST_F(UDPv4Tests, send_and_receive_between_allowed_sockets_using_unicast)
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
         senderThread->join();
         sem.wait();
+        msg_recv->setCallback(nullptr);
     }
 }
 
@@ -685,6 +689,7 @@ TEST_F(UDPv4Tests, send_and_receive_between_allowed_sockets_using_unicast_to_mul
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
         senderThread->join();
         sem.wait();
+        msg_recv->setCallback(nullptr);
     }
 }
 

--- a/test/unittest/transport/UDPv6Tests.cpp
+++ b/test/unittest/transport/UDPv6Tests.cpp
@@ -277,6 +277,7 @@ TEST_F(UDPv6Tests, send_and_receive_between_ports)
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
     senderThread->join();
     sem.wait();
+    msg_recv->setCallback(nullptr);
 }
 
 TEST_F(UDPv6Tests, send_to_loopback)
@@ -342,6 +343,7 @@ TEST_F(UDPv6Tests, send_to_loopback)
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
     senderThread->join();
     sem.wait();
+    msg_recv->setCallback(nullptr);
 }
 #endif // ifndef __APPLE__
 
@@ -591,6 +593,7 @@ TEST_F(UDPv6Tests, send_and_receive_between_allowed_sockets_using_localhost)
     std::this_thread::sleep_for(std::chrono::milliseconds(1));
     senderThread->join();
     sem.wait();
+    msg_recv->setCallback(nullptr);
 }
 
 TEST_F(UDPv6Tests, send_and_receive_between_allowed_sockets_using_unicast)
@@ -657,6 +660,7 @@ TEST_F(UDPv6Tests, send_and_receive_between_allowed_sockets_using_unicast)
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
         senderThread->join();
         sem.wait();
+        msg_recv->setCallback(nullptr);
     }
 }
 
@@ -724,6 +728,7 @@ TEST_F(UDPv6Tests, send_and_receive_between_allowed_sockets_using_unicast_to_mul
         std::this_thread::sleep_for(std::chrono::milliseconds(1));
         senderThread->join();
         sem.wait();
+        msg_recv->setCallback(nullptr);
     }
 }
 

--- a/test/unittest/transport/mock/MockReceiverResource.cpp
+++ b/test/unittest/transport/mock/MockReceiverResource.cpp
@@ -49,17 +49,17 @@ MockReceiverResource::~MockReceiverResource()
         Cleanup();
     }
 
-    delete msg_receiver;
+    delete msg_receiver.load();
 }
 
 MessageReceiver* MockReceiverResource::CreateMessageReceiver()
 {
-    if (msg_receiver == nullptr)
+    if (msg_receiver.load() == nullptr)
     {
-        msg_receiver = new MockMessageReceiver();
-        msg_receiver->init(1024);
+        msg_receiver.store(new MockMessageReceiver());
+        msg_receiver.load()->init(1024);
     }
-    return msg_receiver;
+    return msg_receiver.load();
 }
 
 void MockReceiverResource::OnDataReceived(
@@ -68,19 +68,21 @@ void MockReceiverResource::OnDataReceived(
         const Locator_t&,
         const Locator_t& remote)
 {
-    if (msg_receiver != nullptr)
+    MockMessageReceiver* recv = msg_receiver.load();
+    if (recv != nullptr)
     {
         CDRMessage_t msg(0);
         msg.wraps = true;
         msg.buffer = const_cast<octet*>(buf);
         msg.length = size;
-        msg_receiver->processCDRMsg(remote, &msg);
+        recv->processCDRMsg(remote, &msg);
     }
 }
 
 void MockMessageReceiver::setCallback(
         std::function<void()> cb)
 {
+    std::lock_guard<std::mutex> lock(callback_mutex);
     this->callback = cb;
 }
 
@@ -89,6 +91,7 @@ void MockMessageReceiver::processCDRMsg(
         CDRMessage_t* msg)
 {
     data = msg->buffer;
+    std::lock_guard<std::mutex> lock(callback_mutex);
     if (callback != nullptr)
     {
         callback();

--- a/test/unittest/transport/mock/MockReceiverResource.h
+++ b/test/unittest/transport/mock/MockReceiverResource.h
@@ -17,6 +17,7 @@
 
 #include <atomic>
 #include <functional>
+#include <mutex>
 
 #include <rtps/messages/MessageReceiver.h>
 #include <rtps/network/ReceiverResource.h>
@@ -64,6 +65,7 @@ public:
     void setCallback(
             std::function<void()> cb);
     std::atomic<octet*> data;
+    std::mutex callback_mutex;
     std::function<void()> callback;
 };
 

--- a/test/unittest/transport/mock/MockReceiverResource.h
+++ b/test/unittest/transport/mock/MockReceiverResource.h
@@ -15,6 +15,7 @@
 #ifndef MOCK_RECEIVER_STUFF_H
 #define MOCK_RECEIVER_STUFF_H
 
+#include <atomic>
 #include <functional>
 
 #include <rtps/messages/MessageReceiver.h>
@@ -45,7 +46,7 @@ public:
             const Locator_t& locator);
     ~MockReceiverResource();
     MessageReceiver* CreateMessageReceiver() override;
-    MockMessageReceiver* msg_receiver;
+    std::atomic<MockMessageReceiver*> msg_receiver;
 };
 
 class MockMessageReceiver : public MessageReceiver
@@ -62,7 +63,7 @@ public:
             CDRMessage_t* msg) override;
     void setCallback(
             std::function<void()> cb);
-    octet* data;
+    std::atomic<octet*> data;
     std::function<void()> callback;
 };
 


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

The goal of this PR is to solve some of the minor dataraces that appear when running under the TSAN meta. 

LocalReader datarace:

`ReaderLocator::local_reader_` was being read in `intraprocess_heartbeat` and `intraprocess_delivery` without holding the writer's mutex, while `ReaderLocator::stop()` reset it under that same mutex, causing a data race. Fixed by acquiring `mp_mutex` before calling `local_reader()` in both methods.

As this was already being reported by TSAN when running the `DDSBasic_WarningOnDelete_Test`, no new tests have been added.

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.2.x 2.14.x

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [❌] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_: Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- _N/A_: If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
