### PR TITLE
[24616] Tests and fixes for type support context-aware operations

### DIFF
--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -258,6 +258,11 @@ ReturnCode_t DataWriterImpl::enable()
     {
         std::lock_guard<std::mutex> qos_guard(qos_mutex_);
 
+        // Set Datawriter's DataRepresentationId taking into account the QoS.
+        data_representation_ = qos_.representation().m_value.empty()
+                || XCDR_DATA_REPRESENTATION == qos_.representation().m_value.at(0)
+                        ? XCDR_DATA_REPRESENTATION : XCDR2_DATA_REPRESENTATION;
+
         auto history_att = DataWriterHistory::to_history_attributes(
             qos_.history(),
             qos_.resource_limits(),
@@ -378,11 +383,6 @@ ReturnCode_t DataWriterImpl::enable()
         {
             reader_filters_alloc = qos_.writer_resource_limits().reader_filters_allocation;
         }
-
-        // Set Datawriter's DataRepresentationId taking into account the QoS.
-        data_representation_ = qos_.representation().m_value.empty()
-                || XCDR_DATA_REPRESENTATION == qos_.representation().m_value.at(0)
-                        ? XCDR_DATA_REPRESENTATION : XCDR2_DATA_REPRESENTATION;
 
         lifespan_duration = qos_.lifespan().duration;
     }

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -168,6 +168,14 @@ ReturnCode_t DataReaderImpl::enable()
 {
     assert(reader_ == nullptr);
 
+    // Adapt payload max size in case we have a type support context
+    if (type_support_context_)
+    {
+        uint32_t type_max_size = type_->get_max_serialized_size_ctx(type_support_context_);
+        constexpr auto absolute_max = (std::numeric_limits<uint32_t>::max)();
+        history_.m_att.payloadMaxSize = (type_max_size > (absolute_max - 3u)) ? absolute_max : (type_max_size + 3u);
+    }
+
     ReaderAttributes att;
 
     // TODO(eduponz): Encapsulate this in QosConverters.cpp

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -111,7 +111,6 @@ DataReaderImpl::DataReaderImpl(
     , topic_(topic)
     , qos_(get_datareader_qos_from_settings(qos))
 #pragma warning (disable : 4355 )
-    , history_(type, *topic, qos_)
     , listener_(listener)
     , reader_listener_(this)
     , deadline_duration_us_(qos_.deadline().period.to_ns() * 1e-3)
@@ -168,13 +167,7 @@ ReturnCode_t DataReaderImpl::enable()
 {
     assert(reader_ == nullptr);
 
-    // Adapt payload max size in case we have a type support context
-    if (type_support_context_)
-    {
-        uint32_t type_max_size = type_->get_max_serialized_size_ctx(type_support_context_);
-        constexpr auto absolute_max = (std::numeric_limits<uint32_t>::max)();
-        history_.m_att.payloadMaxSize = (type_max_size > (absolute_max - 3u)) ? absolute_max : (type_max_size + 3u);
-    }
+    history_.reset(new detail::DataReaderHistory(type_, type_support_context_, *topic_, qos_));
 
     ReaderAttributes att;
 
@@ -256,7 +249,7 @@ ReturnCode_t DataReaderImpl::enable()
         subscriber_->rtps_participant(),
         guid_.entityId,
         att, pool,
-        static_cast<ReaderHistory*>(&history_),
+        static_cast<ReaderHistory*>(history_.get()),
         static_cast<ReaderListener*>(&reader_listener_));
 
     if (reader == nullptr)
@@ -570,10 +563,10 @@ ReturnCode_t DataReaderImpl::read_or_take(
 
     set_read_communication_status(false);
 
-    auto it = history_.lookup_available_instance(handle, exact_instance);
+    auto it = history_->lookup_available_instance(handle, exact_instance);
     if (!it.first)
     {
-        if (exact_instance && !history_.is_instance_present(handle))
+        if (exact_instance && !history_->is_instance_present(handle))
         {
             return RETCODE_BAD_PARAMETER;
         }
@@ -764,7 +757,7 @@ ReturnCode_t DataReaderImpl::read_or_take_next_sample(
 
     set_read_communication_status(false);
 
-    auto it = history_.lookup_available_instance(HANDLE_NIL, false);
+    auto it = history_->lookup_available_instance(HANDLE_NIL, false);
     if (!it.first)
     {
         return RETCODE_NO_DATA;
@@ -814,7 +807,7 @@ ReturnCode_t DataReaderImpl::get_first_untaken_info(
         return RETCODE_NOT_ENABLED;
     }
 
-    if (history_.get_first_untaken_info(*info))
+    if (history_->get_first_untaken_info(*info))
     {
         return RETCODE_OK;
     }
@@ -824,7 +817,7 @@ ReturnCode_t DataReaderImpl::get_first_untaken_info(
 uint64_t DataReaderImpl::get_unread_count(
         bool mark_as_read)
 {
-    uint64_t ret_val = reader_ ? history_.get_unread_count(mark_as_read) : 0;
+    uint64_t ret_val = reader_ ? history_->get_unread_count(mark_as_read) : 0;
     if (mark_as_read)
     {
         try_notify_read_conditions();
@@ -1085,7 +1078,7 @@ bool DataReaderImpl::on_data_available(
     {
         CacheChange_t* change = nullptr;
 
-        if (history_.get_change(seq, writer_guid, &change))
+        if (history_->get_change(seq, writer_guid, &change))
         {
             ret_val |= on_new_cache_change_added(change);
         }
@@ -1104,16 +1097,16 @@ bool DataReaderImpl::on_new_cache_change_added(
     CacheChange_t* new_change = const_cast<CacheChange_t*>(change);
     // Update the reception timestamp when the sample is added to the instance
     rtps::Time_t::now(new_change->reader_info.receptionTimestamp);
-    if (!history_.update_instance_nts(new_change))
+    if (!history_->update_instance_nts(new_change))
     {
-        history_.remove_change_sub(new_change);
+        history_->remove_change_sub(new_change);
         return false;
     }
 
     if (qos_.deadline().period.to_ns() > 0 && qos_.deadline().period != dds::c_TimeInfinite &&
             deadline_missed_status_.total_count < std::numeric_limits<uint32_t>::max())
     {
-        if (!history_.set_next_deadline(
+        if (!history_->set_next_deadline(
                     change->instanceHandle,
                     steady_clock::now() + duration_cast<steady_clock::duration>(deadline_duration_us_)))
         {
@@ -1142,12 +1135,12 @@ bool DataReaderImpl::on_new_cache_change_added(
     // If so, remove it from the history and return false to avoid notifying the listener
     if (expiration_ts < current_ts)
     {
-        history_.remove_change_sub(new_change);
+        history_->remove_change_sub(new_change);
         return false;
     }
 
     CacheChange_t* earliest_change;
-    if (history_.get_earliest_change(&earliest_change))
+    if (history_->get_earliest_change(&earliest_change))
     {
         if (earliest_change == change)
         {
@@ -1185,7 +1178,7 @@ void DataReaderImpl::update_subscription_matched_status(
 
     if (count_change < 0)
     {
-        if (history_.writer_not_alive(status.remoteEndpointGuid))
+        if (history_->writer_not_alive(status.remoteEndpointGuid))
         {
             set_read_communication_status(true);
         }
@@ -1264,7 +1257,7 @@ bool DataReaderImpl::deadline_timer_reschedule()
     assert(deadline_missed_status_.total_count < std::numeric_limits<uint32_t>::max());
 
     steady_clock::time_point next_deadline_us;
-    if (!history_.get_next_deadline(timer_owner_, next_deadline_us))
+    if (!history_->get_next_deadline(timer_owner_, next_deadline_us))
     {
         EPROSIMA_LOG_ERROR(DATA_READER, "Could not get the next deadline from the history");
         return false;
@@ -1360,7 +1353,7 @@ bool DataReaderImpl::deadline_missed()
         return false; // do not reschedule
     }
 
-    if (!history_.set_next_deadline(
+    if (!history_->set_next_deadline(
                 timer_owner_,
                 steady_clock::now() + duration_cast<steady_clock::duration>(deadline_duration_us_), true))
     {
@@ -1397,7 +1390,7 @@ bool DataReaderImpl::lifespan_expired()
     fastdds::rtps::Time_t::now(current_ts);
 
     CacheChange_t* earliest_change;
-    while (history_.get_earliest_change(&earliest_change))
+    while (history_->get_earliest_change(&earliest_change))
     {
         fastdds::rtps::Time_t expiration_ts = earliest_change->sourceTimestamp + qos_.lifespan().duration;
 
@@ -1410,7 +1403,7 @@ bool DataReaderImpl::lifespan_expired()
         }
 
         // The earliest change has expired
-        history_.remove_change_sub(earliest_change);
+        history_->remove_change_sub(earliest_change);
 
         try_notify_read_conditions();
     }
@@ -1567,7 +1560,7 @@ LivelinessChangedStatus& DataReaderImpl::update_liveliness_status(
 {
     if (0 < status.not_alive_count_change)
     {
-        if (history_.writer_not_alive(iHandle2GUID(status.last_publication_handle)))
+        if (history_->writer_not_alive(iHandle2GUID(status.last_publication_handle)))
         {
             set_read_communication_status(true);
         }
@@ -1942,13 +1935,13 @@ std::shared_ptr<IPayloadPool> DataReaderImpl::get_payload_pool()
 
     // When the user requested PREALLOCATED_WITH_REALLOC, but we know the type cannot
     // grow, we translate the policy into bare PREALLOCATED
-    if (PREALLOCATED_WITH_REALLOC_MEMORY_MODE == history_.m_att.memoryPolicy &&
+    if (PREALLOCATED_WITH_REALLOC_MEMORY_MODE == history_->m_att.memoryPolicy &&
             (type_->is_bounded_ctx(type_support_context_) || is_plain))
     {
-        history_.m_att.memoryPolicy = PREALLOCATED_MEMORY_MODE;
+        history_->m_att.memoryPolicy = PREALLOCATED_MEMORY_MODE;
     }
 
-    PoolConfig config = PoolConfig::from_history_attributes(history_.m_att);
+    PoolConfig config = PoolConfig::from_history_attributes(history_->m_att);
 
     if (!sample_pool_)
     {
@@ -1970,7 +1963,7 @@ void DataReaderImpl::release_payload_pool()
 
     if (!is_custom_payload_pool_)
     {
-        PoolConfig config = PoolConfig::from_history_attributes(history_.m_att);
+        PoolConfig config = PoolConfig::from_history_attributes(history_->m_att);
         std::shared_ptr<fastdds::rtps::ITopicPayloadPool> topic_payload_pool =
                 std::dynamic_pointer_cast<fastdds::rtps::ITopicPayloadPool>(payload_pool_);
         topic_payload_pool->release_history(config, true);
@@ -2103,7 +2096,7 @@ InstanceHandle_t DataReaderImpl::lookup_instance(
     {
         if (type_->compute_key_ctx(type_support_context_, const_cast<void*>(instance), handle, false))
         {
-            if (!history_.is_instance_present(handle) || !handle.isDefined())
+            if (!history_->is_instance_present(handle) || !handle.isDefined())
             {
                 handle = HANDLE_NIL;
             }
@@ -2294,7 +2287,7 @@ void DataReaderImpl::try_notify_read_conditions() noexcept
         std::lock_guard<RecursiveTimedMutex> _(reader_->getMutex());
 
         auto old_mask = last_mask_state_;
-        last_mask_state_ = history_.get_mask_status();
+        last_mask_state_ = history_->get_mask_status();
         current_mask = last_mask_state_;
 
         notify = last_mask_state_.sample_states & ~old_mask.sample_states ||

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
@@ -456,7 +456,7 @@ protected:
     DataReaderQos qos_;
 
     //!History
-    detail::DataReaderHistory history_;
+    std::unique_ptr<detail::DataReaderHistory> history_ {};
 
     //!Listener
     DataReaderListener* listener_ = nullptr;

--- a/src/cpp/fastdds/subscriber/DataReaderImpl/ReadTakeCommand.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl/ReadTakeCommand.hpp
@@ -68,7 +68,7 @@ struct ReadTakeCommand
             bool loop_for_data)
         : type_(reader.type_)
         , loan_manager_(reader.loan_manager_)
-        , history_(reader.history_)
+        , history_(*reader.history_)
         , reader_(reader.reader_)
         , info_pool_(reader.sample_info_pool_)
         , sample_pool_(reader.sample_pool_)

--- a/src/cpp/fastdds/subscriber/DataReaderImpl/ReadTakeCommand.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl/ReadTakeCommand.hpp
@@ -80,6 +80,7 @@ struct ReadTakeCommand
         , handle_(instance->first)
         , single_instance_(single_instance)
         , loop_for_data_(loop_for_data)
+        , type_support_context_(reader.type_support_context_)
     {
         assert(0 <= remaining_samples_);
 
@@ -330,6 +331,7 @@ private:
     InstanceHandle_t handle_;
     bool single_instance_;
     bool loop_for_data_;
+    std::shared_ptr<TopicDataType::Context> type_support_context_;
 
     bool finished_ = false;
     ReturnCode_t return_value_ = RETCODE_NO_DATA;
@@ -421,7 +423,7 @@ private:
         if (data_values_.has_ownership())
         {
             // perform deserialization
-            return type_->deserialize(*payload, data_values_.buffer()[current_slot_]);
+            return type_->deserialize_ctx(type_support_context_, *payload, data_values_.buffer()[current_slot_]);
         }
         else
         {

--- a/src/cpp/fastdds/subscriber/history/DataReaderHistory.cpp
+++ b/src/cpp/fastdds/subscriber/history/DataReaderHistory.cpp
@@ -46,22 +46,30 @@ using fastdds::RecursiveTimedMutex;
 
 static HistoryAttributes to_history_attributes(
         const TypeSupport& type,
+        const std::shared_ptr<TopicDataType::Context>& context,
         const DataReaderQos& qos)
 {
     auto initial_samples = qos.resource_limits().allocated_samples;
     auto max_samples = qos.resource_limits().max_samples;
 
     auto mempolicy = qos.endpoint().history_memory_policy;
-    auto payloadMaxSize = type->max_serialized_type_size + 3; // possible alignment
+    uint32_t type_max_size = type->max_serialized_type_size;
+    if (context)
+    {
+        type_max_size = type->get_max_serialized_size_ctx(context);
+    }
+    constexpr auto absolute_max = (std::numeric_limits<uint32_t>::max)();
+    uint32_t payloadMaxSize = (type_max_size > (absolute_max - 3u)) ? absolute_max : (type_max_size + 3u);
 
     return HistoryAttributes(mempolicy, payloadMaxSize, initial_samples, max_samples);
 }
 
 DataReaderHistory::DataReaderHistory(
         const TypeSupport& type,
+        const std::shared_ptr<TopicDataType::Context>& context,
         const TopicDescription& topic,
         const DataReaderQos& qos)
-    : ReaderHistory(to_history_attributes(type, qos))
+    : ReaderHistory(to_history_attributes(type, context, qos))
     , key_writers_allocation_(qos.reader_resource_limits().matched_publisher_allocation)
     , history_qos_(qos.history())
     , resource_limited_qos_(qos.resource_limits())
@@ -69,6 +77,7 @@ DataReaderHistory::DataReaderHistory(
     , type_name_(topic.get_type_name())
     , has_keys_(type->is_compute_key_provided)
     , type_(type.get())
+    , context_(context)
 {
     if (resource_limited_qos_.max_samples <= 0)
     {
@@ -154,7 +163,7 @@ DataReaderHistory::DataReaderHistory(
 #if HAVE_SECURITY
                         is_key_protected = mp_reader->getAttributes().security_attributes().is_key_protected;
 #endif // if HAVE_SECURITY
-                        return type_->compute_key(a_change->serializedPayload, a_change->instanceHandle,
+                        return type_->compute_key_ctx(context_, a_change->serializedPayload, a_change->instanceHandle,
                                        is_key_protected);
                     }
 

--- a/src/cpp/fastdds/subscriber/history/DataReaderHistory.hpp
+++ b/src/cpp/fastdds/subscriber/history/DataReaderHistory.hpp
@@ -74,12 +74,14 @@ public:
      * Constructor.
      * Requires information about the DataReader.
      *
-     * @param type  Type information. Needed to know if the type is keyed, as long as the maximum serialized size.
-     * @param topic Topic description. Topic and type name are used on debug messages.
-     * @param qos   DataReaderQoS policy. History related limits are taken from here.
+     * @param type     Type information. Needed to know if the type is keyed, as long as the maximum serialized size.
+     * @param context  Type support context. Used when calling type support methods that require a context.
+     * @param topic    Topic description. Topic and type name are used on debug messages.
+     * @param qos      DataReaderQoS policy. History related limits are taken from here.
      */
     DataReaderHistory(
             const TypeSupport& type,
+            const std::shared_ptr<TopicDataType::Context>& context,
             const TopicDescription& topic,
             const DataReaderQos& qos);
 
@@ -396,7 +398,9 @@ private:
     //!Whether the type has keys
     bool has_keys_;
     //!TopicDataType
-    fastdds::dds::TopicDataType* type_;
+    TopicDataType* type_;
+    //!Context for the TopicDataType
+    std::shared_ptr<TopicDataType::Context> context_;
 
     /// Function to compute the instance handle of a received change
     std::function<bool(CacheChange_t*)> compute_key_for_change_fn_;

--- a/test/blackbox/api/dds-pim/PubSubReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubReader.hpp
@@ -540,8 +540,11 @@ public:
                     // Ensure the datareader is created disabled so that the context can be set before enabling it.
                     auto sub_qos = subscriber_->get_qos();
                     bool was_auto_enable = sub_qos.entity_factory().autoenable_created_entities;
-                    sub_qos.entity_factory().autoenable_created_entities = false;
-                    subscriber_->set_qos(sub_qos);
+                    if (was_auto_enable)
+                    {
+                        sub_qos.entity_factory().autoenable_created_entities = false;
+                        subscriber_->set_qos(sub_qos);
+                    }
                     // Create the datareader disabled and set the context.
                     datareader_ = subscriber_->create_datareader(topic_desc, datareader_qos_, &listener_, status_mask_);
                     if (datareader_ != nullptr)

--- a/test/blackbox/api/dds-pim/PubSubReader.hpp
+++ b/test/blackbox/api/dds-pim/PubSubReader.hpp
@@ -531,7 +531,30 @@ public:
             }
             if (datareader_ == nullptr)
             {
-                datareader_ = subscriber_->create_datareader(topic_desc, datareader_qos_, &listener_, status_mask_);
+                if (nullptr == context_.get())
+                {
+                    datareader_ = subscriber_->create_datareader(topic_desc, datareader_qos_, &listener_, status_mask_);
+                }
+                else
+                {
+                    // Ensure the datareader is created disabled so that the context can be set before enabling it.
+                    auto sub_qos = subscriber_->get_qos();
+                    bool was_auto_enable = sub_qos.entity_factory().autoenable_created_entities;
+                    sub_qos.entity_factory().autoenable_created_entities = false;
+                    subscriber_->set_qos(sub_qos);
+                    // Create the datareader disabled and set the context.
+                    datareader_ = subscriber_->create_datareader(topic_desc, datareader_qos_, &listener_, status_mask_);
+                    if (datareader_ != nullptr)
+                    {
+                        datareader_->set_type_support_context(context_);
+                        if (was_auto_enable)
+                        {
+                            sub_qos.entity_factory().autoenable_created_entities = true;
+                            subscriber_->set_qos(sub_qos);
+                            datareader_->enable();
+                        }
+                    }
+                }
             }
 
             if (datareader_ != nullptr)
@@ -1772,6 +1795,13 @@ public:
         return *this;
     }
 
+    PubSubReader& context(
+            const std::shared_ptr<eprosima::fastdds::dds::TopicDataType::Context>& context)
+    {
+        context_ = context;
+        return *this;
+    }
+
     bool update_partition(
             const std::string& partition)
     {
@@ -2264,6 +2294,7 @@ protected:
     eprosima::fastdds::dds::DataReader* datareader_;
     eprosima::fastdds::dds::DataReaderQos datareader_qos_;
     eprosima::fastdds::dds::StatusMask status_mask_;
+    std::shared_ptr<eprosima::fastdds::dds::TopicDataType::Context> context_;
     std::string topic_name_;
     eprosima::fastdds::rtps::GUID_t participant_guid_;
     eprosima::fastdds::rtps::GUID_t datareader_guid_;

--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -483,8 +483,11 @@ public:
                     // Ensure the datawriter is created disabled so that the context can be set before enabling it.
                     auto pub_qos = publisher_->get_qos();
                     bool was_auto_enable = pub_qos.entity_factory().autoenable_created_entities;
-                    pub_qos.entity_factory().autoenable_created_entities = false;
-                    publisher_->set_qos(pub_qos);
+                    if (was_auto_enable)
+                    {
+                        pub_qos.entity_factory().autoenable_created_entities = false;
+                        publisher_->set_qos(pub_qos);
+                    }
                     // Create the datawriter disabled and set the context.
                     datawriter_ = publisher_->create_datawriter(topic_, datawriter_qos_, &listener_, status_mask_);
                     if (datawriter_ != nullptr)

--- a/test/blackbox/api/dds-pim/PubSubWriter.hpp
+++ b/test/blackbox/api/dds-pim/PubSubWriter.hpp
@@ -474,7 +474,30 @@ public:
             }
             if (datawriter_ == nullptr)
             {
-                datawriter_ = publisher_->create_datawriter(topic_, datawriter_qos_, &listener_, status_mask_);
+                if (nullptr == context_.get())
+                {
+                    datawriter_ = publisher_->create_datawriter(topic_, datawriter_qos_, &listener_, status_mask_);
+                }
+                else
+                {
+                    // Ensure the datawriter is created disabled so that the context can be set before enabling it.
+                    auto pub_qos = publisher_->get_qos();
+                    bool was_auto_enable = pub_qos.entity_factory().autoenable_created_entities;
+                    pub_qos.entity_factory().autoenable_created_entities = false;
+                    publisher_->set_qos(pub_qos);
+                    // Create the datawriter disabled and set the context.
+                    datawriter_ = publisher_->create_datawriter(topic_, datawriter_qos_, &listener_, status_mask_);
+                    if (datawriter_ != nullptr)
+                    {
+                        datawriter_->set_type_support_context(context_);
+                        if (was_auto_enable)
+                        {
+                            pub_qos.entity_factory().autoenable_created_entities = true;
+                            publisher_->set_qos(pub_qos);
+                            datawriter_->enable();
+                        }
+                    }
+                }
             }
 
             if (datawriter_ != nullptr)
@@ -1935,6 +1958,13 @@ public:
         return *this;
     }
 
+    PubSubWriter& context(
+            const std::shared_ptr<eprosima::fastdds::dds::TopicDataType::Context>& context)
+    {
+        context_ = context;
+        return *this;
+    }
+
     eprosima::fastdds::dds::TypeSupport get_type_support()
     {
         return type_;
@@ -2203,6 +2233,7 @@ protected:
     eprosima::fastdds::dds::DataWriter* datawriter_;
     eprosima::fastdds::dds::DataWriterQos datawriter_qos_;
     eprosima::fastdds::dds::StatusMask status_mask_;
+    std::shared_ptr<eprosima::fastdds::dds::TopicDataType::Context> context_;
     std::string topic_name_;
     eprosima::fastdds::rtps::GUID_t participant_guid_;
     eprosima::fastdds::rtps::GUID_t datawriter_guid_;

--- a/test/blackbox/common/DDSBlackboxTestsCustomSerialization.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsCustomSerialization.cpp
@@ -103,10 +103,8 @@ size_t calculate_serialized_size(
         const test::CustomData& data,
         size_t& current_alignment)
 {
-    auto ctx = calculator.get_context();
-    test::CustomContext::check_context(std::dynamic_pointer_cast<test::CustomContext>(ctx));
-
     // We directly encode the data inside the representation header, so we don't need to add any size for the data.
+    static_cast<void>(calculator);
     static_cast<void>(data);
     return current_alignment;
 }
@@ -116,10 +114,8 @@ void serialize(
         Cdr& scdr,
         const test::CustomData& data)
 {
-    auto ctx = scdr.get_context();
-    test::CustomContext::check_context(std::dynamic_pointer_cast<test::CustomContext>(ctx));
-
     // We directly encode the data inside the representation header, so we don't need to serialize any data.
+    static_cast<void>(scdr);
     static_cast<void>(data);
 }
 
@@ -128,9 +124,6 @@ void deserialize(
         Cdr& dcdr,
         test::CustomData& data)
 {
-    auto ctx = dcdr.get_context();
-    test::CustomContext::check_context(std::dynamic_pointer_cast<test::CustomContext>(ctx));
-
     // We directly encode the data inside the representation header.
     std::array<uint8_t, 2> options = dcdr.get_dds_cdr_options();
     data.data = options[0];
@@ -221,7 +214,7 @@ public:
 
         eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload.data), payload.max_size);
         // Object that serializes the data.
-        eprosima::fastcdr::Cdr ser(fastbuffer, context, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
+        eprosima::fastcdr::Cdr ser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
                 data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
                 eprosima::fastcdr::CdrVersion::XCDRv1 : eprosima::fastcdr::CdrVersion::XCDRv2);
         payload.encapsulation = ser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
@@ -274,7 +267,7 @@ public:
             eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload.data), payload.length);
 
             // Object that deserializes the data.
-            eprosima::fastcdr::Cdr deser(fastbuffer, context, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN);
+            eprosima::fastcdr::Cdr deser(fastbuffer, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN);
 
             // Deserialize encapsulation.
             deser.read_encapsulation();
@@ -312,7 +305,7 @@ public:
 
         try
         {
-            eprosima::fastcdr::CdrSizeCalculator calculator(context,
+            eprosima::fastcdr::CdrSizeCalculator calculator(
                     data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
                     eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
             size_t current_alignment {0};

--- a/test/blackbox/common/DDSBlackboxTestsCustomSerialization.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsCustomSerialization.cpp
@@ -80,3 +80,54 @@ struct CustomContext : public TopicDataType::Context
 
 //}
 
+//{ Custom serialization methods
+
+namespace eprosima {
+namespace fastcdr {
+
+namespace test = eprosima::fastdds::dds::custom_serialization_test;
+
+template<>
+size_t calculate_serialized_size(
+        CdrSizeCalculator& calculator,
+        const test::CustomData& data,
+        size_t& current_alignment)
+{
+    auto ctx = calculator.get_context();
+    test::CustomContext::check_context(std::dynamic_pointer_cast<test::CustomContext>(ctx));
+
+    // We directly encode the data inside the representation header, so we don't need to add any size for the data.
+    static_cast<void>(data);
+    return current_alignment;
+}
+
+template<>
+void serialize(
+        Cdr& scdr,
+        const test::CustomData& data)
+{
+    auto ctx = scdr.get_context();
+    test::CustomContext::check_context(std::dynamic_pointer_cast<test::CustomContext>(ctx));
+
+    // We directly encode the data inside the representation header, so we don't need to serialize any data.
+    static_cast<void>(data);
+}
+
+template<>
+void deserialize(
+        Cdr& dcdr,
+        test::CustomData& data)
+{
+    auto ctx = dcdr.get_context();
+    test::CustomContext::check_context(std::dynamic_pointer_cast<test::CustomContext>(ctx));
+
+    // We directly encode the data inside the representation header.
+    auto options = dcdr.get_dds_cdr_options();
+    data.data = options[0];
+}
+
+}  // namespace fastcdr
+}  // namespace eprosima
+
+//}
+

--- a/test/blackbox/common/DDSBlackboxTestsCustomSerialization.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsCustomSerialization.cpp
@@ -325,7 +325,7 @@ public:
     }
 
     void* create_data_ctx(
-            const std::shared_ptr<Context>& context)
+            const std::shared_ptr<Context>& context) override
     {
         was_called(custom_calls_.create_data);
         CustomContext::check_context(context);
@@ -340,7 +340,7 @@ public:
 
     void delete_data_ctx(
             const std::shared_ptr<Context>& context,
-            void* data)
+            void* data) override
     {
         was_called(custom_calls_.delete_data);
         CustomContext::check_context(context);
@@ -469,7 +469,7 @@ public:
     }
 
     uint32_t get_max_serialized_size_ctx(
-            const std::shared_ptr<Context>& context)
+            const std::shared_ptr<Context>& context) override
     {
         was_called(custom_calls_.get_max_serialized_size);
         CustomContext::check_context(context);

--- a/test/blackbox/common/DDSBlackboxTestsCustomSerialization.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsCustomSerialization.cpp
@@ -131,3 +131,304 @@ void deserialize(
 
 //}
 
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+namespace custom_serialization_test {
+
+/**
+ * @brief CustomTypeSupport class that implements the TopicDataType interface for the CustomData type.
+ *
+ * It checks that the operations without context are not called by calling the corresponding _ctx methods with a null context.
+ * The CustomData objects serialization is done inside the representation header, so the serialized size of the data is 0.
+ * XCDRv1 is considered plain so we can check invocation of the construct_sample method.
+ * XCDRv2 is not considered plain, so we can check the invocation of create_data and delete_data methods.
+ */
+class CustomTypeSupport : public TopicDataType
+{
+public:
+
+    typedef CustomData type;
+
+    CustomTypeSupport()
+    {
+        set_name("CustomData");
+        // Data is sent inside the representation header on this custom type support.
+        max_serialized_type_size = rtps::SerializedPayload_t::representation_header_size;
+        is_compute_key_provided = true;
+    }
+
+    bool serialize(
+            const void* const data,
+            rtps::SerializedPayload_t& payload,
+            eprosima::fastdds::dds::DataRepresentationId_t data_representation) override
+    {
+        return serialize_ctx(nullptr, data, payload, data_representation);
+    }
+
+    bool serialize_ctx(
+            const std::shared_ptr<Context>& context,
+            const void* const data,
+            rtps::SerializedPayload_t& payload,
+            eprosima::fastdds::dds::DataRepresentationId_t data_representation) override
+    {
+        CustomContext::check_context(context);
+
+        eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload.data), payload.max_size);
+        // Object that serializes the data.
+        eprosima::fastcdr::Cdr ser(fastbuffer, context, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN,
+                data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+                eprosima::fastcdr::CdrVersion::XCDRv1 : eprosima::fastcdr::CdrVersion::XCDRv2);
+        payload.encapsulation = ser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
+        ser.set_encoding_flag(
+            data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR :
+            eprosima::fastcdr::EncodingAlgorithmFlag::PLAIN_CDR2);
+
+        try
+        {
+            const CustomData* p_type = static_cast<const CustomData*>(data);
+
+            // Serialize encapsulation
+            ser.serialize_encapsulation();
+            // Serialize the object.
+            ser << *p_type;
+            ser.set_dds_cdr_options({ p_type->data, 0 });
+        }
+        catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+        {
+            return false;
+        }
+
+        // Get the serialized length
+        payload.length = static_cast<uint32_t>(ser.get_serialized_data_length());
+        return true;
+    }
+
+    bool deserialize(
+            rtps::SerializedPayload_t& payload,
+            void* data) override
+    {
+        return deserialize_ctx(nullptr, payload, data);
+    }
+
+    bool deserialize_ctx(
+            const std::shared_ptr<Context>& context,
+            rtps::SerializedPayload_t& payload,
+            void* data) override
+    {
+        CustomContext::check_context(context);
+
+        try
+        {
+            // Convert DATA to pointer of your type
+            CustomData* p_type = static_cast<CustomData*>(data);
+
+            // Object that manages the raw buffer.
+            eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload.data), payload.length);
+
+            // Object that deserializes the data.
+            eprosima::fastcdr::Cdr deser(fastbuffer, context, eprosima::fastcdr::Cdr::DEFAULT_ENDIAN);
+
+            // Deserialize encapsulation.
+            deser.read_encapsulation();
+            payload.encapsulation = deser.endianness() == eprosima::fastcdr::Cdr::BIG_ENDIANNESS ? CDR_BE : CDR_LE;
+
+            // Deserialize the object.
+            deser >> *p_type;
+
+            // Check that the options are correct
+            auto options = deser.get_dds_cdr_options();
+            EXPECT_EQ(options[0], p_type->data);
+        }
+        catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    uint32_t calculate_serialized_size(
+            const void* const data,
+            eprosima::fastdds::dds::DataRepresentationId_t data_representation) override
+    {
+        return calculate_serialized_size_ctx(nullptr, data, data_representation);
+    }
+
+    uint32_t calculate_serialized_size_ctx(
+            const std::shared_ptr<Context>& context,
+            const void* const data,
+            eprosima::fastdds::dds::DataRepresentationId_t data_representation) override
+    {
+        CustomContext::check_context(context);
+
+        try
+        {
+            eprosima::fastcdr::CdrSizeCalculator calculator(
+                data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+                eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
+            size_t current_alignment {0};
+            const ::Data64kb* p_type =
+                    static_cast<const ::Data64kb*>(data);
+            auto calc_size = calculator.calculate_serialized_size(*p_type, current_alignment);
+            return static_cast<uint32_t>(calc_size) + rtps::SerializedPayload_t::representation_header_size;
+        }
+        catch (eprosima::fastcdr::exception::Exception& /*exception*/)
+        {
+            return 0;
+        }
+    }
+
+    void* create_data() override
+    {
+        return create_data_ctx(nullptr);
+    }
+
+    void* create_data_ctx(
+            const std::shared_ptr<Context>& context)
+    {
+        CustomContext::check_context(context);
+        return new CustomData();
+    }
+
+    void delete_data(
+            void* data) override
+    {
+        delete_data_ctx(nullptr, data);
+    }
+
+    void delete_data_ctx(
+            const std::shared_ptr<Context>& context,
+            void* data)
+    {
+        CustomContext::check_context(context);
+        delete static_cast<CustomData*>(data);
+    }
+
+    bool compute_key(
+            rtps::SerializedPayload_t& payload,
+            rtps::InstanceHandle_t& ihandle,
+            bool force_md5 = false) override
+    {
+        return compute_key_ctx(nullptr, payload, ihandle, force_md5);
+    }
+
+    bool compute_key_ctx(
+            const std::shared_ptr<Context>& context,
+            rtps::SerializedPayload_t& payload,
+            rtps::InstanceHandle_t& ihandle,
+            bool force_md5 = false) override
+    {
+        CustomData data;
+        if (deserialize_ctx(context, payload, &data))
+        {
+            return compute_key_ctx(context, &data, ihandle, force_md5);
+        }
+        return false;
+    }
+
+    bool compute_key(
+            const void* const data,
+            rtps::InstanceHandle_t& ihandle,
+            bool force_md5 = false) override
+    {
+        return compute_key_ctx(nullptr, data, ihandle, force_md5);
+    }
+
+    bool compute_key_ctx(
+            const std::shared_ptr<Context>& context,
+            const void* const data,
+            rtps::InstanceHandle_t& ihandle,
+            bool force_md5 = false) override
+    {
+        CustomContext::check_context(context);
+
+        const CustomData* p_type = static_cast<const CustomData*>(data);
+        if (force_md5)
+        {
+            eprosima::fastdds::MD5 md5;
+            md5.init();
+            md5.update(&p_type->data, sizeof(p_type->data));
+            md5.finalize();
+            for (uint8_t i = 0; i < 16; ++i)
+            {
+                ihandle.value[i] = md5.digest[i];
+            }
+        }
+        else
+        {
+            // If the key is smaller than 16 bytes, we can just copy it directly to the handle.
+            std::memset(ihandle.value, 0, sizeof(ihandle.value));
+            std::memcpy(ihandle.value, &p_type->data, sizeof(p_type->data));
+        }
+        return true;
+    }
+
+    bool is_bounded() const override
+    {
+        return is_bounded_ctx(nullptr);
+    }
+
+    bool is_bounded_ctx(
+            const std::shared_ptr<Context>& context) const
+    {
+        CustomContext::check_context(context);
+
+        return true;
+    }
+
+    bool is_plain(
+            DataRepresentationId_t representation) const override
+    {
+        return is_plain_ctx(nullptr, representation);
+    }
+
+    bool is_plain_ctx(
+            const std::shared_ptr<Context>& context,
+            DataRepresentationId_t representation) const override
+    {
+        CustomContext::check_context(context);
+        return eprosima::fastdds::dds::DataRepresentationId_t::XCDR_DATA_REPRESENTATION == representation;
+    }
+
+    bool construct_sample(
+            void* memory) const override
+    {
+        return construct_sample_ctx(nullptr, memory);
+    }
+
+    bool construct_sample_ctx(
+            const std::shared_ptr<Context>& context,
+            void* memory) const override
+    {
+        CustomContext::check_context(context);
+        CustomData* p_type = static_cast<CustomData*>(memory);
+        new (p_type) CustomData();
+        return true;
+    }
+
+    void register_type_object_representation() override
+    {
+        register_type_object_representation_ctx(nullptr);
+    }
+
+    void register_type_object_representation_ctx(
+            const std::shared_ptr<Context>& context) override
+    {
+        CustomContext::check_context(context);
+    }
+
+    uint32_t get_max_serialized_size_ctx(
+            const std::shared_ptr<Context>& context)
+    {
+        CustomContext::check_context(context);
+        return max_serialized_type_size;
+    }
+
+};
+
+}  // namespace custom_serialization_test
+}  // namespace dds
+}  // namespace fastdds
+}  // namespace eprosima

--- a/test/blackbox/common/DDSBlackboxTestsCustomSerialization.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsCustomSerialization.cpp
@@ -283,7 +283,7 @@ public:
             deser >> *p_type;
 
             // Check that the options are correct
-            auto options = deser.get_dds_cdr_options();
+            std::array<uint8_t, 2> options = deser.get_dds_cdr_options();
             EXPECT_EQ(options[0], p_type->data);
         }
         catch (eprosima::fastcdr::exception::Exception& /*exception*/)
@@ -311,12 +311,11 @@ public:
 
         try
         {
-            eprosima::fastcdr::CdrSizeCalculator calculator(
-                data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
-                eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
+            eprosima::fastcdr::CdrSizeCalculator calculator(context,
+                    data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+                    eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
             size_t current_alignment {0};
-            const ::Data64kb* p_type =
-                    static_cast<const ::Data64kb*>(data);
+            const CustomData* p_type = static_cast<const CustomData*>(data);
             auto calc_size = calculator.calculate_serialized_size(*p_type, current_alignment);
             return static_cast<uint32_t>(calc_size) + rtps::SerializedPayload_t::representation_header_size;
         }
@@ -421,7 +420,7 @@ public:
     }
 
     bool is_bounded_ctx(
-            const std::shared_ptr<Context>& context) const
+            const std::shared_ptr<Context>& context) const override
     {
         was_called(custom_calls_.is_bounded);
         CustomContext::check_context(context);
@@ -489,7 +488,7 @@ public:
         return custom_calls_;
     }
 
-private:
+protected:
 
     void was_called(
             bool& flag) const
@@ -500,6 +499,21 @@ private:
 
     mutable std::mutex mutex_;
     mutable CustomTypeSupportCalls custom_calls_;
+};
+
+class CustomTypeSupportUnbounded : public CustomTypeSupport
+{
+public:
+
+    bool is_bounded_ctx(
+            const std::shared_ptr<Context>& context) const override
+    {
+        was_called(custom_calls_.is_bounded);
+        CustomContext::check_context(context);
+
+        return false;
+    }
+
 };
 
 TEST(CustomSerializationTests, XCDRv1_plain)
@@ -634,8 +648,8 @@ TEST(CustomSerializationTests, XCDRv2_not_plain)
 {
     auto context = CustomContext::instance();
 
-    PubSubWriter<CustomTypeSupport> writer(TEST_TOPIC_NAME);
-    PubSubReader<CustomTypeSupport> reader(TEST_TOPIC_NAME);
+    PubSubWriter<CustomTypeSupportUnbounded> writer(TEST_TOPIC_NAME);
+    PubSubReader<CustomTypeSupportUnbounded> reader(TEST_TOPIC_NAME);
     CustomTypeSupport* writer_type = nullptr;
     CustomTypeSupport* reader_type = nullptr;
     CustomData sent_data;
@@ -693,6 +707,7 @@ TEST(CustomSerializationTests, XCDRv2_not_plain)
         auto expected_calls = writer_type->get_calls();
         expected_calls.compute_key_data = true;
         expected_calls.serialize = true;
+        expected_calls.calculate_serialized_size = true;
 
         EXPECT_TRUE(writer.send_sample(sent_data));
 

--- a/test/blackbox/common/DDSBlackboxTestsCustomSerialization.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsCustomSerialization.cpp
@@ -306,8 +306,8 @@ public:
         try
         {
             eprosima::fastcdr::CdrSizeCalculator calculator(
-                    data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
-                    eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
+                data_representation == DataRepresentationId_t::XCDR_DATA_REPRESENTATION ?
+                eprosima::fastcdr::CdrVersion::XCDRv1 :eprosima::fastcdr::CdrVersion::XCDRv2);
             size_t current_alignment {0};
             const CustomData* p_type = static_cast<const CustomData*>(data);
             auto calc_size = calculator.calculate_serialized_size(*p_type, current_alignment);

--- a/test/blackbox/common/DDSBlackboxTestsCustomSerialization.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsCustomSerialization.cpp
@@ -132,7 +132,7 @@ void deserialize(
     test::CustomContext::check_context(std::dynamic_pointer_cast<test::CustomContext>(ctx));
 
     // We directly encode the data inside the representation header.
-    auto options = dcdr.get_dds_cdr_options();
+    std::array<uint8_t, 2> options = dcdr.get_dds_cdr_options();
     data.data = options[0];
 }
 

--- a/test/blackbox/common/DDSBlackboxTestsCustomSerialization.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsCustomSerialization.cpp
@@ -14,6 +14,7 @@
 
 
 #include <cstdint>
+#include <cstring>
 #include <limits>
 #include <memory>
 
@@ -22,14 +23,15 @@
 #include <fastcdr/Cdr.h>
 #include <fastcdr/CdrSizeCalculator.hpp>
 
+#include <fastdds/dds/core/LoanableSequence.hpp>
+#include <fastdds/dds/core/StackAllocatedSequence.hpp>
 #include <fastdds/dds/topic/TopicDataType.hpp>
+#include <fastdds/rtps/common/SerializedPayload.hpp>
+#include <fastdds/utils/md5.hpp>
 
 #include "BlackboxTests.hpp"
 #include "PubSubReader.hpp"
 #include "PubSubWriter.hpp"
-#include <fastdds/rtps/common/SerializedPayload.hpp>
-#include <cstring>
-#include <fastdds/utils/md5.hpp>
 
 //{ Type and context definitions
 
@@ -45,6 +47,13 @@ struct CustomData
 {
     uint8_t data;
 };
+
+bool operator ==(
+        const CustomData& lhs,
+        const CustomData& rhs)
+{
+    return lhs.data == rhs.data;
+}
 
 /**
  * @brief CustomContext type that will be used in the custom serialization tests.
@@ -454,7 +463,9 @@ public:
 
     void register_type_object_representation() override
     {
-        register_type_object_representation_ctx(nullptr);
+        // Note this is called from the participant when the type is registered.
+        // Adding the context, since we don't have access to the context here.
+        register_type_object_representation_ctx(CustomContext::instance());
     }
 
     void register_type_object_representation_ctx(
@@ -490,6 +501,260 @@ private:
     mutable std::mutex mutex_;
     mutable CustomTypeSupportCalls custom_calls_;
 };
+
+TEST(CustomSerializationTests, XCDRv1_plain)
+{
+    auto context = CustomContext::instance();
+
+    PubSubWriter<CustomTypeSupport> writer(TEST_TOPIC_NAME);
+    PubSubReader<CustomTypeSupport> reader(TEST_TOPIC_NAME);
+    CustomTypeSupport* writer_type = nullptr;
+    CustomTypeSupport* reader_type = nullptr;
+    CustomData sent_data;
+    sent_data.data = 42;
+
+    // Check reader initialization calls
+    {
+        CustomTypeSupport::CustomTypeSupportCalls expected_calls {};
+        expected_calls.get_max_serialized_size = true;
+        expected_calls.register_type_object_representation = true;
+        expected_calls.is_bounded = true;
+        expected_calls.is_plain = true;
+
+        reader.reliability(eprosima::fastdds::dds::ReliabilityQosPolicyKind::RELIABLE_RELIABILITY_QOS)
+                .durability_kind(eprosima::fastdds::dds::DurabilityQosPolicyKind::TRANSIENT_LOCAL_DURABILITY_QOS)
+                .data_representation({ eprosima::fastdds::dds::DataRepresentationId_t::XCDR_DATA_REPRESENTATION })
+                .context(context)
+                .init();
+        ASSERT_TRUE(reader.isInitialized());
+        reader_type = dynamic_cast<CustomTypeSupport*>(reader.get_type_support().get());
+        ASSERT_NE(reader_type, nullptr);
+
+        EXPECT_EQ(reader_type->get_calls(), expected_calls);
+    }
+
+    // Check writer initialization calls
+    {
+        CustomTypeSupport::CustomTypeSupportCalls expected_calls {};
+        expected_calls.get_max_serialized_size = true;
+        expected_calls.register_type_object_representation = true;
+        expected_calls.is_bounded = true;
+        expected_calls.is_plain = true;
+
+        writer.reliability(eprosima::fastdds::dds::ReliabilityQosPolicyKind::RELIABLE_RELIABILITY_QOS)
+                .durability_kind(eprosima::fastdds::dds::DurabilityQosPolicyKind::TRANSIENT_LOCAL_DURABILITY_QOS)
+                .data_representation({ eprosima::fastdds::dds::DataRepresentationId_t::XCDR_DATA_REPRESENTATION })
+                .context(context)
+                .init();
+        ASSERT_TRUE(writer.isInitialized());
+        writer_type = dynamic_cast<CustomTypeSupport*>(writer.get_type_support().get());
+        ASSERT_NE(writer_type, nullptr);
+
+        EXPECT_EQ(writer_type->get_calls(), expected_calls);
+    }
+
+    // Wait for discovery
+    writer.wait_discovery();
+    reader.wait_discovery();
+
+    DataReader& data_reader = reader.get_native_reader();
+    DataWriter& data_writer = writer.get_native_writer();
+
+    // Check calls after loaning and discarding a sample
+    {
+        auto expected_calls = writer_type->get_calls();
+        expected_calls.construct_sample = true;
+
+        void* loaned_sample = nullptr;
+        ReturnCode_t loan_result = data_writer.loan_sample(
+            loaned_sample, DataWriter::LoanInitializationKind::CONSTRUCTED_LOAN_INITIALIZATION);
+        EXPECT_EQ(loan_result, RETCODE_OK);
+        EXPECT_EQ(data_writer.discard_loan(loaned_sample), RETCODE_OK);
+
+        EXPECT_EQ(writer_type->get_calls(), expected_calls);
+    }
+
+    // Check calls after sending a sample
+    {
+        auto expected_calls = writer_type->get_calls();
+        expected_calls.compute_key_data = true;
+        expected_calls.serialize = true;
+
+        EXPECT_TRUE(writer.send_sample(sent_data));
+
+        EXPECT_EQ(writer_type->get_calls(), expected_calls);
+    }
+
+    // Check calls after a message is received but before it is read or taken
+    {
+        auto expected_calls = reader_type->get_calls();
+        // This is not called since the writer transmits the instance handle along with the data
+        expected_calls.compute_key_payload = false;
+
+        EXPECT_TRUE(data_reader.wait_for_unread_message({1, 0}));
+
+        EXPECT_EQ(reader_type->get_calls(), expected_calls);
+    }
+
+    // Check calls after reading with loans
+    {
+        auto expected_calls = reader_type->get_calls();
+        // No calls are added since the data is not deserialized
+
+        FASTDDS_SEQUENCE(DataSeq, CustomData);
+        DataSeq data_seq;
+        SampleInfoSeq info_seq;
+        EXPECT_EQ(data_reader.read(data_seq, info_seq), RETCODE_OK);
+        EXPECT_EQ(data_seq.length(), 1u);
+        EXPECT_EQ(info_seq.length(), 1u);
+        EXPECT_TRUE(info_seq[0].valid_data);
+        EXPECT_EQ(data_reader.return_loan(data_seq, info_seq), RETCODE_OK);
+
+        EXPECT_EQ(reader_type->get_calls(), expected_calls);
+    }
+
+    // Check calls after taking without loans
+    {
+        auto expected_calls = reader_type->get_calls();
+        expected_calls.deserialize = true;
+
+        StackAllocatedSequence<CustomData, 1> data_seq_take;
+        SampleInfoSeq info_seq_take(1);
+        EXPECT_EQ(data_reader.take(data_seq_take, info_seq_take), RETCODE_OK);
+        EXPECT_EQ(data_seq_take.length(), 1u);
+        EXPECT_EQ(info_seq_take.length(), 1u);
+        EXPECT_TRUE(info_seq_take[0].valid_data);
+        EXPECT_EQ(sent_data, data_seq_take[0]);
+
+        EXPECT_EQ(reader_type->get_calls(), expected_calls);
+    }
+}
+
+TEST(CustomSerializationTests, XCDRv2_not_plain)
+{
+    auto context = CustomContext::instance();
+
+    PubSubWriter<CustomTypeSupport> writer(TEST_TOPIC_NAME);
+    PubSubReader<CustomTypeSupport> reader(TEST_TOPIC_NAME);
+    CustomTypeSupport* writer_type = nullptr;
+    CustomTypeSupport* reader_type = nullptr;
+    CustomData sent_data;
+    sent_data.data = 42;
+
+    // Check reader initialization calls
+    {
+        CustomTypeSupport::CustomTypeSupportCalls expected_calls{};
+        expected_calls.get_max_serialized_size = true;
+        expected_calls.register_type_object_representation = true;
+        expected_calls.is_bounded = true;
+        expected_calls.is_plain = true;
+
+        reader.reliability(eprosima::fastdds::dds::ReliabilityQosPolicyKind::RELIABLE_RELIABILITY_QOS)
+                .durability_kind(eprosima::fastdds::dds::DurabilityQosPolicyKind::TRANSIENT_LOCAL_DURABILITY_QOS)
+                .data_representation({ eprosima::fastdds::dds::DataRepresentationId_t::XCDR2_DATA_REPRESENTATION })
+                .resource_limits_allocated_samples(0)
+                .context(context)
+                .init();
+        ASSERT_TRUE(reader.isInitialized());
+        reader_type = dynamic_cast<CustomTypeSupport*>(reader.get_type_support().get());
+        ASSERT_NE(reader_type, nullptr);
+
+        EXPECT_EQ(reader_type->get_calls(), expected_calls);
+    }
+
+    // Check writer initialization calls
+    {
+        CustomTypeSupport::CustomTypeSupportCalls expected_calls{};
+        expected_calls.get_max_serialized_size = true;
+        expected_calls.register_type_object_representation = true;
+        expected_calls.is_bounded = true;
+        expected_calls.is_plain = true;
+
+        writer.reliability(eprosima::fastdds::dds::ReliabilityQosPolicyKind::RELIABLE_RELIABILITY_QOS)
+                .durability_kind(eprosima::fastdds::dds::DurabilityQosPolicyKind::TRANSIENT_LOCAL_DURABILITY_QOS)
+                .data_representation({ eprosima::fastdds::dds::DataRepresentationId_t::XCDR2_DATA_REPRESENTATION })
+                .context(context)
+                .init();
+        ASSERT_TRUE(writer.isInitialized());
+        writer_type = dynamic_cast<CustomTypeSupport*>(writer.get_type_support().get());
+        ASSERT_NE(writer_type, nullptr);
+
+        EXPECT_EQ(writer_type->get_calls(), expected_calls);
+    }
+
+    // Wait for discovery
+    writer.wait_discovery();
+    reader.wait_discovery();
+
+    DataReader& data_reader = reader.get_native_reader();
+
+    // Check calls after sending a sample
+    {
+        auto expected_calls = writer_type->get_calls();
+        expected_calls.compute_key_data = true;
+        expected_calls.serialize = true;
+
+        EXPECT_TRUE(writer.send_sample(sent_data));
+
+        EXPECT_EQ(writer_type->get_calls(), expected_calls);
+    }
+
+    // Check calls after a message is received but before it is read or taken
+    {
+        auto expected_calls = reader_type->get_calls();
+        // This is not called since the writer transmits the instance handle along with the data
+        expected_calls.compute_key_payload = false;
+
+        EXPECT_TRUE(data_reader.wait_for_unread_message({ 1, 0 }));
+
+        EXPECT_EQ(reader_type->get_calls(), expected_calls);
+    }
+
+    // Check calls after reading with loans
+    {
+        auto expected_calls = reader_type->get_calls();
+        expected_calls.create_data = true;
+        expected_calls.deserialize = true;
+        expected_calls.delete_data = false; // Data is kept in the loan manager until the reader is destroyed.
+
+        FASTDDS_SEQUENCE(DataSeq, CustomData);
+        DataSeq data_seq;
+        SampleInfoSeq info_seq;
+        EXPECT_EQ(data_reader.read(data_seq, info_seq), RETCODE_OK);
+        EXPECT_EQ(data_seq.length(), 1u);
+        EXPECT_EQ(info_seq.length(), 1u);
+        EXPECT_TRUE(info_seq[0].valid_data);
+        EXPECT_EQ(data_reader.return_loan(data_seq, info_seq), RETCODE_OK);
+
+        EXPECT_EQ(reader_type->get_calls(), expected_calls);
+    }
+
+    // Check calls after taking without loans
+    {
+        auto expected_calls = reader_type->get_calls();
+        expected_calls.deserialize = true;
+
+        StackAllocatedSequence<CustomData, 1> data_seq_take;
+        SampleInfoSeq info_seq_take(1);
+        EXPECT_EQ(data_reader.take(data_seq_take, info_seq_take), RETCODE_OK);
+        EXPECT_EQ(data_seq_take.length(), 1u);
+        EXPECT_EQ(info_seq_take.length(), 1u);
+        EXPECT_TRUE(info_seq_take[0].valid_data);
+        EXPECT_EQ(sent_data, data_seq_take[0]);
+
+        EXPECT_EQ(reader_type->get_calls(), expected_calls);
+    }
+
+    // Check calls after destroying the reader
+    {
+        auto expected_calls = reader_type->get_calls();
+        expected_calls.delete_data = true;
+
+        reader.destroy();
+
+        EXPECT_EQ(reader_type->get_calls(), expected_calls);
+    }
+}
 
 }  // namespace custom_serialization_test
 }  // namespace dds

--- a/test/blackbox/common/DDSBlackboxTestsCustomSerialization.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsCustomSerialization.cpp
@@ -32,6 +32,7 @@
 #include "BlackboxTests.hpp"
 #include "PubSubReader.hpp"
 #include "PubSubWriter.hpp"
+#include "UDPMessageSender.hpp"
 
 //{ Type and context definitions
 
@@ -639,6 +640,64 @@ TEST(CustomSerializationTests, XCDRv1_plain)
         EXPECT_EQ(info_seq_take.length(), 1u);
         EXPECT_TRUE(info_seq_take[0].valid_data);
         EXPECT_EQ(sent_data, data_seq_take[0]);
+
+        EXPECT_EQ(reader_type->get_calls(), expected_calls);
+    }
+
+    {
+        auto expected_calls = reader_type->get_calls();
+        expected_calls.compute_key_payload = true;
+        expected_calls.compute_key_data = true;
+
+        struct PacketNoInlineQos
+        {
+            std::array<char, 4> rtps_id{ {'R', 'T', 'P', 'S'} };
+            std::array<uint8_t, 2> protocol_version{ {2, 3} };
+            std::array<uint8_t, 2> vendor_id{ {0x01, 0x0F} };
+            rtps::GuidPrefix_t sender_prefix{};
+
+            struct DataSubMsg
+            {
+                uint8_t submessage_id = 0x15; // DATA
+    #if FASTDDS_IS_BIG_ENDIAN_TARGET
+                uint8_t flags = 0x04;         // D=1
+    #else
+                uint8_t flags = 0x05;         // E=1, D=1
+    #endif  // FASTDDS_IS_BIG_ENDIAN_TARGET
+                uint16_t octets_to_next_header = 24;
+                uint16_t extra_flags = 0;
+                uint16_t octets_to_inline_qos = 16;
+                rtps::EntityId_t reader_id{};
+                rtps::EntityId_t writer_id{};
+                rtps::SequenceNumber_t sn{ 0, 2u };
+                // Minimal serialized payload: just the CDR_LE encapsulation header.
+                std::array<uint8_t, 4> serialized_payload{ {0x00, 0x01, 24u, 0x00} };
+            }
+            data;
+        };
+
+        rtps::LocatorList locators;
+        if ((RETCODE_OK == data_reader.get_listening_locators(locators)) && !locators.empty())
+        {
+            UDPMessageSender msg_sender;
+            PacketNoInlineQos packet;
+            packet.sender_prefix = data_writer.guid().guidPrefix;
+            packet.data.writer_id = data_writer.guid().entityId;
+            packet.data.reader_id = data_reader.guid().entityId;
+
+            CDRMessage_t msg(0);
+            uint32_t msg_len = static_cast<uint32_t>(sizeof(packet));
+            msg.init(reinterpret_cast<octet*>(&packet), msg_len);
+            msg.length = msg_len;
+            msg.pos = msg_len;
+
+            for (const auto& locator : locators)
+            {
+                msg_sender.send(msg, locator);
+            }
+        }
+
+        EXPECT_TRUE(data_reader.wait_for_unread_message({ 1, 0 }));
 
         EXPECT_EQ(reader_type->get_calls(), expected_calls);
     }

--- a/test/blackbox/common/DDSBlackboxTestsCustomSerialization.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsCustomSerialization.cpp
@@ -148,6 +148,40 @@ class CustomTypeSupport : public TopicDataType
 {
 public:
 
+    struct CustomTypeSupportCalls
+    {
+        bool serialize = false;
+        bool deserialize = false;
+        bool calculate_serialized_size = false;
+        bool create_data = false;
+        bool delete_data = false;
+        bool compute_key_payload = false;
+        bool compute_key_data = false;
+        bool is_bounded = false;
+        bool is_plain = false;
+        bool construct_sample = false;
+        bool register_type_object_representation = false;
+        bool get_max_serialized_size = false;
+
+        bool operator ==(
+                const CustomTypeSupportCalls& other) const
+        {
+            return serialize == other.serialize &&
+                   deserialize == other.deserialize &&
+                   calculate_serialized_size == other.calculate_serialized_size &&
+                   create_data == other.create_data &&
+                   delete_data == other.delete_data &&
+                   compute_key_payload == other.compute_key_payload &&
+                   compute_key_data == other.compute_key_data &&
+                   is_bounded == other.is_bounded &&
+                   is_plain == other.is_plain &&
+                   construct_sample == other.construct_sample &&
+                   register_type_object_representation == other.register_type_object_representation &&
+                   get_max_serialized_size == other.get_max_serialized_size;
+        }
+
+    };
+
     typedef CustomData type;
 
     CustomTypeSupport()
@@ -172,6 +206,7 @@ public:
             rtps::SerializedPayload_t& payload,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override
     {
+        was_called(custom_calls_.serialize);
         CustomContext::check_context(context);
 
         eprosima::fastcdr::FastBuffer fastbuffer(reinterpret_cast<char*>(payload.data), payload.max_size);
@@ -217,6 +252,7 @@ public:
             rtps::SerializedPayload_t& payload,
             void* data) override
     {
+        was_called(custom_calls_.deserialize);
         CustomContext::check_context(context);
 
         try
@@ -261,6 +297,7 @@ public:
             const void* const data,
             eprosima::fastdds::dds::DataRepresentationId_t data_representation) override
     {
+        was_called(custom_calls_.calculate_serialized_size);
         CustomContext::check_context(context);
 
         try
@@ -288,6 +325,7 @@ public:
     void* create_data_ctx(
             const std::shared_ptr<Context>& context)
     {
+        was_called(custom_calls_.create_data);
         CustomContext::check_context(context);
         return new CustomData();
     }
@@ -302,6 +340,7 @@ public:
             const std::shared_ptr<Context>& context,
             void* data)
     {
+        was_called(custom_calls_.delete_data);
         CustomContext::check_context(context);
         delete static_cast<CustomData*>(data);
     }
@@ -320,6 +359,7 @@ public:
             rtps::InstanceHandle_t& ihandle,
             bool force_md5 = false) override
     {
+        was_called(custom_calls_.compute_key_payload);
         CustomData data;
         if (deserialize_ctx(context, payload, &data))
         {
@@ -342,6 +382,7 @@ public:
             rtps::InstanceHandle_t& ihandle,
             bool force_md5 = false) override
     {
+        was_called(custom_calls_.compute_key_data);
         CustomContext::check_context(context);
 
         const CustomData* p_type = static_cast<const CustomData*>(data);
@@ -373,6 +414,7 @@ public:
     bool is_bounded_ctx(
             const std::shared_ptr<Context>& context) const
     {
+        was_called(custom_calls_.is_bounded);
         CustomContext::check_context(context);
 
         return true;
@@ -388,6 +430,7 @@ public:
             const std::shared_ptr<Context>& context,
             DataRepresentationId_t representation) const override
     {
+        was_called(custom_calls_.is_plain);
         CustomContext::check_context(context);
         return eprosima::fastdds::dds::DataRepresentationId_t::XCDR_DATA_REPRESENTATION == representation;
     }
@@ -402,6 +445,7 @@ public:
             const std::shared_ptr<Context>& context,
             void* memory) const override
     {
+        was_called(custom_calls_.construct_sample);
         CustomContext::check_context(context);
         CustomData* p_type = static_cast<CustomData*>(memory);
         new (p_type) CustomData();
@@ -416,16 +460,35 @@ public:
     void register_type_object_representation_ctx(
             const std::shared_ptr<Context>& context) override
     {
+        was_called(custom_calls_.register_type_object_representation);
         CustomContext::check_context(context);
     }
 
     uint32_t get_max_serialized_size_ctx(
             const std::shared_ptr<Context>& context)
     {
+        was_called(custom_calls_.get_max_serialized_size);
         CustomContext::check_context(context);
         return max_serialized_type_size;
     }
 
+    CustomTypeSupportCalls get_calls() const
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        return custom_calls_;
+    }
+
+private:
+
+    void was_called(
+            bool& flag) const
+    {
+        std::lock_guard<std::mutex> lock(mutex_);
+        flag = true;
+    }
+
+    mutable std::mutex mutex_;
+    mutable CustomTypeSupportCalls custom_calls_;
 };
 
 }  // namespace custom_serialization_test

--- a/test/blackbox/common/DDSBlackboxTestsCustomSerialization.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsCustomSerialization.cpp
@@ -1,0 +1,82 @@
+// Copyright 2026 Proyectos y Sistemas de Mantenimiento SL (eProsima).
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+
+#include <cstdint>
+#include <limits>
+#include <memory>
+
+#include <gtest/gtest.h>
+
+#include <fastcdr/Cdr.h>
+#include <fastcdr/CdrSizeCalculator.hpp>
+
+#include <fastdds/dds/topic/TopicDataType.hpp>
+
+#include "BlackboxTests.hpp"
+#include "PubSubReader.hpp"
+#include "PubSubWriter.hpp"
+#include <fastdds/rtps/common/SerializedPayload.hpp>
+#include <cstring>
+#include <fastdds/utils/md5.hpp>
+
+//{ Type and context definitions
+
+namespace eprosima {
+namespace fastdds {
+namespace dds {
+namespace custom_serialization_test {
+
+/**
+ * @brief CustomData type that will be used in the custom serialization tests.
+ */
+struct CustomData
+{
+    uint8_t data;
+};
+
+/**
+ * @brief CustomContext type that will be used in the custom serialization tests.
+ */
+struct CustomContext : public TopicDataType::Context
+{
+    ~CustomContext() override = default;
+
+    /**
+     * @brief Returns a shared pointer to the singleton instance of CustomContext.
+     */
+    static std::shared_ptr<CustomContext> instance()
+    {
+        static std::shared_ptr<CustomContext> instance = std::make_shared<CustomContext>();
+        return instance;
+    }
+
+    /**
+     * @brief Checks that the given context is the same as the singleton instance of CustomContext.
+     */
+    static void check_context(
+            const std::shared_ptr<TopicDataType::Context>& context)
+    {
+        EXPECT_EQ(context, instance());
+    }
+
+};
+
+}  // namespace custom_serialization_test
+}  // namespace dds
+}  // namespace fastdds
+}  // namespace eprosima
+
+//}
+

--- a/test/unittest/dds/subscriber/DataReaderHistoryTests.cpp
+++ b/test/unittest/dds/subscriber/DataReaderHistoryTests.cpp
@@ -79,7 +79,7 @@ TEST(DataReaderHistory, exclusive_ownership_non_keyed_sample_reception)
     DataReaderQos qos;
     qos.ownership().kind = eprosima::fastdds::dds::EXCLUSIVE_OWNERSHIP_QOS;
     qos.history().kind = KEEP_ALL_HISTORY_QOS;
-    DataReaderHistory history(type, topic, qos);
+    DataReaderHistory history(type, nullptr, topic, qos);
     eprosima::fastdds::RecursiveTimedMutex mutex;
     eprosima::fastdds::rtps::StatelessReader reader(&history, &mutex);
     std::vector<std::unique_ptr<eprosima::fastdds::rtps::CacheChange_t>> changes;
@@ -139,7 +139,7 @@ TEST(DataReaderHistory, exclusive_ownership_keyed_sample_reception)
     DataReaderQos qos;
     qos.ownership().kind = eprosima::fastdds::dds::EXCLUSIVE_OWNERSHIP_QOS;
     qos.history().kind = KEEP_ALL_HISTORY_QOS;
-    DataReaderHistory history(type, topic, qos);
+    DataReaderHistory history(type, nullptr, topic, qos);
     eprosima::fastdds::RecursiveTimedMutex mutex;
     eprosima::fastdds::rtps::StatelessReader reader(&history, &mutex);
     std::vector<std::unique_ptr<eprosima::fastdds::rtps::CacheChange_t>> changes;


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

This adds additional tests for the feature introduced in #6320, and fixes some related issues.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.2.x 2.14.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- __NO__: Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_:New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- _N/A_: Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
