### PR TITLE
[24612] Changes after fastcdr branch-out to 2.4.x

### DIFF
--- a/.github/workflows/reusable-mac-ci.yml
+++ b/.github/workflows/reusable-mac-ci.yml
@@ -27,7 +27,7 @@ on:
         description: 'Branch or tag of Fast CDR repository (https://github.com/eProsima/Fast-CDR)'
         required: false
         type: string
-        default: 'master'
+        default: '2.3.x'
       use-ccache:
         description: 'Use CCache to speed up the build'
         required: false

--- a/.github/workflows/reusable-mac-ci.yml
+++ b/.github/workflows/reusable-mac-ci.yml
@@ -103,6 +103,7 @@ jobs:
         with:
           remote_repository: eProsima/Fast-CDR
           fallback_branch: ${{ inputs.fastcdr_branch }}
+          skip_base: true
 
       - name: Download Fast CDR
         uses: eProsima/eProsima-CI/external/checkout@v0

--- a/.github/workflows/reusable-sanitizers-ci.yml
+++ b/.github/workflows/reusable-sanitizers-ci.yml
@@ -43,7 +43,7 @@ on:
         description: 'Branch or tag of Fast CDR repository (https://github.com/eProsima/Fast-CDR)'
         required: false
         type: string
-        default: 'master'
+        default: '2.3.x'
 
 defaults:
   run:

--- a/.github/workflows/reusable-sanitizers-ci.yml
+++ b/.github/workflows/reusable-sanitizers-ci.yml
@@ -99,6 +99,7 @@ jobs:
         with:
           remote_repository: eProsima/Fast-CDR
           fallback_branch: ${{ inputs.fastcdr_ref }}
+          skip_base: true
 
       - name: Download Fast CDR
         uses: eProsima/eProsima-CI/external/checkout@v0
@@ -288,6 +289,7 @@ jobs:
         with:
           remote_repository: eProsima/Fast-CDR
           fallback_branch: ${{ inputs.fastcdr_ref }}
+          skip_base: true
 
       - name: Download Fast CDR
         uses: eProsima/eProsima-CI/external/checkout@v0
@@ -478,6 +480,7 @@ jobs:
         with:
           remote_repository: eProsima/Fast-CDR
           fallback_branch: ${{ inputs.fastcdr_ref }}
+          skip_base: true
 
       - name: Download Fast CDR
         uses: eProsima/eProsima-CI/external/checkout@v0

--- a/.github/workflows/reusable-ubuntu-ci.yml
+++ b/.github/workflows/reusable-ubuntu-ci.yml
@@ -136,6 +136,7 @@ jobs:
         with:
           remote_repository: eProsima/Fast-CDR
           fallback_branch: ${{ inputs.fastcdr-branch }}
+          skip_base: true
 
       - name: Download Fast CDR
         uses: eProsima/eProsima-CI/external/checkout@v0

--- a/.github/workflows/reusable-ubuntu-ci.yml
+++ b/.github/workflows/reusable-ubuntu-ci.yml
@@ -31,7 +31,7 @@ on:
         description: 'Branch or tag of Fast CDR repository (https://github.com/eProsima/Fast-CDR)'
         required: false
         type: string
-        default: 'master'
+        default: '2.3.x'
       security:
         description: 'Enable security features'
         required: false

--- a/.github/workflows/reusable-windows-ci.yml
+++ b/.github/workflows/reusable-windows-ci.yml
@@ -27,7 +27,7 @@ on:
         description: 'Branch or tag of Fast CDR repository (https://github.com/eProsima/Fast-CDR)'
         required: false
         type: string
-        default: 'master'
+        default: '2.3.x'
       cmake-config:
         description: 'CMake configuration to use'
         required: false

--- a/.github/workflows/reusable-windows-ci.yml
+++ b/.github/workflows/reusable-windows-ci.yml
@@ -110,6 +110,7 @@ jobs:
         with:
           remote_repository: eProsima/Fast-CDR
           fallback_branch: ${{ inputs.fastcdr_branch }}
+          skip_base: true
 
       - name: Download Fast CDR
         uses: eProsima/eProsima-CI/external/checkout@v0

