### PR TITLE
Fix IDL parser for scoped enum literals and leading comments

### DIFF
--- a/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/IdlGrammar.hpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/IdlGrammar.hpp
@@ -32,7 +32,7 @@ using namespace tao::TAO_PEGTL_NAMESPACE;
 struct line_comment : seq<star<space>, seq<one<'/'>, one<'/'>>, until<eolf>> {};
 struct block_comment : seq<star<space>, seq<one<'/'>, one<'*'>>, until<seq<one<'*'>, one<'/'>>>, star<space>> {};
 struct comment : sor<line_comment, block_comment> {};
-struct ws : sor<comment, plus<space>> {};
+struct ws : plus<sor<comment, plus<space>>> {};
 
 // octal digits
 struct odigit : range<'0', '7'> {};

--- a/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/IdlGrammar.hpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/IdlGrammar.hpp
@@ -307,7 +307,7 @@ struct type_declarator;
 struct typedef_dcl : seq<kw_typedef, type_declarator> {};
 struct native_dcl : seq<kw_native, simple_declarator> {};
 struct annotation_appl;
-struct enumerator : seq<star<annotation_appl>, identifier> {};
+struct enumerator : seq<star<annotation_appl>, scoped_name> {};
 struct enum_dcl : seq<kw_enum, identifier, open_brace, enumerator, star<comma, enumerator>, close_brace> {};
 struct union_forward_dcl : seq<kw_union, identifier> {};
 struct element_spec : seq<star<annotation_appl>, type_spec, declarator> {};

--- a/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/IdlParser.hpp
+++ b/src/cpp/fastdds/xtypes/dynamic_types/idl_parser/IdlParser.hpp
@@ -84,9 +84,7 @@ struct action<identifier>
             std::map<std::string, std::string>& state,
             std::vector<traits<DynamicData>::ref_type>& /*operands*/)
     {
-        auto module = ctx->modules().current();
         const std::string identifier_name = in.string();
-        const std::string scoped_identifier_name = module->create_scoped_name(identifier_name);
 
         if (state.count("enum_name"))
         {
@@ -106,19 +104,11 @@ struct action<identifier>
                     // identifier is an annotation's parameter name, and handled in action<annotation_appl_param>. Do nothing
                     return;
                 }
-                else
-                {
-                    state["enum_member_names"] +=  scoped_identifier_name + ";";
-                    if (state.count("annotation_names") && !state["annotation_names"].empty())
-                    {
-                        state["annotation_member_name"] = identifier_name;
-                        if (!ctx->annotations().update_pending_annotations(state))
-                        {
-                            EPROSIMA_LOG_ERROR(IDLPARSER, "Error annotating enum member");
-                            return;
-                        }
-                    }
-                }
+
+                // Enum literals are parsed as scoped_name, even when they are unqualified.
+                // Let action<scoped_name> consume the full token so persisted IDLs that contain
+                // fully-qualified enum literals round-trip through the parser.
+                return;
             }
         }
         else if (state.count("struct_name"))
@@ -339,6 +329,33 @@ struct action<scoped_name>
             return;
         }
 
+        if (state.count("enum_name") && !state["enum_name"].empty())
+        {
+            std::string enum_member_name = identifier_name;
+            if (identifier_name.find("::") == std::string::npos)
+            {
+                enum_member_name = module->create_scoped_name(identifier_name);
+            }
+
+            state["enum_member_names"] += enum_member_name + ";";
+
+            if (state.count("annotation_names") && !state["annotation_names"].empty())
+            {
+                const auto last_scope_separator = identifier_name.rfind("::");
+                state["annotation_member_name"] = last_scope_separator == std::string::npos ?
+                        identifier_name :
+                        identifier_name.substr(last_scope_separator + 2);
+
+                if (!ctx->annotations().update_pending_annotations(state))
+                {
+                    EPROSIMA_LOG_ERROR(IDLPARSER, "Error annotating enum member");
+                    return;
+                }
+            }
+
+            return;
+        }
+
         if (state["type"] == "sequence" && state["element_type"].empty())
         {
             // <scoped_name> is the element type of a sequence (previously declared)
@@ -349,7 +366,7 @@ struct action<scoped_name>
             return;
         }
 
