### PR TITLE
[25475] Catch exception when constructing a payload pool Node

### DIFF
--- a/src/cpp/rtps/history/TopicPayloadPool.cpp
+++ b/src/cpp/rtps/history/TopicPayloadPool.cpp
@@ -180,8 +180,15 @@ TopicPayloadPool::PayloadNode* TopicPayloadPool::allocate(
 TopicPayloadPool::PayloadNode* TopicPayloadPool::do_allocate(
         uint32_t size)
 {
-    PayloadNode* payload = new (std::nothrow) PayloadNode(size);
-
+    PayloadNode* payload = nullptr;
+    try
+    {
+        payload = new PayloadNode(size);
+    }
+    catch (const std::bad_alloc&)
+    {
+    }
+    
     if (payload != nullptr)
     {
         payload->data_index(static_cast<uint32_t>(all_payloads_.size()));

--- a/src/cpp/rtps/history/TopicPayloadPool.cpp
+++ b/src/cpp/rtps/history/TopicPayloadPool.cpp
@@ -188,7 +188,7 @@ TopicPayloadPool::PayloadNode* TopicPayloadPool::do_allocate(
     catch (const std::bad_alloc&)
     {
     }
-    
+
     if (payload != nullptr)
     {
         payload->data_index(static_cast<uint32_t>(all_payloads_.size()));

--- a/src/cpp/rtps/history/TopicPayloadPool.hpp
+++ b/src/cpp/rtps/history/TopicPayloadPool.hpp
@@ -147,7 +147,7 @@ protected:
             }
             else
             {
-                buffer = (octet*)calloc(size + sizeof(NodeInfo) - 1, sizeof(octet));
+                buffer = (octet*)calloc(size + data_offset, sizeof(octet));
             }
 
             if (buffer == nullptr)

--- a/test/unittest/rtps/history/TopicPayloadPoolTests.cpp
+++ b/test/unittest/rtps/history/TopicPayloadPoolTests.cpp
@@ -17,6 +17,7 @@
 #include <rtps/history/TopicPayloadPool.hpp>
 #include <fastdds/rtps/common/CacheChange.hpp>
 
+#include <limits>
 #include <tuple>
 
 using namespace eprosima::fastdds::rtps;
@@ -481,6 +482,49 @@ TEST(TopicPayloalPoolTests, dynamic_reusable_memory_zero_size)
 {
     PoolConfig config{ DYNAMIC_REUSABLE_MEMORY_MODE, 128, 0, 1};
     do_dynamic_topic_payload_pool_zero_size_test(config);
+}
+
+//! Regression test for redmine issue #25475
+//! When the allocation of a new payload node fails, the pool must report the
+//! failure gracefully (returning false) instead of letting the std::bad_alloc
+//! thrown by the PayloadNode constructor propagate out of get_payload.
+//! Might require to be run in a constrained environment (i.e. container with limited memory)
+//! to actually trigger the allocation failure, but will not fail if the allocation succeeds.
+TEST(TopicPayloalPoolTests, bad_alloc_on_get_payload_is_handled)
+{
+    // An infinite history so that the pool is allowed to allocate on demand
+    // (otherwise allocate() would short-circuit on the maximum pool size).
+    PoolConfig config{ DYNAMIC_RESERVE_MEMORY_MODE, 128, 0, 0 };
+
+    std::unique_ptr<ITopicPayloadPool> pool = TopicPayloadPool::get(config);
+    ASSERT_NE(pool, nullptr);
+    pool->reserve_history(config, false);
+
+    // Request a payload so large that the underlying calloc is expected to fail,
+    // making the PayloadNode constructor throw std::bad_alloc.
+    constexpr uint32_t huge_size = (std::numeric_limits<uint32_t>::max)();
+
+    CacheChange_t change;
+    bool result = true;
+
+    // The pool must never let the exception escape.
+    EXPECT_NO_THROW(result = pool->get_payload(huge_size, change.serializedPayload));
+
+    if (result)
+    {
+        // On a platform able to satisfy such a large allocation, release it.
+        EXPECT_EQ(huge_size, change.serializedPayload.max_size);
+        pool->release_payload(change.serializedPayload);
+    }
+    else
+    {
+        // On allocation failure the payload must be left in a clean state.
+        EXPECT_EQ(change.serializedPayload.data, nullptr);
+        EXPECT_EQ(change.serializedPayload.max_size, 0u);
+        EXPECT_EQ(change.serializedPayload.payload_owner, nullptr);
+    }
+
+    pool->release_history(config, false);
 }
 
 #ifdef INSTANTIATE_TEST_SUITE_P


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

Fixes a common misuse of `std::nothrow`. Calling `new (std::nothrow) T()` only avoids throwing when allocating T, but exceptions thrown when executing T's constructor are not avoided.

This fixes the problem by capturing `std::bad_alloc` when creating the node.

A regression test is also added.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.2.x 2.14.x

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- _N/A_: If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
