### PR TITLE
bound key material lengths in KeyMaterialCDRDeserialize

### DIFF
--- a/src/cpp/security/cryptography/AESGCMGMAC_KeyExchange.cpp
+++ b/src/cpp/security/cryptography/AESGCMGMAC_KeyExchange.cpp
@@ -140,7 +140,12 @@ bool AESGCMGMAC_KeyExchange::set_remote_participant_crypto_tokens(
     }
 
     KeyMaterial_AES_GCM_GMAC keymat;
-    KeyMaterialCDRDeserialize(keymat, &plaintext);
+    if (!KeyMaterialCDRDeserialize(keymat, &plaintext))
+    {
+        EPROSIMA_LOG_WARNING(SECURITY_CRYPTO, "Malformed CryptoToken");
+        exception = SecurityException("Malformed CryptoToken");
+        return false;
+    }
     remote_participant->RemoteParticipant2ParticipantKeyMaterial.push_back(keymat);
 
     return true;
@@ -285,7 +290,12 @@ bool AESGCMGMAC_KeyExchange::set_remote_datareader_crypto_tokens(
         }
 
         KeyMaterial_AES_GCM_GMAC keymat;
-        KeyMaterialCDRDeserialize(keymat, &plaintext);
+        if (!KeyMaterialCDRDeserialize(keymat, &plaintext))
+        {
+            EPROSIMA_LOG_WARNING(SECURITY_CRYPTO, "Malformed CryptoToken");
+            exception = SecurityException("Malformed CryptoToken");
+            return false;
+        }
         remote_reader->Entity2RemoteKeyMaterial.push_back(keymat);
 
         remote_reader_lock.unlock();
@@ -353,7 +363,12 @@ bool AESGCMGMAC_KeyExchange::set_remote_datawriter_crypto_tokens(
         }
 
         KeyMaterial_AES_GCM_GMAC keymat;
-        KeyMaterialCDRDeserialize(keymat, &plaintext);
+        if (!KeyMaterialCDRDeserialize(keymat, &plaintext))
+        {
+            EPROSIMA_LOG_WARNING(SECURITY_CRYPTO, "Malformed CryptoToken");
+            exception = SecurityException("Malformed CryptoToken");
+            return false;
+        }
 
         remote_writer->Entity2RemoteKeyMaterial.push_back(keymat);
 
@@ -457,7 +472,7 @@ std::vector<uint8_t> AESGCMGMAC_KeyExchange::KeyMaterialCDRSerialize(
     return buffer;
 }
 
