### PR TITLE
Tsan/2.6.x/flowcontroler loi deadlock

### DIFF
--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -1221,55 +1221,58 @@ bool StatefulWriter::matched_reader_remove(
 {
     ReaderProxy* rproxy = nullptr;
     std::unique_lock<RecursiveTimedMutex> lock(mp_mutex);
-    std::unique_lock<LocatorSelectorSender> guard_locator_selector_general(locator_selector_general_);
-    std::unique_lock<LocatorSelectorSender> guard_locator_selector_async(locator_selector_async_);
 
-    for (ReaderProxyIterator it = matched_local_readers_.begin();
-            it != matched_local_readers_.end(); ++it)
     {
-        if ((*it)->guid() == reader_guid)
-        {
-            logInfo(RTPS_WRITER, "Reader Proxy removed: " << reader_guid);
-            rproxy = std::move(*it);
-            it = matched_local_readers_.erase(it);
-            break;
-        }
-    }
+        std::unique_lock<LocatorSelectorSender> guard_locator_selector_general(locator_selector_general_);
+        std::unique_lock<LocatorSelectorSender> guard_locator_selector_async(locator_selector_async_);
 
-    if (rproxy == nullptr)
-    {
-        for (ReaderProxyIterator it = matched_datasharing_readers_.begin();
-                it != matched_datasharing_readers_.end(); ++it)
+        for (ReaderProxyIterator it = matched_local_readers_.begin();
+                it != matched_local_readers_.end(); ++it)
         {
             if ((*it)->guid() == reader_guid)
             {
                 logInfo(RTPS_WRITER, "Reader Proxy removed: " << reader_guid);
                 rproxy = std::move(*it);
-                it = matched_datasharing_readers_.erase(it);
+                it = matched_local_readers_.erase(it);
                 break;
             }
         }
-    }
 
-    if (rproxy == nullptr)
-    {
-        for (ReaderProxyIterator it = matched_remote_readers_.begin();
-                it != matched_remote_readers_.end(); ++it)
+        if (rproxy == nullptr)
         {
-            if ((*it)->guid() == reader_guid)
+            for (ReaderProxyIterator it = matched_datasharing_readers_.begin();
+                    it != matched_datasharing_readers_.end(); ++it)
             {
-                logInfo(RTPS_WRITER, "Reader Proxy removed: " << reader_guid);
-                rproxy = std::move(*it);
-                it = matched_remote_readers_.erase(it);
-                break;
+                if ((*it)->guid() == reader_guid)
+                {
+                    logInfo(RTPS_WRITER, "Reader Proxy removed: " << reader_guid);
+                    rproxy = std::move(*it);
+                    it = matched_datasharing_readers_.erase(it);
+                    break;
+                }
             }
         }
-    }
 
-    locator_selector_general_.locator_selector.remove_entry(reader_guid);
-    locator_selector_async_.locator_selector.remove_entry(reader_guid);
-    update_reader_info(locator_selector_general_, false);
-    update_reader_info(locator_selector_async_, false);
+        if (rproxy == nullptr)
+        {
+            for (ReaderProxyIterator it = matched_remote_readers_.begin();
+                    it != matched_remote_readers_.end(); ++it)
+            {
+                if ((*it)->guid() == reader_guid)
+                {
+                    logInfo(RTPS_WRITER, "Reader Proxy removed: " << reader_guid);
+                    rproxy = std::move(*it);
+                    it = matched_remote_readers_.erase(it);
+                    break;
+                }
+            }
+        }
+
+        locator_selector_general_.locator_selector.remove_entry(reader_guid);
+        locator_selector_async_.locator_selector.remove_entry(reader_guid);
+        update_reader_info(locator_selector_general_, false);
+        update_reader_info(locator_selector_async_, false);
+    }
 
     if (getMatchedReadersSize() == 0)
     {
@@ -1281,14 +1284,11 @@ bool StatefulWriter::matched_reader_remove(
         rproxy->stop();
         matched_readers_pool_.push_back(rproxy);
 
-        guard_locator_selector_async.unlock();
-        guard_locator_selector_general.unlock();
-
         check_acked_status();
 
         if (nullptr != mp_listener)
         {
-            // call the listener without locks taken
+            // listener is called without locks taken
             lock.unlock();
 
             mp_listener->on_reader_discovery(this, ReaderDiscoveryInfo::REMOVED_READER, reader_guid, nullptr);

--- a/src/cpp/rtps/writer/StatefulWriter.cpp
+++ b/src/cpp/rtps/writer/StatefulWriter.cpp
@@ -599,7 +599,8 @@ void StatefulWriter::send_heartbeat_to_all_readers()
             select_all_readers_nts(group, locator_selector_general_);
 
             assert(
-                (SequenceNumber_t::unknown() == get_seq_num_min() && SequenceNumber_t::unknown() == get_seq_num_max()) ||
+                (SequenceNumber_t::unknown() == get_seq_num_min() &&
+                SequenceNumber_t::unknown() == get_seq_num_max()) ||
                 (SequenceNumber_t::unknown() != get_seq_num_min() &&
                 SequenceNumber_t::unknown() != get_seq_num_max()));
 
@@ -1062,8 +1063,8 @@ bool StatefulWriter::matched_reader_add(
         }
         else
         {
-            logWarning(RTPS_WRITER, "Maximum number of reader proxies (" << max_readers <<
-                    ") reached for writer " << m_guid);
+            logWarning(RTPS_WRITER, "Maximum number of reader proxies (" << max_readers
+                                                                         << ") reached for writer " << m_guid);
             return false;
         }
     }
@@ -1200,8 +1201,8 @@ bool StatefulWriter::matched_reader_add(
 
     logInfo(RTPS_WRITER, "Reader Proxy " << rp->guid() << " added to " << this->m_guid.entityId << " with "
                                          << rdata.remote_locators().unicast.size() << "(u)-"
-                                         << rdata.remote_locators().multicast.size() <<
-            "(m) locators");
+                                         << rdata.remote_locators().multicast.size()
+                                         << "(m) locators");
 
     if (nullptr != mp_listener)
     {
@@ -1280,13 +1281,14 @@ bool StatefulWriter::matched_reader_remove(
         rproxy->stop();
         matched_readers_pool_.push_back(rproxy);
 
+        guard_locator_selector_async.unlock();
+        guard_locator_selector_general.unlock();
+
         check_acked_status();
 
         if (nullptr != mp_listener)
         {
             // call the listener without locks taken
-            guard_locator_selector_async.unlock();
-            guard_locator_selector_general.unlock();
             lock.unlock();
 
             mp_listener->on_reader_discovery(this, ReaderDiscoveryInfo::REMOVED_READER, reader_guid, nullptr);
@@ -1490,7 +1492,8 @@ void StatefulWriter::check_acked_status()
                     mp_listener->onWriterChangeReceivedByAll(this, change);
 
                     // Stop if we got to either next_all_acked_notify_sequence_ or the first change
-                } while (seq > end_seq);
+                }
+                while (seq > end_seq);
             }
 
             next_all_acked_notify_sequence_ = min_low_mark + 1;
@@ -2040,10 +2043,11 @@ bool StatefulWriter::ack_timer_expired()
         do
         {
             last_sequence_number_++;
-        } while (!mp_history->get_change(
-            last_sequence_number_,
-            getGuid(),
-            &change) && last_sequence_number_ < next_sequence_number());
+        }
+        while (!mp_history->get_change(
+                    last_sequence_number_,
+                    getGuid(),
+                    &change) && last_sequence_number_ < next_sequence_number());
 
         if (!mp_history->get_change(
                     last_sequence_number_,

--- a/test/blackbox/api/fastrtps_deprecated/PubSubReader.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubReader.hpp
@@ -163,7 +163,8 @@ private:
                 do
                 {
                     reader_.receive_one(sub, ret);
-                } while (ret);
+                }
+                while (ret);
             }
         }
 
@@ -334,8 +335,8 @@ public:
             if (subscriber_ != nullptr)
             {
                 subscriber_guid_ = subscriber_->getGuid();
-                std::cout << "Created subscriber " << subscriber_guid_ << " for topic " <<
-                    subscriber_attr_.topic.topicName << std::endl;
+                std::cout << "Created subscriber " << subscriber_guid_ << " for topic "
+                          << subscriber_attr_.topic.topicName << std::endl;
 
                 initialized_ = true;
             }

--- a/test/blackbox/api/fastrtps_deprecated/PubSubReader.hpp
+++ b/test/blackbox/api/fastrtps_deprecated/PubSubReader.hpp
@@ -384,6 +384,18 @@ public:
         receiving_.store(true);
     }
 