-        if (state.count("enum_name") && !state["enum_name"].empty())
+        if (state.count("union_name") && !state["union_name"].empty())
         {
             if (state["union_discriminant"].empty())
             {
@@ -1616,8 +1633,10 @@ struct action<enum_dcl>
         for (size_t i = 0; i < tokens.size(); i++)
         {
             const std::string& member_name = tokens[i];
+            const auto sep = member_name.rfind("::");
+            const std::string plain_name = (sep == std::string::npos) ? member_name : member_name.substr(sep + 2);
             MemberDescriptor::_ref_type member_descriptor {traits<MemberDescriptor>::make_shared()};
-            member_descriptor->name(member_name);
+            member_descriptor->name(plain_name);
 
             if (type_descriptor->literal_type())
             {

--- a/test/feature/idl_parser/CMakeLists.txt
+++ b/test/feature/idl_parser/CMakeLists.txt
@@ -86,5 +86,6 @@ file(COPY
     ${PROJECT_SOURCE_DIR}/test/feature/idl_parser/idl_extra_cases/try_construct_annotation.idl
     ${PROJECT_SOURCE_DIR}/test/feature/idl_parser/idl_extra_cases/value_annotation.idl
     ${PROJECT_SOURCE_DIR}/test/feature/idl_parser/idl_extra_cases/default_literal_annotation.idl
+    ${PROJECT_SOURCE_DIR}/test/feature/idl_parser/idl_extra_cases/enum_in_nested_module.idl
     DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/IDL
 )

--- a/test/feature/idl_parser/CMakeLists.txt
+++ b/test/feature/idl_parser/CMakeLists.txt
@@ -87,5 +87,6 @@ file(COPY
     ${PROJECT_SOURCE_DIR}/test/feature/idl_parser/idl_extra_cases/value_annotation.idl
     ${PROJECT_SOURCE_DIR}/test/feature/idl_parser/idl_extra_cases/default_literal_annotation.idl
     ${PROJECT_SOURCE_DIR}/test/feature/idl_parser/idl_extra_cases/enum_in_nested_module.idl
+    ${PROJECT_SOURCE_DIR}/test/feature/idl_parser/idl_extra_cases/leading_comment_annotation.idl
     DESTINATION ${CMAKE_CURRENT_BINARY_DIR}/IDL
 )

--- a/test/feature/idl_parser/IdlParserTests.cpp
+++ b/test/feature/idl_parser/IdlParserTests.cpp
@@ -3115,6 +3115,24 @@ TEST_F(IdlParserTests, get_declared_type_names_w_early_stop)
     ASSERT_EQ(declared_types, expected_type_names);
 }
 
+// Regression test: enum members inside nested modules must be stored under their plain identifier
+// (e.g. "VALUE_A"), not their fully-scoped name (e.g. "outer::inner::VALUE_A").
+TEST_F(IdlParserTests, enum_in_nested_module)
+{
+    DynamicTypeBuilderFactory::_ref_type factory {DynamicTypeBuilderFactory::get_instance()};
+    std::vector<std::string> empty_include_paths;
+
+    DynamicTypeBuilder::_ref_type builder = factory->create_type_w_uri(
+        "IDL/enum_in_nested_module.idl",
+        "outer::inner::NestedEnum",
+        empty_include_paths);
+    ASSERT_TRUE(builder);
+    DynamicTypeMember::_ref_type member;
+    EXPECT_EQ(builder->get_member_by_name(member, "VALUE_A"), RETCODE_OK);
+    EXPECT_EQ(builder->get_member_by_name(member, "VALUE_B"), RETCODE_OK);
+    EXPECT_EQ(builder->get_member_by_name(member, "VALUE_C"), RETCODE_OK);
+}
+
 int main(
         int argc,
         char** argv)

--- a/test/feature/idl_parser/IdlParserTests.cpp
+++ b/test/feature/idl_parser/IdlParserTests.cpp
@@ -3133,6 +3133,23 @@ TEST_F(IdlParserTests, enum_in_nested_module)
     EXPECT_EQ(builder->get_member_by_name(member, "VALUE_C"), RETCODE_OK);
 }
 
+TEST_F(IdlParserTests, leading_comment_before_annotation)
+{
+    DynamicTypeBuilderFactory::_ref_type factory {DynamicTypeBuilderFactory::get_instance()};
+    std::vector<std::string> empty_include_paths;
+
+    DynamicTypeBuilder::_ref_type builder = factory->create_type_w_uri(
+        "IDL/leading_comment_annotation.idl",
+        "LeadingCommentIdl",
+        empty_include_paths);
+    ASSERT_TRUE(builder);
+    DynamicTypeMember::_ref_type member;
+    EXPECT_EQ(builder->get_member_by_name(member, "index"), RETCODE_OK);
+    EXPECT_EQ(builder->get_member_by_name(member, "message"), RETCODE_OK);
+    DynamicType::_ref_type type = builder->build();
+    ASSERT_TRUE(type);
+}
+
 int main(
         int argc,
         char** argv)

--- a/test/feature/idl_parser/idl_extra_cases/enum_in_nested_module.idl
+++ b/test/feature/idl_parser/idl_extra_cases/enum_in_nested_module.idl
@@ -1,0 +1,23 @@
+// Regression test IDL: enum members inside deeply-nested modules must be stored
+// under their plain identifier, not their fully-scoped name.
+module outer
+{
+    module inner
+    {
+        enum NestedEnum
+        {
+            VALUE_A,
+            VALUE_B,
+            VALUE_C
+        };
+    };
+};
+
+module outer
+{
+    @extensibility(APPENDABLE)
+    struct NestedEnumStruct
+    {
+        outer::inner::NestedEnum value;
+    };
+};

--- a/test/feature/idl_parser/idl_extra_cases/leading_comment_annotation.idl
+++ b/test/feature/idl_parser/idl_extra_cases/leading_comment_annotation.idl
@@ -1,0 +1,9 @@
+// Regenerate Fast DDS type support from this directory with:
+//   fastddsgen -d . LeadingCommentIdl.idl
+
+@final
+struct LeadingCommentIdl
+{
+    unsigned long index;
+    string message;
+};


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->
The IDL parser only accepted bare identifiers as enum members, so persisted IDL files containing fully-qualified enum literals failed to parse.

This changes the grammar to accept `scoped_name` for enumerators and updates the parser to handle qualified literals. Enum members are still registered under their unqualified name, so existing behavior is unchanged.

Added a test covering an enum in a large nested module.

While investigating, we found a related failure in the same parser: it rejects a file when a comment is followed by whitespace (e.g. a blank line) and then an annotation (such as `@final`).

A regression test has also been added to cover this issue.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.4.x 3.2.x 2.14.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [ ] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [ ] Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [ ] New feature has been added to the `versions.md` file (if applicable).
- [ ] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [ ] Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
