### PR TITLE
cross compile error

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -109,7 +109,7 @@ endif()
 include(${PROJECT_SOURCE_DIR}/cmake/common/check_configuration.cmake)
 
 set(FORCE_CXX "11" CACHE STRING "C++ standard fulfillment selection")
-check_stdcxx(${FORCE_CXX})
+check_stdcxx(${FORCE_CXX} run_fallback_test)
 
 check_endianness()
 

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -14,7 +14,7 @@
 
 # Require C++ 14 for testing as both GTest v1.14.0 and ROS 2 Jazzy require it anyways
 set(FORCE_CXX "14")
-check_stdcxx(${FORCE_CXX})
+check_stdcxx(${FORCE_CXX} run_fallback_test)
 
 option(PERFORMANCE_TESTS "Activate the building and execution of performance tests" OFF)
 option(SYSTEM_TESTS "Activate the building and execution of system tests" OFF)


### PR DESCRIPTION
modify cmake file

>check_stdcxx(${FORCE_CXX})

changed to

>check_stdcxx(${FORCE_CXX} run_fallback_test)

## Description

cross compile error, the error is: 
```
-- Version: 3.6.1.0
CMake Error at cmake/common/check_configuration.cmake:38 (message):
  The specified C++ cxx_std_11 feature is not supported using default
  compiler.
Call Stack (most recent call first):
  cmake/common/check_configuration.cmake:105 (get_set_stdcxx)
  CMakeLists.txt:112 (check_stdcxx)
-- Configuring incomplete, errors occurred!
```
the cross compiler: /opt/vs-linux/x86-arm/arm-gnu-toolchain-12.2.rel1-x86_64-aarch64-none-linux-gnu/bin/aarch64-none-linux-gnu-g++, ar, ld, and so on