-void AESGCMGMAC_KeyExchange::KeyMaterialCDRDeserialize(
+bool AESGCMGMAC_KeyExchange::KeyMaterialCDRDeserialize(
         KeyMaterial_AES_GCM_GMAC& buffer,
         std::vector<uint8_t>* CDR)
 {
@@ -466,9 +481,14 @@ void AESGCMGMAC_KeyExchange::KeyMaterialCDRDeserialize(
     buffer.master_sender_key.fill(0);
     buffer.master_receiver_specific_key.fill(0);
 
-    // transformation kind is always 0 0 0 n
-    // TODO: Check 0 values
+    const size_t cdr_size = CDR->size();
     const uint8_t* data = CDR->data();
+
+    // transformation kind is always 0 0 0 n
+    if (cdr_size < 4)
+    {
+        return false;
+    }
     uint8_t kind = data[3];
     buffer.transformation_kind[3] = kind;
     if (kind == 0)
@@ -476,57 +496,81 @@ void AESGCMGMAC_KeyExchange::KeyMaterialCDRDeserialize(
         // empty key material
         buffer.sender_key_id.fill(0);
         buffer.receiver_specific_key_id.fill(0);
+        return true;
     }
-    else
+
+    // 128 bits for kinds 1 and 2. 256 bits for kinds 3 and 4.
+    uint8_t key_len;
+    size_t pos;
+
+    // master_salt : sequence<octet,32>
+    //    seq_len would always be 0 0 0 n
+    pos = 4 + 3;  // 4 - transformation_kind. 3 - 0's
+    if (pos >= cdr_size)
     {
-        // 128 bits for kinds 1 and 2. 256 bits for kinds 3 and 4.
-        // TODO: Check desired length
-        // uint8_t desired_key_len = kind <= 2 ? 16 : 32;
-
-        uint8_t key_len;
-        uint8_t pos;
-
-        // master_salt : sequence<octet,32>
-        //    seq_len would always be 0 0 0 n
-        //    TODO: check 0 values
-        pos = 4 + 3;  // 4 - transformation_kind. 3 - 0's
-        key_len = data[pos++];
-        // TODO: check key_len
-        memcpy(buffer.master_salt.data(), &data[pos], key_len);
-        pos += key_len;
-
-        // sender_key_id : octet[4]
-        memcpy(buffer.sender_key_id.data(), &data[pos], 4);
-        pos += 4;
-
-        // master_sender_key : sequence<octet,32>
-        //    seq_len would always be 0 0 0 n
-        //    TODO: check 0 values
-        pos += 3;
-        key_len = data[pos++];
-        // TODO: check key_len
-        memcpy(buffer.master_sender_key.data(), &data[pos], key_len);
-        pos += key_len;
-
-        // receiver_specific_key_id : octet[4]
-        uint8_t has_specific_key = 0;
-        for (uint8_t i = 0; i < 4; i++)
-        {
-            buffer.receiver_specific_key_id[i] = data[pos++];
-            has_specific_key |= buffer.receiver_specific_key_id[i];
-        }
-
-        if (has_specific_key != 0)
-        {
-            // master_receiver_specific_key : sequence<octet,32>
-            //    seq_len would always be 0 0 0 n
-            //    TODO: check 0 values
-            pos += 3;
-            key_len = data[pos++];
-            // TODO: check key_len
-            memcpy(buffer.master_receiver_specific_key.data(), &data[pos], key_len);
-        }
+        return false;
     }
+    key_len = data[pos++];
+    if (static_cast<size_t>(key_len) > buffer.master_salt.size() || pos + key_len > cdr_size)
+    {
+        return false;
+    }
+    memcpy(buffer.master_salt.data(), &data[pos], key_len);
+    pos += key_len;
+
+    // sender_key_id : octet[4]
+    if (pos + 4 > cdr_size)
+    {
+        return false;
+    }
+    memcpy(buffer.sender_key_id.data(), &data[pos], 4);
+    pos += 4;
+
+    // master_sender_key : sequence<octet,32>
+    //    seq_len would always be 0 0 0 n
+    pos += 3;
+    if (pos >= cdr_size)
+    {
+        return false;
+    }
+    key_len = data[pos++];
+    if (static_cast<size_t>(key_len) > buffer.master_sender_key.size() || pos + key_len > cdr_size)
+    {
+        return false;
+    }
+    memcpy(buffer.master_sender_key.data(), &data[pos], key_len);
+    pos += key_len;
+
+    // receiver_specific_key_id : octet[4]
+    if (pos + 4 > cdr_size)
+    {
+        return false;
+    }
+    uint8_t has_specific_key = 0;
+    for (uint8_t i = 0; i < 4; i++)
+    {
+        buffer.receiver_specific_key_id[i] = data[pos++];
+        has_specific_key |= buffer.receiver_specific_key_id[i];
+    }
+
+    if (has_specific_key != 0)
+    {
+        // master_receiver_specific_key : sequence<octet,32>
+        //    seq_len would always be 0 0 0 n
+        pos += 3;
+        if (pos >= cdr_size)
+        {
+            return false;
+        }
+        key_len = data[pos++];
+        if (static_cast<size_t>(key_len) > buffer.master_receiver_specific_key.size() || pos + key_len > cdr_size)
+        {
+            return false;
+        }
+        memcpy(buffer.master_receiver_specific_key.data(), &data[pos], key_len);
+    }
+
+    return true;
 }
 
 /*

--- a/src/cpp/security/cryptography/AESGCMGMAC_KeyExchange.h
+++ b/src/cpp/security/cryptography/AESGCMGMAC_KeyExchange.h
@@ -79,7 +79,7 @@ public:
     //CDR Serialization and Deserialization of KeyMaterials
     std::vector<uint8_t> KeyMaterialCDRSerialize(
             KeyMaterial_AES_GCM_GMAC& key);
-    void KeyMaterialCDRDeserialize(
+    bool KeyMaterialCDRDeserialize(
             KeyMaterial_AES_GCM_GMAC& buffer,
             std::vector<uint8_t>* CDR);
 

--- a/test/unittest/security/cryptography/CryptographyPluginTests.hpp
+++ b/test/unittest/security/cryptography/CryptographyPluginTests.hpp
@@ -334,6 +334,26 @@ TEST_F(CryptographyPluginTest, exchange_CDRSerializenDeserialize){
     access_plugin.return_permissions_handle(&perm_handle, exception);
 }
 
+TEST_F(CryptographyPluginTest, exchange_DeserializeMalformedKeyMaterial)
+{
+    using namespace eprosima::fastdds::rtps::security;
+
+    KeyMaterial_AES_GCM_GMAC result;
+
+    // master_salt sequence length larger than the 32-byte destination array
+    std::vector<uint8_t> oversized_salt {0, 0, 0, 1, 0, 0, 0, 0xFF};
+    oversized_salt.insert(oversized_salt.end(), 300, 0x41);
+    ASSERT_FALSE(CryptoPlugin->keyexchange()->KeyMaterialCDRDeserialize(result, &oversized_salt));
+
+    // truncated token: announces a non-empty transformation kind but carries no key material
+    std::vector<uint8_t> truncated {0, 0, 0, 1};
+    ASSERT_FALSE(CryptoPlugin->keyexchange()->KeyMaterialCDRDeserialize(result, &truncated));
+
+    // well-formed empty key material is still accepted
+    std::vector<uint8_t> empty_material {0, 0, 0, 0};
+    ASSERT_TRUE(CryptoPlugin->keyexchange()->KeyMaterialCDRDeserialize(result, &empty_material));
+}
+
 TEST_F(CryptographyPluginTest, exchange_ParticipantCryptoTokens)
 {
     using namespace eprosima::fastdds::rtps::security;


### PR DESCRIPTION
## Description

`KeyMaterialCDRDeserialize` parses the `dds.cryp.keymat` binary property carried in a `CryptoToken` sent by a remote participant, so every length byte in it crosses a trust boundary.

`Repro:` join a secured domain and send a participant/datawriter/datareader `CryptoToken` whose first sequence length byte (`master_salt`) is `0xFF` followed by enough bytes.
`Cause:` each `key_len` is read straight off the wire and handed to `memcpy` into the 32-byte `std::array` members (`master_salt`, `master_sender_key`, `master_receiver_specific_key`) with no check, and the CDR buffer size is never validated before indexing, so a `key_len` up to 255 writes past the destination (ASan reports a `stack-buffer-overflow`, `WRITE of size 255`).
`Fix:` validate the available CDR size at each step and reject any `key_len` larger than its destination array, returning `false` so the three `set_remote_*_crypto_tokens` callers drop the malformed token.

The validation lives in the deserialiser itself rather than the callers, since the callers only have the opaque token bytes.

<!-- @Mergifyio backport 3.4.x 3.2.x 2.14.x -->

## Contributor Checklist

- [x] Commit messages follow the project guidelines.
- [x] The code follows the style guidelines of this project.
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- _N/A_ Any new/modified methods have been properly documented using Doxygen.
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension)
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior.
- [x] Changes are API compatible.
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation.
- [x] Applicable backports have been included in the description.