+    void startReception(
+            size_t expected_samples)
+    {
+        {
+            std::unique_lock<std::mutex> lock(mutex_);
+            current_processed_count_ = 0;
+            number_samples_expected_ = expected_samples;
+            last_seq.clear();
+        }
+        receiving_.store(true);
+    }
+
     void stopReception()
     {
         receiving_.store(false);

--- a/test/blackbox/common/BlackboxTestsPubSubFlowControllers.cpp
+++ b/test/blackbox/common/BlackboxTestsPubSubFlowControllers.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <atomic>
 #include <thread>
 
 #include <gtest/gtest.h>
@@ -228,6 +229,56 @@ TEST_P(PubSubFlowControllers, AsyncMultipleWritersFlowController64kb)
 
     // Block reader until reception finished or timeout.
     entities.block_for_all();
+}
+
+// Regression test for a lock-order-inversion (potential deadlock) reported by TSAN between a
+// writer's FlowControllerImpl mutex and its LocatorSelectorSender
+TEST(PubSubFlowControllers, AsyncPubSubReaderRemovalWhileDeliveringDoesNotDeadlock)
+{
+    std::string topic_name = "FlowControllerLockOrderInversion";
+
+    PubSubWriter<HelloWorldPubSubType> writer(topic_name);
+
+    writer.asynchronously(eprosima::fastrtps::ASYNCHRONOUS_PUBLISH_MODE)
+            .reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
+            .durability_kind(eprosima::fastrtps::VOLATILE_DURABILITY_QOS)
+            .history_depth(100)
+            .init();
+    ASSERT_TRUE(writer.isInitialized());
+
+    constexpr size_t n_loops = 20;
+
+    for (size_t i = 0; i < n_loops; ++i)
+    {
+        PubSubReader<HelloWorldPubSubType> reader(topic_name);
+        reader.reliability(eprosima::fastrtps::RELIABLE_RELIABILITY_QOS)
+                .durability_kind(eprosima::fastrtps::VOLATILE_DURABILITY_QOS)
+                .history_depth(100)
+                .init();
+        ASSERT_TRUE(reader.isInitialized());
+
+        writer.wait_discovery(1, std::chrono::seconds(10));
+        reader.wait_discovery();
+
+        std::atomic<bool> keep_sending{true};
+        std::thread sender(
+            [&writer, &keep_sending]()
+            {
+                while (keep_sending.load(std::memory_order_relaxed))
+                {
+                    auto data = default_helloworld_data_generator(1);
+                    writer.send(data, 0);
+                }
+            });
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+        reader.destroy();
+
+        keep_sending.store(false, std::memory_order_relaxed);
+        sender.join();
+
+        writer.wait_reader_undiscovery();
+    }
 }
 
 #ifdef INSTANTIATE_TEST_SUITE_P


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.2.x 2.14.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

This PR aims to fix a potential lock-order-inversion deadlock in `StatefulWriter` between the `LocatorSelectorSender` and the `FlowControler` that triggered during participant tear-down while another participant still delivers samples.
## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [_N/A_] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- [_N/A_] Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [_N/A_] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [_N/A_] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- [_N/A_] New feature has been added to the `versions.md` file (if applicable).
- [_N/A_] New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [_N/A_] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
