### PR TITLE
[25442] Make `skip-ci` label report required statuses as pass

### DIFF
--- a/.github/workflows/mac-ci.yml
+++ b/.github/workflows/mac-ci.yml
@@ -48,10 +48,7 @@ concurrency:
 
 jobs:
   mac-ci:
-    if: ${{ (
-              !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
-              !contains(github.event.pull_request.labels.*.name, 'conflicts')
-            ) }}
+    if: ${{ !(github.event_name == 'pull_request') || !contains(github.event.pull_request.labels.*.name, 'conflicts') }}
     uses: ./.github/workflows/reusable-mac-ci.yml
     with:
       label: ${{ inputs.label || 'mac-ci' }}
@@ -60,4 +57,5 @@ jobs:
       ctest-args: ${{ inputs.ctest-args }}
       fastdds-branch: ${{ inputs.fastdds_branch || github.ref || 'master' }}
       use-ccache: ${{ ((inputs.use-ccache == true) && true) || false }}
-      run-tests: ${{ ((inputs.run-tests == true) && true) || (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'no-test')) }}
+      run-build: ${{ !(github.event_name == 'pull_request') || !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
+      run-tests: ${{ ((inputs.run-tests == true) && true) || (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'no-test') && !contains(github.event.pull_request.labels.*.name, 'skip-ci')) }}

--- a/.github/workflows/mac-ci.yml
+++ b/.github/workflows/mac-ci.yml
@@ -57,5 +57,11 @@ jobs:
       ctest-args: ${{ inputs.ctest-args }}
       fastdds-branch: ${{ inputs.fastdds_branch || github.ref || 'master' }}
       use-ccache: ${{ ((inputs.use-ccache == true) && true) || false }}
-      run-build: ${{ !(github.event_name == 'pull_request') || !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
-      run-tests: ${{ ((inputs.run-tests == true) && true) || (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'no-test') && !contains(github.event.pull_request.labels.*.name, 'skip-ci')) }}
+      run-build: ${{ !(github.event_name == 'pull_request') ||
+                     !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
+      run-tests: ${{ (inputs.run-tests == true) ||
+                     (
+                       (github.event_name == 'pull_request') &&
+                       (!contains(github.event.pull_request.labels.*.name, 'no-test')) &&
+                       (!contains(github.event.pull_request.labels.*.name, 'skip-ci'))
+                     ) }}

--- a/.github/workflows/reusable-mac-ci.yml
+++ b/.github/workflows/reusable-mac-ci.yml
@@ -33,6 +33,11 @@ on:
         required: false
         type: boolean
         default: false
+      run-build:
+        description: 'Build Fast DDS (CI skipped otherwise)'
+        required: false
+        type: boolean
+        default: true
       run-tests:
         description: 'Run test suite of Fast DDS'
         required: false
@@ -56,6 +61,7 @@ jobs:
           - 'RelWithDebInfo'
     steps:
       - name: Sync eProsima/Fast-DDS repository
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/external/checkout@v0
         with:
           path: src/fastdds
@@ -63,16 +69,19 @@ jobs:
           ref: ${{ inputs.fastdds-branch }}
 
       - name: Install Fix Python version
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/external/setup-python@v0
         with:
           python-version: '3.11'
 
       - name: Get minimum supported version of CMake
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/external/get-cmake@v0
         with:
           cmakeVersion: '3.28.6'
 
       - name: Install brew dependencies
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/macos/install_brew_packages@v0
         with:
           packages: llvm tinyxml2 openssl@3.0
@@ -80,17 +89,19 @@ jobs:
           upgrade: false
 
       - name: Install colcon
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/macos/install_colcon@v0
 
       - name: Install Python dependencies
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/macos/install_python_packages@v0
         with:
           packages: vcstool xmlschema psutil
           upgrade: false
 
       - name: Setup CCache
+        if: ${{ inputs.run-build == true && inputs.use-ccache == true }}
         uses: eProsima/eProsima-CI/external/setup-ccache-action@v0
-        if: ${{ inputs.use-ccache == true }}
         with:
           api_token: ${{ secrets.GITHUB_TOKEN }}
 
@@ -99,6 +110,7 @@ jobs:
 
       - name: Get Fast CDR branch
         id: get_fastcdr_branch
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/ubuntu/get_related_branch_from_repo@v0
         with:
           remote_repository: eProsima/Fast-CDR
@@ -107,12 +119,14 @@ jobs:
 
       - name: Download Fast CDR
         uses: eProsima/eProsima-CI/external/checkout@v0
+        if: ${{ inputs.run-build == true }}
         with:
           repository: eProsima/Fast-CDR
           path: ${{ github.workspace }}/src/fastcdr
           ref: ${{ steps.get_fastcdr_branch.outputs.deduced_branch }}
 
       - name: Fetch Fast DDS dependencies
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/ubuntu/vcs_import@v0
         with:
           vcs_repos_file: ${{ github.workspace }}/src/fastdds/fastdds.repos
@@ -120,6 +134,7 @@ jobs:
           skip_existing: 'true'
 
       - name: Fetch Fast DDS CI dependencies
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/ubuntu/vcs_import@v0
         with:
           vcs_repos_file: ${{ github.workspace }}/src/fastdds/.github/workflows/config/fastdds_test.repos
@@ -132,6 +147,7 @@ jobs:
       #   - Not working solution: https://github.com/macports/macports-ports/pull/21839/files
       - name: Colcon build
         continue-on-error: false
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/ubuntu/colcon_build@v0
         with:
           colcon_meta_file: ${{ github.workspace }}/src/fastdds/.github/workflows/config/fastdds_build.meta ${{ github.workspace }}/src/fastdds/.github/workflows/config/fastdds_test.meta
@@ -142,7 +158,7 @@ jobs:
           workspace: ${{ github.workspace }}
 
       - name: Upload build artifacts
-        if: ${{ inputs.run-tests == true }}
+        if: ${{ inputs.run-build == true && inputs.run-tests == true }}
         uses: eProsima/eProsima-CI/external/upload-artifact@v0
         with:
           name: fastdds_build_${{ inputs.label }}
@@ -216,8 +232,8 @@ jobs:
           sudo echo "ff1e::ffff:efff:1 acme.org.test" | sudo tee -a /etc/hosts
 
       - name: Colcon test
-        if: ${{ inputs.run-tests == true }}
         id: test
+        if: ${{ inputs.run-tests == true }}
         uses: eProsima/eProsima-CI/ubuntu/colcon_test@v0
         with:
           colcon_meta_file: ${{ github.workspace }}/src/fastdds/.github/workflows/config/fastdds_test.meta

--- a/.github/workflows/reusable-ubuntu-ci.yml
+++ b/.github/workflows/reusable-ubuntu-ci.yml
@@ -73,7 +73,6 @@ defaults:
 jobs:
   fastdds_build:
     runs-on: ${{ inputs.os-image }}
-    if: ${{ inputs.run-build == true }}
     strategy:
       fail-fast: false
       matrix:
@@ -89,9 +88,11 @@ jobs:
           repo: eProsima/Fast-DDS
 
       - name: Free disk space
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/ubuntu/free_disk_space@v0
 
       - name: Sync eProsima/Fast-DDS repository
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/external/checkout@v0
         with:
           path: src/fastdds
@@ -99,16 +100,19 @@ jobs:
           ref: ${{ inputs.fastdds-branch }}
 
       - name: Install Fix Python version
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/external/setup-python@v0
         with:
           python-version: '3.11'
 
       - name: Get minimum supported version of CMake
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/external/get-cmake@v0
         with:
           cmakeVersion: '3.28.6'
 
       - name: Install apt dependencies
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/ubuntu/install_apt_packages@v0
         with:
           packages: libasio-dev libtinyxml2-dev libssl-dev
@@ -116,9 +120,11 @@ jobs:
           upgrade: false
 
       - name: Install colcon
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/ubuntu/install_colcon@v0
 
       - name: Install Python dependencies
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/ubuntu/install_python_packages@v0
         with:
           packages: vcstool xmlschema
@@ -126,12 +132,13 @@ jobs:
 
       - name: Setup CCache
         uses: eProsima/eProsima-CI/external/setup-ccache-action@v0
-        if: ${{ inputs.use-ccache == true }}
+        if: ${{ inputs.run-build == true && inputs.use-ccache == true }}
         with:
           api_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get Fast CDR branch
         id: get_fastcdr_branch
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/ubuntu/get_related_branch_from_repo@v0
         with:
           remote_repository: eProsima/Fast-CDR
@@ -139,6 +146,7 @@ jobs:
           skip_base: true
 
       - name: Download Fast CDR
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/external/checkout@v0
         with:
           repository: eProsima/Fast-CDR
@@ -146,6 +154,7 @@ jobs:
           ref: ${{ steps.get_fastcdr_branch.outputs.deduced_branch }}
 
       - name: Fetch Fast DDS dependencies
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/ubuntu/vcs_import@v0
         with:
           vcs_repos_file: ${{ github.workspace }}/src/fastdds/fastdds.repos
@@ -157,6 +166,7 @@ jobs:
       # we disable the compilation of the tools here and enable it in the Fast DDS test job.
       - name: Colcon build
         continue-on-error: false
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/ubuntu/colcon_build@v0
         with:
           colcon_meta_file: ${{ github.workspace }}/src/fastdds/.github/workflows/config/fastdds_build.meta
@@ -167,6 +177,7 @@ jobs:
           workspace: ${{ github.workspace }}
 
       - name: Upload build artifacts
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/external/upload-artifact@v0
         with:
           name: fastdds_build_${{ inputs.label }}
@@ -175,7 +186,6 @@ jobs:
   fastdds_test:
     needs: fastdds_build
     runs-on: ${{ inputs.os-image }}
-    if: ${{ inputs.run-tests == true }}
     strategy:
       fail-fast: false
       matrix:
@@ -183,44 +193,52 @@ jobs:
           - 'RelWithDebInfo'
     steps:
       - name: Free disk space
+        if: ${{ inputs.run-tests == true }}
         uses: eProsima/eProsima-CI/ubuntu/free_disk_space@v0
 
       - name: Download build artifacts
+        if: ${{ inputs.run-tests == true }}
         uses: eProsima/eProsima-CI/external/download-artifact@v0
         with:
           name: fastdds_build_${{ inputs.label }}
           path: ${{ github.workspace }}
 
       - name: Install Fix Python version
+        if: ${{ inputs.run-tests == true }}
         uses: eProsima/eProsima-CI/external/setup-python@v0
         with:
           python-version: '3.11'
 
       - name: Get minimum supported version of CMake
+        if: ${{ inputs.run-tests == true }}
         uses: eProsima/eProsima-CI/external/get-cmake@v0
         with:
           cmakeVersion: '3.28.6'
 
       - name: Install apt packages
+        if: ${{ inputs.run-tests == true }}
         uses: eProsima/eProsima-CI/ubuntu/install_apt_packages@v0
         with:
           packages: libasio-dev libtinyxml2-dev libssl-dev
 
       - name: Install colcon
+        if: ${{ inputs.run-tests == true }}
         uses: eProsima/eProsima-CI/ubuntu/install_colcon@v0
 
       - name: Install Python dependencies
+        if: ${{ inputs.run-tests == true }}
         uses: eProsima/eProsima-CI/ubuntu/install_python_packages@v0
         with:
           packages: vcstool xmlschema psutil
 
       - name: Setup CCache
+        if: ${{ inputs.run-tests == true && inputs.use-ccache == true }}
         uses: eProsima/eProsima-CI/external/setup-ccache-action@v0
-        if: ${{ inputs.use-ccache == true }}
         with:
           api_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Set up hosts file for DNS testing
+        if: ${{ inputs.run-tests == true }}
         run: |
           sudo echo "" | sudo tee -a /etc/hosts
           sudo echo "127.0.0.1 localhost.test" | sudo tee -a /etc/hosts
@@ -236,6 +254,7 @@ jobs:
       #                which entails logout/login or rebooting the machine. This is not feasible in a CI environment.
 
       - name: Fetch Fast DDS CI dependencies
+        if: ${{ inputs.run-tests == true }}
         uses: eProsima/eProsima-CI/ubuntu/vcs_import@v0
         with:
           vcs_repos_file: ${{ github.workspace }}/src/fastdds/.github/workflows/config/fastdds_test.repos
@@ -244,6 +263,7 @@ jobs:
 
       - name: Colcon build
         continue-on-error: false
+        if: ${{ inputs.run-tests == true }}
         uses: eProsima/eProsima-CI/ubuntu/colcon_build@v0
         with:
           colcon_meta_file: ${{ github.workspace }}/src/fastdds/.github/workflows/config/fastdds_build.meta ${{ github.workspace }}/src/fastdds/.github/workflows/config/fastdds_test.meta
@@ -255,6 +275,7 @@ jobs:
 
       - name: Colcon test
         id: test
+        if: ${{ inputs.run-tests == true }}
         uses: eProsima/eProsima-CI/ubuntu/colcon_test@v0
         with:
           colcon_meta_file: ${{ github.workspace }}/src/fastdds/.github/workflows/config/fastdds_test.meta
@@ -267,7 +288,7 @@ jobs:
 
       - name: Fast DDS test summary
         uses: eProsima/eProsima-CI/ubuntu/junit_summary@v0
-        if: ${{ !cancelled() }}
+        if: ${{ !cancelled() && inputs.run-tests == true }}
         with:
           junit_reports_dir: "${{ steps.test.outputs.ctest_results_path }}"
           print_summary: 'True'
@@ -286,30 +307,36 @@ jobs:
           - 'RelWithDebInfo'
     steps:
       - name: Free disk space
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/ubuntu/free_disk_space@v0
 
       - name: Download build artifacts
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/external/download-artifact@v0
         with:
           name: fastdds_build_${{ inputs.label }}
           path: ${{ github.workspace }}
 
       - name: Install Fix Python version
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/external/setup-python@v0
         with:
           python-version: '3.11'
 
       - name: Get minimum supported version of CMake
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/external/get-cmake@v0
         with:
           cmakeVersion: '3.28.6'
 
       - name: Install apt packages
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/ubuntu/install_apt_packages@v0
         with:
           packages: libasio-dev libtinyxml2-dev libssl-dev swig4.1
 
       - name: Install and configure SWIG test
+        if: ${{ inputs.run-build == true }}
         run: |
           sudo apt-get install -y swig4.1
           sudo update-alternatives --install /usr/bin/swig swig /usr/bin/swig4.1 100
@@ -317,27 +344,31 @@ jobs:
           swig -version
 
       - name: Install colcon
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/ubuntu/install_colcon@v0
 
       - name: Install Python dependencies
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/ubuntu/install_python_packages@v0
         with:
           packages: xmlschema
 
       - name: Setup CCache
+        if: ${{ inputs.run-build == true && inputs.use-ccache == true }}
         uses: eProsima/eProsima-CI/external/setup-ccache-action@v0
-        if: ${{ inputs.use-ccache == true }}
         with:
           api_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get Fast DDS Python branch
         id: get_fastdds_python_branch
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/ubuntu/get_related_branch_from_repo@v0
         with:
           remote_repository: eProsima/Fast-DDS-python
           fallback_branch: ${{ env.fastdds-python-branch }}
 
       - name: Download Fast DDS Python repo
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/external/checkout@v0
         with:
           repository: eProsima/Fast-DDS-python
@@ -346,6 +377,7 @@ jobs:
 
       - name: Colcon build
         continue-on-error: false
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/ubuntu/colcon_build@v0
         with:
           colcon_meta_file: ${{ github.workspace }}/src/fastdds/.github/workflows/config/fastdds_build.meta
@@ -357,6 +389,7 @@ jobs:
           workspace: ${{ github.workspace }}
 
       - name: Upload python build artifacts
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/external/upload-artifact@v0
         with:
           name: fastdds_python_build_${{ inputs.label }}
@@ -365,7 +398,7 @@ jobs:
   fastdds_python_test:
     needs: fastdds_python_build
     runs-on: ${{ inputs.os-image }}
-    if: ${{ inputs.security == true && inputs.run-tests == true }}
+    if: ${{ inputs.security == true }}
     strategy:
       fail-fast: false
       matrix:
@@ -373,44 +406,53 @@ jobs:
           - 'RelWithDebInfo'
     steps:
       - name: Free disk space
+        if: ${{ inputs.run-tests == true }}
         uses: eProsima/eProsima-CI/ubuntu/free_disk_space@v0
 
       - name: Download python build artifacts
+        if: ${{ inputs.run-tests == true }}
         uses: eProsima/eProsima-CI/external/download-artifact@v0
         with:
           name: fastdds_python_build_${{ inputs.label }}
           path: ${{ github.workspace }}
 
       - name: Install Fix Python version
+        if: ${{ inputs.run-tests == true }}
         uses: eProsima/eProsima-CI/external/setup-python@v0
         with:
           python-version: '3.11'
 
       - name: Get minimum supported version of CMake
+        if: ${{ inputs.run-tests == true }}
         uses: eProsima/eProsima-CI/external/get-cmake@v0
         with:
           cmakeVersion: '3.28.6'
 
       - name: Install apt packages
+        if: ${{ inputs.run-tests == true }}
         uses: eProsima/eProsima-CI/ubuntu/install_apt_packages@v0
         with:
           packages: libasio-dev libtinyxml2-dev libssl-dev swig4.1
 
       - name: Install and configure SWIG test
+        if: ${{ inputs.run-tests == true }}
         run: |
           sudo update-alternatives --install /usr/bin/swig swig /usr/bin/swig4.1 100
           sudo update-alternatives --set swig /usr/bin/swig4.1
           swig -version
 
       - name: Install colcon
+        if: ${{ inputs.run-tests == true }}
         uses: eProsima/eProsima-CI/ubuntu/install_colcon@v0
 
       - name: Install Python dependencies
+        if: ${{ inputs.run-tests == true }}
         uses: eProsima/eProsima-CI/ubuntu/install_python_packages@v0
         with:
           packages: vcstool xmlschema
 
       - name: Fetch Fast DDS CI dependencies
+        if: ${{ inputs.run-tests == true }}
         uses: eProsima/eProsima-CI/ubuntu/vcs_import@v0
         with:
           vcs_repos_file: ${{ github.workspace }}/src/fastdds/.github/workflows/config/fastdds_test.repos
@@ -418,13 +460,14 @@ jobs:
           skip_existing: 'true'
 
       - name: Setup CCache
+        if: ${{ inputs.run-tests == true && inputs.use-ccache == true }}
         uses: eProsima/eProsima-CI/external/setup-ccache-action@v0
-        if: ${{ inputs.use-ccache == true }}
         with:
           api_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Colcon build
         continue-on-error: false
+        if: ${{ inputs.run-tests == true }}
         uses: eProsima/eProsima-CI/ubuntu/colcon_build@v0
         with:
           colcon_meta_file: ${{ github.workspace }}/src/fastdds/.github/workflows/config/fastdds_build.meta ${{ github.workspace }}/src/fastdds/.github/workflows/config/python_test.meta
@@ -436,6 +479,7 @@ jobs:
 
       - name: Colcon test
         id: python_test
+        if: ${{ inputs.run-tests == true }}
         uses: eProsima/eProsima-CI/ubuntu/colcon_test@v0
         with:
           colcon_meta_file: ${{ github.workspace }}/src/fastdds/.github/workflows/config/python_test.meta
@@ -448,8 +492,8 @@ jobs:
           test_report_artifact: ${{ format('test_report_{0}_{1}_{2}', inputs.label, github.job, join(matrix.*, '_')) }}
 
       - name: Fast DDS Python test summary
+        if: ${{ !cancelled() && inputs.run-tests == true }}
         uses: eProsima/eProsima-CI/ubuntu/junit_summary@v0
-        if: ${{ !cancelled() }}
         with:
           junit_reports_dir: "${{ steps.python_test.outputs.ctest_results_path }}"
           print_summary: 'True'
@@ -468,57 +512,67 @@ jobs:
           - 'RelWithDebInfo'
     steps:
       - name: Free disk space
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/ubuntu/free_disk_space@v0
 
       - name: Download python build artifacts
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/external/download-artifact@v0
         with:
           name: fastdds_python_build_${{ inputs.label }}
           path: ${{ github.workspace }}
 
       - name: Install Fix Python version
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/external/setup-python@v0
         with:
           python-version: '3.11'
 
       - name: Get minimum supported version of CMake
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/external/get-cmake@v0
         with:
           cmakeVersion: '3.28.6'
 
       - name: Install apt packages
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/ubuntu/install_apt_packages@v0
         with:
           packages: libasio-dev libtinyxml2-dev libssl-dev swig4.1 doxygen imagemagick plantuml libenchant-2-2
 
       - name: Install and configure SWIG test
+        if: ${{ inputs.run-build == true }}
         run: |
           sudo update-alternatives --install /usr/bin/swig swig /usr/bin/swig4.1 100
           sudo update-alternatives --set swig /usr/bin/swig4.1
           swig -version
 
       - name: Install colcon
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/ubuntu/install_colcon@v0
 
       - name: Install Python dependencies
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/ubuntu/install_python_packages@v0
         with:
           packages: vcstool xmlschema psutil
 
       - name: Setup CCache
+        if: ${{ inputs.run-build == true && inputs.use-ccache == true }}
         uses: eProsima/eProsima-CI/external/setup-ccache-action@v0
-        if: ${{ inputs.use-ccache == true }}
         with:
           api_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Get Fast DDS Docs branch
         id: get_fastdds_docs_branch
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/ubuntu/get_related_branch_from_repo@v0
         with:
           remote_repository: eProsima/Fast-DDS-docs
           fallback_branch: ${{ env.fastdds-docs-branch }}
 
       - name: Download Fast DDS documentation repo
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/external/checkout@v0
         with:
           repository: eProsima/Fast-DDS-docs
@@ -534,6 +588,7 @@ jobs:
           skip_existing: 'true'
 
       - name: Install Fast DDS Docs required python packages
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/ubuntu/install_python_packages@v0
         with:
           upgrade: false
@@ -541,6 +596,7 @@ jobs:
 
       - name: Colcon build
         continue-on-error: false
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/ubuntu/colcon_build@v0
         with:
           colcon_meta_file: ${{ github.workspace }}/src/fastdds/.github/workflows/config/fastdds_build.meta ${{ github.workspace }}/src/fastdds/.github/workflows/config/documentation.meta
@@ -584,52 +640,61 @@ jobs:
           - 'RelWithDebInfo'
     steps:
       - name: Free disk space
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/ubuntu/free_disk_space@v0
 
       - name: Download build artifacts
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/external/download-artifact@v0
         with:
           name: fastdds_build_${{ inputs.label }}
           path: ${{ github.workspace }}
 
       - name: Install Fix Python version
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/external/setup-python@v0
         with:
           python-version: '3.11'
 
       - name: Get minimum supported version of CMake
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/external/get-cmake@v0
         with:
           cmakeVersion: '3.28.6'
 
       - name: Install apt packages
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/ubuntu/install_apt_packages@v0
         with:
           packages: libasio-dev libtinyxml2-dev libssl-dev
 
       - name: Install colcon
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/ubuntu/install_colcon@v0
 
       - name: Install Python dependencies
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/ubuntu/install_python_packages@v0
         with:
           packages: xmlschema
 
       - name: Setup CCache
+        if: ${{ inputs.run-build == true && inputs.use-ccache == true }}
         uses: eProsima/eProsima-CI/external/setup-ccache-action@v0
-        if: ${{ inputs.use-ccache == true }}
         with:
           api_token: ${{ secrets.GITHUB_TOKEN }}
 
       # Get Shapes Demo to make sure it keeps compiling
       - name: Get Shapes Demo branch
         id: get_shapes_demo_branch
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/ubuntu/get_related_branch_from_repo@v0
         with:
           remote_repository: eProsima/ShapesDemo
           fallback_branch: ${{ env.shapes-demo-branch }}
 
       - name: Download Shapes Demo repo
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/external/checkout@v0
         with:
           repository: eProsima/ShapesDemo
@@ -640,6 +705,7 @@ jobs:
       # Do not setup python as it will internally modify the pythonLocation env variable
       # and we want to use a fix version
       - name: Install Qt
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/external/install_qt@v0
         with:
           version: '6.8.3'
@@ -649,6 +715,7 @@ jobs:
           setup-python: 'false'
 
       - name: Colcon build
+        if: ${{ inputs.run-build == true }}
         continue-on-error: false
         uses: eProsima/eProsima-CI/ubuntu/colcon_build@v0
         with:
@@ -669,25 +736,30 @@ jobs:
           - 'RelWithDebInfo'
     steps:
       - name: Free disk space
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/ubuntu/free_disk_space@v0
 
       - name: Download build artifacts
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/external/download-artifact@v0
         with:
           name: fastdds_build_${{ inputs.label }}
           path: ${{ github.workspace }}
 
       - name: Install Fix Python version
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/external/setup-python@v0
         with:
           python-version: '3.11'
 
       - name: Get minimum supported version of CMake
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/external/get-cmake@v0
         with:
           cmakeVersion: '3.28.6'
 
       - name: Install apt dependencies
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/ubuntu/install_apt_packages@v0
         with:
           packages: libasio-dev libtinyxml2-dev libssl-dev
@@ -695,21 +767,24 @@ jobs:
           upgrade: false
 
       - name: Install colcon
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/ubuntu/install_colcon@v0
 
       - name: Install Python dependencies
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/ubuntu/install_python_packages@v0
         with:
           packages: vcstool xmlschema msparser
           upgrade: false
 
       - name: Setup CCache
+        if: ${{ inputs.run-build == true && inputs.use-ccache == true }}
         uses: eProsima/eProsima-CI/external/setup-ccache-action@v0
-        if: ${{ inputs.use-ccache == true }}
         with:
           api_token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Sync osrf/osrf_testing_tools_cpp repository
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/external/checkout@v0
         with:
           repository: osrf/osrf_testing_tools_cpp
@@ -717,6 +792,7 @@ jobs:
           ref: 2.3.0
 
       - name: OSRF testing tools build
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/ubuntu/colcon_build@v0
         with:
           colcon_meta_file: ''
@@ -727,6 +803,7 @@ jobs:
           workspace: ${{ github.workspace }}
 
       - name: Profilling tests build
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/ubuntu/colcon_build@v0
         with:
           colcon_meta_file: ${{ github.workspace }}/src/fastdds/.github/workflows/config/fastdds_build.meta
@@ -738,12 +815,14 @@ jobs:
           workspace_dependencies: ${{ github.workspace }}/install
 
       - name: Clean workspace - Profiling tests
+        if: ${{ inputs.run-build == true }}
         run: |
           cd ${{ github.workspace }}
           rm -rf build install log src/osrf_testing_tools_cpp
 
       - name: No security colcon build
         continue-on-error: false
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/ubuntu/colcon_build@v0
         with:
           colcon_meta_file: ${{ github.workspace }}/src/fastdds/.github/workflows/config/fastdds_build.meta
@@ -754,11 +833,13 @@ jobs:
           workspace: ${{ github.workspace }}
 
       - name: Clean workspace - No security
+        if: ${{ inputs.run-build == true }}
         run: |
           cd ${{ github.workspace }}
           rm -rf build install log
 
       - name: No statistics colcon build
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/ubuntu/colcon_build@v0
         with:
           colcon_meta_file: ${{ github.workspace }}/src/fastdds/.github/workflows/config/fastdds_build.meta
@@ -769,12 +850,14 @@ jobs:
           workspace: ${{ github.workspace }}
 
       - name: Clean workspace - No statistics
+        if: ${{ inputs.run-build == true }}
         run: |
           cd ${{ github.workspace }}
           rm -rf build install log
 
       # No .metas file, so FASTDDS_ENFORCE_LOG_INFO is set OFF by default. Missed important args are manually included
       - name: No enforcing log info colcon build
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/ubuntu/colcon_build@v0
         with:
           colcon_meta_file: ''
@@ -785,11 +868,13 @@ jobs:
           workspace: ${{ github.workspace }}
 
       - name: Clean workspace - No enforce log info
+        if: ${{ inputs.run-build == true }}
         run: |
           cd ${{ github.workspace }}
           rm -rf build install log
 
       - name: No shared libs colcon build
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/ubuntu/colcon_build@v0
         with:
           colcon_meta_file: ${{ github.workspace }}/src/fastdds/.github/workflows/config/fastdds_build.meta
@@ -800,11 +885,13 @@ jobs:
           workspace: ${{ github.workspace }}
 
       - name: Clean workspace - No shared libs
+        if: ${{ inputs.run-build == true }}
         run: |
           cd ${{ github.workspace }}
           rm -rf build install log
 
       - name: Null dereference colcon build
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/ubuntu/colcon_build@v0
         with:
           colcon_meta_file: ${{ github.workspace }}/src/fastdds/.github/workflows/config/fastdds_build.meta
@@ -816,22 +903,26 @@ jobs:
           workspace: ${{ github.workspace }}
 
       - name: Clean workspace - No shared libs
+        if: ${{ inputs.run-build == true }}
         run: |
           cd ${{ github.workspace }}
           rm -rf build install log
 
       - name: Vanilla colcon build
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/ubuntu/colcon_build@v0
         with:
           cmake_build_type: ${{ matrix.cmake-build-type }}
           workspace: ${{ github.workspace }}
 
       - name: Clean workspace - Vanilla build
+        if: ${{ inputs.run-build == true }}
         run: |
           cd ${{ github.workspace }}
           rm -rf build install log
 
       - name: No TLS colcon build
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/ubuntu/colcon_build@v0
         with:
           colcon_meta_file: ${{ github.workspace }}/src/fastdds/.github/workflows/config/fastdds_build.meta
@@ -842,11 +933,13 @@ jobs:
           workspace: ${{ github.workspace }}
 
       - name: Clean workspace - No TLS
+        if: ${{ inputs.run-build == true }}
         run: |
           cd ${{ github.workspace }}
           rm -rf build install log
 
       - name: GCC latest colcon build
+        if: ${{ inputs.run-build == true }}
         run: |
           cd ${{ github.workspace }}/src/fastdds/.github/workflows/docker/ubuntu/alternative_builds
           docker build -t fastdds_gcc_latest -f fastdds_gcc_latest.Dockerfile .

--- a/.github/workflows/reusable-windows-ci.yml
+++ b/.github/workflows/reusable-windows-ci.yml
@@ -33,6 +33,11 @@ on:
         required: false
         type: string
         default: 'RelWithDebInfo'
+      run-build:
+        description: 'Build Fast DDS (CI skipped otherwise)'
+        required: false
+        type: boolean
+        default: true
       run-tests:
         description: 'Run test suite of Fast DDS'
         required: false
@@ -54,6 +59,7 @@ jobs:
           - 'v143'
     steps:
       - name: Sync eProsima/Fast-DDS repository
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/external/checkout@v0
         with:
           path: src/fastdds
@@ -61,21 +67,25 @@ jobs:
           ref: ${{ inputs.fastdds_branch }}
 
       - name: Install Fix Python version
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/external/setup-python@v0
         with:
           python-version: '3.11'
 
       - name: Get minimum supported version of CMake
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/external/get-cmake@v0
         with:
           cmakeVersion: '3.28.6'
 
       - name: Install OpenSSL
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eprosima-CI/windows/install_openssl@v0
         with:
           version: '3.1.1'
 
       - name: Update OpenSSL environment variables
+        if: ${{ inputs.run-build == true }}
         run: |
           # Update the environment
           if (Test-Path -Path $Env:ProgramW6432\OpenSSL)
@@ -97,15 +107,18 @@ jobs:
           }
 
       - name: Install colcon
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/windows/install_colcon@v0
 
       - name: Install Python dependencies
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/windows/install_python_packages@v0
         with:
           packages: vcstool xmlschema psutil
 
       - name: Get Fast CDR branch
         id: get_fastcdr_branch
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/ubuntu/get_related_branch_from_repo@v0
         with:
           remote_repository: eProsima/Fast-CDR
@@ -113,6 +126,7 @@ jobs:
           skip_base: true
 
       - name: Download Fast CDR
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/external/checkout@v0
         with:
           repository: eProsima/Fast-CDR
@@ -120,6 +134,7 @@ jobs:
           ref: ${{ steps.get_fastcdr_branch.outputs.deduced_branch }}
 
       - name: Fetch Fast DDS dependencies
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/windows/vcs_import@v0
         with:
           vcs_repos_file: ${{ github.workspace }}\src\fastdds\fastdds.repos
@@ -127,6 +142,7 @@ jobs:
           skip_existing: 'true'
 
       - name: Fetch Fast DDS CI dependencies
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/windows/vcs_import@v0
         with:
           vcs_repos_file: ${{ github.workspace }}\src\fastdds\.github\workflows\config\fastdds_test.repos
@@ -136,6 +152,7 @@ jobs:
       - name: Build
         id: build
         continue-on-error: false
+        if: ${{ inputs.run-build == true }}
         uses: eProsima/eProsima-CI/windows/colcon_build@v0
         with:
           colcon_meta_file: ${{ github.workspace }}\src\fastdds\.github\workflows\config\fastdds_build.meta ${{ github.workspace }}\src\fastdds\.github\workflows\config\fastdds_test.meta
@@ -147,7 +164,7 @@ jobs:
           workspace: ${{ github.workspace }}
 
       - name: Upload build artifacts
-        if: ${{ inputs.run-tests == true }}
+        if: ${{ inputs.run-build == true && inputs.run-tests == true }}
         uses: eProsima/eProsima-CI/external/upload-artifact@v0
         with:
           name: fastdds_build_${{ inputs.label }}_${{ matrix.vs-toolset }}
@@ -265,8 +282,8 @@ jobs:
 
       #Build Windows examples testing docker image
       - name: Build with example testing
-        if: ${{ inputs.run-tests == true && matrix.test_filter == 'examples' }}
         continue-on-error: false
+        if: ${{ inputs.run-tests == true && matrix.test_filter == 'examples' }}
         uses: eProsima/eProsima-CI/windows/colcon_build@v0
         with:
           colcon_meta_file: ${{ github.workspace }}\src\fastdds\.github\workflows\config\fastdds_build.meta ${{ github.workspace }}\src\fastdds\.github\workflows\config\fastdds_test.meta
@@ -278,8 +295,8 @@ jobs:
           workspace: ${{ github.workspace }}
 
       - name: Test
-        if: ${{ inputs.run-tests == true }}
         id: test
+        if: ${{ inputs.run-tests == true }}
         uses: eProsima/eProsima-CI/windows/colcon_test@v0
         with:
           colcon_meta_file: ${{ github.workspace }}\src\fastdds\.github\workflows\config\fastdds_test.meta

--- a/.github/workflows/sanitizers-ci.yml
+++ b/.github/workflows/sanitizers-ci.yml
@@ -53,17 +53,28 @@ concurrency:
 
 jobs:
   sanitizers-ci:
-    if: ${{ (
-              !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
-              !contains(github.event.pull_request.labels.*.name, 'no-test') &&
-              !contains(github.event.pull_request.labels.*.name, 'conflicts')
-            ) }}
+    if: ${{ !contains(github.event.pull_request.labels.*.name, 'conflicts') }}
     uses: ./.github/workflows/reusable-sanitizers-ci.yml
     with:
       label: ${{ inputs.label || 'fastdds-sanitizers-ci' }}
-      run_asan_fastdds: ${{ ((inputs.run_asan_fastdds == true) && true) || github.event_name == 'pull_request' }}
-      run_tsan_fastdds: ${{ ((inputs.run_tsan_fastdds == true) && true) || github.event_name == 'pull_request' }}
-      run_ubsan_fastdds: ${{ ((inputs.run_ubsan_fastdds == true) && true) || github.event_name == 'pull_request' }}
+      run_asan_fastdds: ${{ ((inputs.run_asan_fastdds == true) && true) ||
+                            (
+                              (github.event_name == 'pull_request') &&
+                              !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
+                              !contains(github.event.pull_request.labels.*.name, 'no-test')
+                            ) }}
+      run_tsan_fastdds: ${{ ((inputs.run_tsan_fastdds == true) && true) ||
+                            (
+                              (github.event_name == 'pull_request') &&
+                              !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
+                              !contains(github.event.pull_request.labels.*.name, 'no-test')
+                            ) }}
+      run_ubsan_fastdds: ${{ ((inputs.run_ubsan_fastdds == true) && true) ||
+                             (
+                               (github.event_name == 'pull_request') &&
+                               !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
+                               !contains(github.event.pull_request.labels.*.name, 'no-test')
+                             ) }}
       colcon_build_args: ${{ inputs.colcon_build_args || '' }}
       colcon_test_args: ${{ inputs.colcon_test_args || '' }}
       cmake_args: ${{ inputs.cmake_args || '' }}

--- a/.github/workflows/ubuntu-ci.yml
+++ b/.github/workflows/ubuntu-ci.yml
@@ -66,7 +66,15 @@ jobs:
       ctest-args: ${{ inputs.ctest-args || '-LE xfail' }}
       fastdds-branch: ${{ inputs.fastdds_branch || github.ref || 'master' }}
       security: ${{ ((inputs.security == true) && true) || github.event_name == 'pull_request' }}
-      run-build: ${{ !(github.event_name == 'pull_request') || !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
-      run-tests: ${{ ((inputs.run-tests == true) && true) || (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'no-test') && !contains(github.event.pull_request.labels.*.name, 'skip-ci')) }}
+      run-build: ${{ !(github.event_name == 'pull_request') ||
+                     !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
+      run-tests: ${{ (inputs.run-tests == true) ||
+                     (
+                       (github.event_name == 'pull_request') &&
+                       (!contains(github.event.pull_request.labels.*.name, 'no-test')) &&
+                       (!contains(github.event.pull_request.labels.*.name, 'skip-ci'))
+                     ) }}
       use-ccache: ${{ ((inputs.use-ccache == true) && true) || false }}
-      add-label: ${{ (github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name == github.repository) && true || false }}
+      add-label: ${{ (github.event_name == 'pull_request') &&
+                     (github.event.pull_request.head.repo.full_name == github.repository) &&
+                     true || false }}

--- a/.github/workflows/ubuntu-ci.yml
+++ b/.github/workflows/ubuntu-ci.yml
@@ -77,4 +77,5 @@ jobs:
       use-ccache: ${{ ((inputs.use-ccache == true) && true) || false }}
       add-label: ${{ (github.event_name == 'pull_request') &&
                      (github.event.pull_request.head.repo.full_name == github.repository) &&
+                     (!contains(github.event.pull_request.labels.*.name, 'skip-ci')) &&
                      true || false }}

--- a/.github/workflows/ubuntu-ci.yml
+++ b/.github/workflows/ubuntu-ci.yml
@@ -67,6 +67,6 @@ jobs:
       fastdds-branch: ${{ inputs.fastdds_branch || github.ref || 'master' }}
       security: ${{ ((inputs.security == true) && true) || github.event_name == 'pull_request' }}
       run-build: ${{ !(github.event_name == 'pull_request') || !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
-      run-tests: ${{ ((inputs.run-tests == true) && true) || (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'no-test')) }}
+      run-tests: ${{ ((inputs.run-tests == true) && true) || (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'no-test') && !contains(github.event.pull_request.labels.*.name, 'skip-ci')) }}
       use-ccache: ${{ ((inputs.use-ccache == true) && true) || false }}
       add-label: ${{ (github.event_name == 'pull_request') && (github.event.pull_request.head.repo.full_name == github.repository) && true || false }}

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -43,10 +43,7 @@ concurrency:
 
 jobs:
   windows-ci:
-    if: ${{ (
-              !contains(github.event.pull_request.labels.*.name, 'skip-ci') &&
-              !contains(github.event.pull_request.labels.*.name, 'conflicts')
-            ) }}
+    if: ${{ !(github.event_name == 'pull_request') || !contains(github.event.pull_request.labels.*.name, 'conflicts') }}
     uses: ./.github/workflows/reusable-windows-ci.yml
     with:
       label: ${{ inputs.label || 'windows-ci' }}
@@ -54,4 +51,5 @@ jobs:
       cmake-args: '-DSECURITY=ON ${{ inputs.cmake-args }}'
       ctest-args: ${{ inputs.ctest-args }}
       fastdds_branch: ${{ inputs.fastdds_branch || github.ref || 'master' }}
-      run-tests: ${{ ((inputs.run-tests == true) && true) || (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'no-test')) }}
+      run-build: ${{ !(github.event_name == 'pull_request') || !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
+      run-tests: ${{ ((inputs.run-tests == true) && true) || (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'no-test') && !contains(github.event.pull_request.labels.*.name, 'skip-ci')) }}

--- a/.github/workflows/windows-ci.yml
+++ b/.github/workflows/windows-ci.yml
@@ -51,5 +51,11 @@ jobs:
       cmake-args: '-DSECURITY=ON ${{ inputs.cmake-args }}'
       ctest-args: ${{ inputs.ctest-args }}
       fastdds_branch: ${{ inputs.fastdds_branch || github.ref || 'master' }}
-      run-build: ${{ !(github.event_name == 'pull_request') || !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
-      run-tests: ${{ ((inputs.run-tests == true) && true) || (github.event_name == 'pull_request' && !contains(github.event.pull_request.labels.*.name, 'no-test') && !contains(github.event.pull_request.labels.*.name, 'skip-ci')) }}
+      run-build: ${{ !(github.event_name == 'pull_request') ||
+                     !contains(github.event.pull_request.labels.*.name, 'skip-ci') }}
+      run-tests: ${{ (inputs.run-tests == true) ||
+                     (
+                       (github.event_name == 'pull_request') &&
+                       (!contains(github.event.pull_request.labels.*.name, 'no-test')) &&
+                       (!contains(github.event.pull_request.labels.*.name, 'skip-ci'))
+                     ) }}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.2.x 2.14.x

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- _N/A_: The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_: Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
