### PR TITLE
[25464] Implement payload release in move assignment

### DIFF
--- a/include/fastdds/rtps/common/SerializedPayload.hpp
+++ b/include/fastdds/rtps/common/SerializedPayload.hpp
@@ -103,10 +103,27 @@ struct FASTDDS_EXPORTED_API SerializedPayload_t
             const SerializedPayload_t& other) = delete;
 
     //!Move constructor
+    //!Directly moves the fields from \c other instead of calling the move assignment operator,
+    //!since the latter assumes the destination is already constructed (it may release the
+    //!currently owned payload). Using the move assignment operator here would read
+    //!uninitialized members of the newly constructed object.
     SerializedPayload_t(
             SerializedPayload_t&& other) noexcept
+        : encapsulation(other.encapsulation)
+        , length(other.length)
+        , data(other.data)
+        , max_size(other.max_size)
+        , pos(other.pos)
+        , payload_owner(other.payload_owner)
+        , is_serialized_key(other.is_serialized_key)
     {
-        *this = std::move(other);
+        other.encapsulation = CDR_BE;
+        other.length = 0;
+        other.data = nullptr;
+        other.max_size = 0;
+        other.pos = 0;
+        other.payload_owner = nullptr;
+        other.is_serialized_key = false;
     }
 
     //!Move operator

--- a/src/cpp/rtps/DataSharing/ReaderPool.hpp
+++ b/src/cpp/rtps/DataSharing/ReaderPool.hpp
@@ -255,6 +255,7 @@ public:
         if (check == c_SequenceNumber_Unknown || check != cache_change.sequenceNumber)
         {
             // data override while processing
+            cache_change.serializedPayload.data = nullptr;
             return false;
         }
 