--- a/.github/workflows/weekly-ubuntu-2.14.x.yml
+++ b/.github/workflows/weekly-ubuntu-2.14.x.yml
@@ -12,7 +12,7 @@ jobs:
       matrix:
         fastcdr-branch:
           - '1.1.x'
-          - '2.x'
+          - '2.3.x'
         security:
           - true
           - false

--- a/RELEASE_SUPPORT.md
+++ b/RELEASE_SUPPORT.md
@@ -19,8 +19,7 @@ This period applies since the end of standard support date to the end of life (E
 
 |Version|Version branch|Latest Release|Release Date|End of Standard Support Date|EOL Date|
 |-------|--------------|--------------|------------|----------------------------|--------|
-|3.6|[3.6.x](https://github.com/eProsima/Fast-DDS/tree/3.6.x) (LTS)|Not yet released|March 2026|March 2027 [^*]|March 2027 [^*]|
-|3.4|[3.4.x](https://github.com/eProsima/Fast-DDS/tree/3.4.x)|[v3.4.0](https://github.com/eProsima/Fast-DDS/releases/tag/v3.4.0)|October 2025|April 2026|April 2026|
+|3.6|[3.6.x](https://github.com/eProsima/Fast-DDS/tree/3.6.x) (LTS)|[v3.6.1](https://github.com/eProsima/Fast-DDS/releases/tag/v3.6.1)|March 2026|March 2027 [^*]|March 2027 [^*]|
 |3.2|[3.2.x](https://github.com/eProsima/Fast-DDS/tree/3.2.x) (LTS)|[v3.2.3](https://github.com/eProsima/Fast-DDS/releases/tag/v3.2.3)|March 2025|March 2026 [^*]|March 2026 [^*]|
 |2.14|[2.14.x](https://github.com/eProsima/Fast-DDS/tree/2.14.x) (LTS)|[v2.14.6](https://github.com/eProsima/Fast-DDS/releases/tag/v2.14.6)|March 2024|May 2026 [^*]|May 2029 [^*]|
 |2.6|[2.6.x](https://github.com/eProsima/Fast-DDS/tree/2.6.x) (LTS)|[v2.6.11](https://github.com/eProsima/Fast-DDS/releases/tag/v2.6.11)|March 2022|July 2024|May 2027[^*]|
@@ -34,6 +33,7 @@ A detailed view of the features of each supported version is available at [Fast 
 |Version|Version branch|Latest Release|Release Date|EOL Date|
 |-------|--------------|--------------|------------|--------|
 |3.5|[3.5.x](https://github.com/eProsima/Fast-DDS/tree/3.5.x)|[v3.5.0](https://github.com/eProsima/Fast-DDS/releases/tag/v3.5.0)|February 2026|April 2026|
+|3.4|[3.4.x](https://github.com/eProsima/Fast-DDS/tree/3.4.x)|[v3.4.0](https://github.com/eProsima/Fast-DDS/releases/tag/v3.4.0)|October 2025|June 2026|
 |3.3|[3.3.x](https://github.com/eProsima/Fast-DDS/tree/3.3.x)|[v3.3.1](https://github.com/eProsima/Fast-DDS/releases/tag/v3.3.1)|July 2025|January 2026|
 |3.1|[3.1.x](https://github.com/eProsima/Fast-DDS/tree/3.1.x)|[v3.1.3](https://github.com/eProsima/Fast-DDS/releases/tag/v3.1.3)|October 2024|June 2025|
 |3.0|[3.0.x](https://github.com/eProsima/Fast-DDS/tree/3.0.x)|[v3.0.2](https://github.com/eProsima/Fast-DDS/releases/tag/v3.0.2)|August 2024|February 2025|

--- a/fastdds.repos
+++ b/fastdds.repos
@@ -6,7 +6,7 @@ repositories:
     fastcdr:
         type: git
         url: https://github.com/eProsima/Fast-CDR.git
-        version: master
+        version: 2.3.x
     fastdds:
         type: git
         url: https://github.com/eProsima/Fast-DDS.git


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This performs the necessary changes to fix Fast CDR to 2.3.x.
It also updates RELEASE_SUPPORT.md to reflect the 3.4.x EOL and the latest 3.6.x version.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.4.x 3.2.x 2.14.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- _N/A_: The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_: Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- __NO__: Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