--- a/src/cpp/rtps/common/SerializedPayload.cpp
+++ b/src/cpp/rtps/common/SerializedPayload.cpp
@@ -32,7 +32,9 @@ SerializedPayload_t& SerializedPayload_t::operator = (
 
     if (payload_owner != nullptr)
     {
-        payload_owner->release_payload(*this); 
+        auto state =  payload_owner->release_payload(*this);
+        assert(state);
+        payload_owner = nullptr;
     }
     else if (data != nullptr)
     {
@@ -62,7 +64,9 @@ SerializedPayload_t::~SerializedPayload_t()
 {
     if (payload_owner != nullptr)
     {
-        payload_owner->release_payload(*this);
+        auto state = payload_owner->release_payload(*this);
+        assert(state);
+        payload_owner = nullptr;
     }
     this->empty();
 }

--- a/src/cpp/rtps/common/SerializedPayload.cpp
+++ b/src/cpp/rtps/common/SerializedPayload.cpp
@@ -32,8 +32,9 @@ SerializedPayload_t& SerializedPayload_t::operator = (
 
     if (payload_owner != nullptr)
     {
-        auto state =  payload_owner->release_payload(*this);
-        assert(state);
+        bool success =  payload_owner->release_payload(*this);
+        static_cast<void>(success);
+        assert(success);
         payload_owner = nullptr;
     }
     else if (data != nullptr)
@@ -64,8 +65,9 @@ SerializedPayload_t::~SerializedPayload_t()
 {
     if (payload_owner != nullptr)
     {
-        auto state = payload_owner->release_payload(*this);
-        assert(state);
+        bool success = payload_owner->release_payload(*this);
+        static_cast<void>(success);
+        assert(success);
         payload_owner = nullptr;
     }
     this->empty();

--- a/src/cpp/rtps/common/SerializedPayload.cpp
+++ b/src/cpp/rtps/common/SerializedPayload.cpp
@@ -30,6 +30,15 @@ SerializedPayload_t& SerializedPayload_t::operator = (
         return *this;
     }
 
+    if (payload_owner != nullptr)
+    {
+        payload_owner->release_payload(*this); 
+    }
+    else if (data != nullptr)
+    {
+        free(data);
+    }
+
     encapsulation = other.encapsulation;
     length = other.length;
     data = other.data;

--- a/test/unittest/rtps/common/CMakeLists.txt
+++ b/test/unittest/rtps/common/CMakeLists.txt
@@ -45,6 +45,8 @@ if(ANDROID)
 endif()
 
 
+set(SERIALIZEDPAYLOADTESTS_SOURCE SerializedPayloadTests.cpp
+    ${PROJECT_SOURCE_DIR}/src/cpp/rtps/common/SerializedPayload.cpp)
 set(SEQUENCENUMBERTESTS_SOURCE SequenceNumberTests.cpp)
 set(PORTPARAMETERSTESTS_SOURCE PortParametersTests.cpp
     ${PROJECT_SOURCE_DIR}/src/cpp/fastdds/core/Time_t.cpp
@@ -99,6 +101,16 @@ target_link_libraries(GuidUtilsTests
     $<$<BOOL:${QNX}>:socket>
     )
 gtest_discover_tests(GuidUtilsTests)
+
+add_executable(SerializedPayloadTests ${SERIALIZEDPAYLOADTESTS_SOURCE})
+target_compile_definitions(SerializedPayloadTests PRIVATE
+    $<$<AND:$<NOT:$<BOOL:${WIN32}>>,$<STREQUAL:"${CMAKE_BUILD_TYPE}","Debug">>:__DEBUG>
+    $<$<BOOL:${INTERNAL_DEBUG}>:__INTERNALDEBUG> # Internal debug activated.
+    )
+target_include_directories(SerializedPayloadTests PRIVATE
+    ${PROJECT_SOURCE_DIR}/include ${PROJECT_BINARY_DIR}/include)
+target_link_libraries(SerializedPayloadTests GTest::gtest)
+gtest_discover_tests(SerializedPayloadTests)
 
 add_executable(SequenceNumberTests ${SEQUENCENUMBERTESTS_SOURCE})
 target_compile_definitions(SequenceNumberTests PRIVATE

--- a/test/unittest/rtps/common/SerializedPayloadTests.cpp
+++ b/test/unittest/rtps/common/SerializedPayloadTests.cpp
@@ -1,0 +1,131 @@
+// Copyright 2026 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <cstddef>
+#include <cstdlib>
+#include <utility>
+
+#include <gtest/gtest.h>
+
+#include <fastdds/rtps/common/SerializedPayload.hpp>
+
+using namespace eprosima::fastdds::rtps;
+
+class TestingPayloadPool : public IPayloadPool
+{
+public:
+
+    ~TestingPayloadPool() override = default;
+
+    bool get_payload(
+            uint32_t size,
+            SerializedPayload_t& payload) override
+    {
+        payload.data = static_cast<octet*>(calloc(size, sizeof(octet)));
+        if (payload.data == nullptr)
+        {
+            return false;
+        }
+
+        payload.payload_owner = this;
+        payload.max_size = size;
+        payload.length = size;
+        return true;
+    }
+
+    bool get_payload(
+            const SerializedPayload_t& data,
+            SerializedPayload_t& payload) override
+    {
+        if (!get_payload(data.length, payload))
+        {
+            return false;
+        }
+
+        payload.copy(&data);
+        return true;
+    }
+
+    bool release_payload(
+            SerializedPayload_t& payload) override
+    {
+        ++release_payload_calls;
+        EXPECT_EQ(this, payload.payload_owner);
+
+        free(payload.data);
+        payload.data = nullptr;
+        payload.payload_owner = nullptr;
+        payload.length = 0;
+        payload.max_size = 0;
+        return true;
+    }
+
+    size_t release_payload_calls = 0;
+};
+
+/*!
+ * @fn TEST(SerializedPayload, MoveAssignmentOperatorReleasesCurrentPayload)
+ * @brief This test checks that move assignment operator releases an already owned destination payload.
+ */
+TEST(SerializedPayload, MoveAssignmentOperatorReleasesCurrentPayload)
+{
+    TestingPayloadPool payload_pool;
+    SerializedPayload_t destination;
+    ASSERT_TRUE(payload_pool.get_payload(4, destination));
+
+    SerializedPayload_t source(8);
+    source.length = 8;
+
+    destination = std::move(source);
+
+    EXPECT_EQ(1u, payload_pool.release_payload_calls);
+    EXPECT_EQ(8u, destination.length);
+    EXPECT_EQ(8u, destination.max_size);
+    EXPECT_NE(nullptr, destination.data);
+    EXPECT_EQ(nullptr, destination.payload_owner);
+    EXPECT_EQ(0u, source.length);
+    EXPECT_EQ(0u, source.max_size);
+    EXPECT_EQ(nullptr, source.data);
+}
+
+/*!
+ * @fn TEST(SerializedPayload, MoveAssignmentOperatorReleasesCurrentUnownedPayload)
+ * @brief This test checks that move assignment operator releases an already allocated destination payload.
+ */
+TEST(SerializedPayload, MoveAssignmentOperatorReleasesCurrentUnownedPayload)
+{
+    SerializedPayload_t destination(4);
+    ASSERT_NE(nullptr, destination.data);
+
+    SerializedPayload_t source(8);
+    source.length = 8;
+
+    destination = std::move(source);
+
+    EXPECT_EQ(8u, destination.length);
+    EXPECT_EQ(8u, destination.max_size);
+    EXPECT_NE(nullptr, destination.data);
+    EXPECT_EQ(nullptr, destination.payload_owner);
+    EXPECT_EQ(0u, source.length);
+    EXPECT_EQ(0u, source.max_size);
+    EXPECT_EQ(nullptr, source.data);
+}
+
+int main(
+        int argc,
+        char** argv)
+{
+    testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

Ensure payload is released when another one is moved into it.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.2.x

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- _N/A_: If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
