### PR TITLE
[25574] Fix TSAN report warnings for interleaved logs

### DIFF
--- a/.github/workflows/reusable-sanitizers-ci.yml
+++ b/.github/workflows/reusable-sanitizers-ci.yml
@@ -392,11 +392,16 @@ jobs:
           $rp = $reportFiles | ForEach-Object { Show-Tsan -Path $_.FullName }
           # filter duplicates
           $rp = $rp | group md5hash | % { $_.group[0] }
-          # Attribute every report to the test executable(s) that produced it, extracted from
-          # its own stack frames (the non-shared-object modules). This is self-contained per
-          # file and robust to interleaving, unlike deriving the test from the tsan.<pid> name.
+          # Attribute every report to the test that produced it, extracted from its own stack
+          # frames. Self-contained per file and robust to interleaving. We prefer the googletest
+          # case name (present as "<Suite>_<Name>_Test::TestBody" in the thread creation stack);
+          # when there is none (e.g. communication subprocesses), we fall back to the test
+          # executable(s), i.e. the non-shared-object modules in the "(module+0x...)" frames.
           $getTests = {
               param($text)
+              $gtest = @([regex]::Matches($text, '([A-Za-z_][A-Za-z0-9_]*)_Test::') |
+                  % { $_.Groups[1].Value } | Sort-Object -Unique)
+              if ($gtest) { return $gtest }
               @([regex]::Matches($text, '\(([^()+\s]+)\+0x[0-9a-fA-F]+\)') |
                   % { $_.Groups[1].Value } | ? { $_ -notmatch '\.so(\.|$)' } | Sort-Object -Unique)
           }
@@ -418,6 +423,13 @@ jobs:
           }
           # Keep one representative per distinct crash signature
           $crash = @($crash | Group-Object signature | % { $_.Group[0] })
+          # Prepend the offending test(s) as the first line of every per-process report file, so
+          # the raw capture shows which test produced it. Done after parsing so it does not affect
+          # Show-Tsan or the crash scan above.
+          foreach ($f in $reportFiles) {
+              $content = Get-Content -Raw -Path $f.FullName
+              Set-Content -Path $f.FullName -Value "Test: $((& $getTests $content) -join ', ')`n`n$content"
+          }
           # Export raw data
           $rp | Export-CliXML (Join-Path $exports all_reports.xml)
           # Group the reports by issue

--- a/.github/workflows/reusable-sanitizers-ci.yml
+++ b/.github/workflows/reusable-sanitizers-ci.yml
@@ -238,6 +238,8 @@ jobs:
     env:
       # Use log_path so each instrumented process write its report to <log_path>.<pid>. Needed to avoid interleaving
       TSAN_OPTIONS: second_deadlock_stack=1 history_size=7 memory_limit_mb=5000 log_path=${{ github.workspace }}/tsan_reports/tsan
+      # Base dir for per-test log_path override injected by tsan_name_reports()
+      TSAN_REPORTS_DIR: ${{ github.workspace }}/tsan_reports
       # GCC 13.2 (Ubuntu Noble default) produces several data races warnings
       # TODO: For now we keep it at GCC 12 and ubuntu 22 until we figure out what to do with them
       # Although hundreds of tests trigger them, these problems arise from approximately
@@ -385,18 +387,19 @@ jobs:
           }
           # Install the report parser module
           Find-Module -Repository PSGallery -Name SanReportParser | Install-Module -Scope CurrentUser -Force
-          # Parse the report files. Each process wrote its own tsan.<pid> file via
+          # Parse the report files. Each process wrote its own <base>.<pid> file via
           # TSAN_OPTIONS=log_path, so reports are never interleaved across processes.
           $reportsDir = "${{ github.workspace }}/tsan_reports"
-          $reportFiles = Get-ChildItem -Path $reportsDir -Filter 'tsan.*' -ErrorAction SilentlyContinue
+          # Every instrumented process writes <base>.<pid>
+          $reportFiles = Get-ChildItem -File -Path $reportsDir -ErrorAction SilentlyContinue |
+              Where-Object Name -match '\.\d+$'
           $rp = $reportFiles | ForEach-Object { Show-Tsan -Path $_.FullName }
           # filter duplicates
           $rp = $rp | group md5hash | % { $_.group[0] }
-          # Attribute every report to the test that produced it, extracted from its own stack
-          # frames. Self-contained per file and robust to interleaving. We prefer the googletest
-          # case name (present as "<Suite>_<Name>_Test::TestBody" in the thread creation stack);
-          # when there is none (e.g. communication subprocesses), we fall back to the test
-          # executable(s), i.e. the non-shared-object modules in the "(module+0x...)" frames.
+          # Attribute a report to its test. The file name is authoritative when it carries the
+          # ctest name. Otherwise (catch-all "tsan.<pid>")
+          # fall back to the report content: the googletest case ("<Suite>_<Name>_Test::TestBody"
+          # in the thread creation stack), else the test executable(s) (non-shared-object modules).
           $getTests = {
               param($text)
               $gtest = @([regex]::Matches($text, '([A-Za-z_][A-Za-z0-9_]*)_Test::') |
@@ -405,9 +408,14 @@ jobs:
               @([regex]::Matches($text, '\(([^()+\s]+)\+0x[0-9a-fA-F]+\)') |
                   % { $_.Groups[1].Value } | ? { $_ -notmatch '\.so(\.|$)' } | Sort-Object -Unique)
           }
+          $testOf = {
+              param($fileName, $text)
+              if ($fileName -match '^(?<t>.+)\.\d+$' -and $Matches.t -ne 'tsan') { return $Matches.t }
+              (& $getTests $text) -join ', '
+          }
           $rp | % {
               Add-Member -InputObject $_ -NotePropertyName test `
-                  -NotePropertyValue ((& $getTests $_.report) -join ', ') -Force
+                  -NotePropertyValue (& $testOf $_.file $_.report) -Force
           }
           # Detect crash reports (SEGV, heap-use-after-free, CHECK failed, ...). Show-Tsan only
           # parses WARNING-delimited reports, so these ERROR reports are invisible to it and would
@@ -419,7 +427,7 @@ jobs:
               $type = if ($blk -match 'ThreadSanitizer:\s*(?<t>[\w-]+)') { $Matches.t } else { 'crash' }
               $sig  = if ($blk -match '(?m)^SUMMARY: ThreadSanitizer:.*$') { $Matches[0].Trim() } else { $type }
               [PSCustomObject]@{ file=$f.Name; type=$type; signature=$sig;
-                                 tests=(& $getTests $blk); report=$blk }
+                                 tests=(& $testOf $f.Name $blk); report=$blk }
           }
           # Keep one representative per distinct crash signature
           $crash = @($crash | Group-Object signature | % { $_.Group[0] })
@@ -428,7 +436,7 @@ jobs:
           # Show-Tsan or the crash scan above.
           foreach ($f in $reportFiles) {
               $content = Get-Content -Raw -Path $f.FullName
-              Set-Content -Path $f.FullName -Value "Test: $((& $getTests $content) -join ', ')`n`n$content"
+              Set-Content -Path $f.FullName -Value "Test: $(& $testOf $f.Name $content)`n`n$content"
           }
           # Export raw data
           $rp | Export-CliXML (Join-Path $exports all_reports.xml)

--- a/.github/workflows/reusable-sanitizers-ci.yml
+++ b/.github/workflows/reusable-sanitizers-ci.yml
@@ -430,6 +430,18 @@ jobs:
           # The step fails on new deadlocks
           $LASTEXITCODE=$sd.count
 
+      # TEMPORARY verification aids for the log_path change; remove once validated.
+      - name: Inspect TSan report capture
+        if: always()
+        run: |
+          echo "## TSan capture check"
+          nfiles=$(ls -1 ${{ github.workspace }}/tsan_reports 2>/dev/null | wc -l)
+          in_files=$(cat ${{ github.workspace }}/tsan_reports/* 2>/dev/null | grep -c "WARNING: ThreadSanitizer:" || true)
+          in_stdout=$(grep -c "WARNING: ThreadSanitizer:" log/latest_test/fastdds/stdout_stderr.log 2>/dev/null || true)
+          echo "Per-process report files : $nfiles"
+          echo "Reports captured in files: $in_files"
+          echo "Reports left in stdout   : $in_stdout   (expected ~0; anything >0 = a process missed the option)"
+
       - name: Check on failures
         if: ${{ steps.report_summary.outcome == 'failure' }}
         shell: pwsh

--- a/.github/workflows/reusable-sanitizers-ci.yml
+++ b/.github/workflows/reusable-sanitizers-ci.yml
@@ -387,10 +387,37 @@ jobs:
           Find-Module -Repository PSGallery -Name SanReportParser | Install-Module -Scope CurrentUser -Force
           # Parse the report files. Each process wrote its own tsan.<pid> file via
           # TSAN_OPTIONS=log_path, so reports are never interleaved across processes.
-          $rp = Get-ChildItem -Path "${{ github.workspace }}/tsan_reports" -Filter 'tsan.*' -ErrorAction SilentlyContinue |
-            ForEach-Object { Show-Tsan -Path $_.FullName }
+          $reportsDir = "${{ github.workspace }}/tsan_reports"
+          $reportFiles = Get-ChildItem -Path $reportsDir -Filter 'tsan.*' -ErrorAction SilentlyContinue
+          $rp = $reportFiles | ForEach-Object { Show-Tsan -Path $_.FullName }
           # filter duplicates
           $rp = $rp | group md5hash | % { $_.group[0] }
+          # Attribute every report to the test executable(s) that produced it, extracted from
+          # its own stack frames (the non-shared-object modules). This is self-contained per
+          # file and robust to interleaving, unlike deriving the test from the tsan.<pid> name.
+          $getTests = {
+              param($text)
+              @([regex]::Matches($text, '\(([^()+\s]+)\+0x[0-9a-fA-F]+\)') |
+                  % { $_.Groups[1].Value } | ? { $_ -notmatch '\.so(\.|$)' } | Sort-Object -Unique)
+          }
+          $rp | % {
+              Add-Member -InputObject $_ -NotePropertyName test `
+                  -NotePropertyValue ((& $getTests $_.report) -join ', ') -Force
+          }
+          # Detect crash reports (SEGV, heap-use-after-free, CHECK failed, ...). Show-Tsan only
+          # parses WARNING-delimited reports, so these ERROR reports are invisible to it and would
+          # otherwise let the job pass green. Scan the per-process files directly.
+          $crash = foreach ($f in $reportFiles) {
+              $content = Get-Content -Raw -Path $f.FullName
+              if ($content -notmatch '(?s)(?<blk>==\d+==ERROR: ThreadSanitizer:.*)') { continue }
+              $blk = $Matches.blk
+              $type = if ($blk -match 'ThreadSanitizer:\s*(?<t>[\w-]+)') { $Matches.t } else { 'crash' }
+              $sig  = if ($blk -match '(?m)^SUMMARY: ThreadSanitizer:.*$') { $Matches[0].Trim() } else { $type }
+              [PSCustomObject]@{ file=$f.Name; type=$type; signature=$sig;
+                                 tests=(& $getTests $blk); report=$blk }
+          }
+          # Keep one representative per distinct crash signature
+          $crash = @($crash | Group-Object signature | % { $_.Group[0] })
           # Export raw data
           $rp | Export-CliXML (Join-Path $exports all_reports.xml)
           # Group the reports by issue
@@ -401,11 +428,11 @@ jobs:
           # Simplified deadlock summary (only one representative report and tests associated)
           $sd = $gd | Sort-Object count -desc | select @{l="fuzzhash";e="name"}, count, `
               @{l="échantillon";e={$_.group[0].report}}, @{l="tests"; `
-                  e={$_.group.file | sls "(.*)\.\d+$" | % { $_.Matches.Groups[1].Value } | Sort-Object | get-unique}}
+                  e={$_.group.test | ? { $_ } | Sort-Object -Unique}}
           # Simplified race summary (only one representative report and tests associated)
           $sr = $gr | Sort-Object count -desc | select @{l="fuzzhash";e="name"}, count, `
               @{l="échantillon";e={$_.group[0].report}}, @{l="tests"; `
-                  e={$_.group.file | sls "(.*)\.\d+$" | % { $_.Matches.Groups[1].Value } | Sort-Object | get-unique}}
+                  e={$_.group.test | ? { $_ } | Sort-Object -Unique}}
           # Export simplified summaries
           $sd, $sr | Export-Clixml (Join-Path $exports summary_data.xml)
           # Export CSV summary of frequencies
@@ -415,32 +442,50 @@ jobs:
           & {$sd; $sr} | Sort-Object { [int]$_.fuzzhash} | % { $fuzzy=$_.fuzzhash;$_.tests |
             select @{l="fuzzhash";e={$fuzzy}}, @{l="test";e={$_}}} |
             Export-Csv (Join-Path $exports issue_test_map.csv)
-          # Keep a file per issue
+          # Keep a file per issue, prefixed with the test(s) that produced it
           $dir = New-Item -ItemType Directory -Path (Join-Path $exports reports)
-          & {$sd; $sr} | % { $_.échantillon | Out-File (Join-Path $dir "$($_.fuzzhash).tsan") }
+          & {$sd; $sr} | % {
+              "Test: $(@($_.tests) -join ', ')`n`n" + $_.échantillon |
+                  Out-File (Join-Path $dir "$($_.fuzzhash).tsan") }
+          # One file per distinct crash, likewise prefixed with the offending test(s)
+          for ($i = 0; $i -lt $crash.Count; $i++) {
+              "Test: $(@($crash[$i].tests) -join ', ')`n`n" + $crash[$i].report |
+                  Out-File (Join-Path $dir "crash_$i.tsan") }
           # Create a summary table
           @{Type="Deadlock";Failed=$sd.count;Hashes=$sd.fuzzhash},
-          @{Type="Data race";Failed=$sr.count;Hashes=$sr.fuzzhash} |
+          @{Type="Data race";Failed=$sr.count;Hashes=$sr.fuzzhash},
+          @{Type="Crash";Failed=$crash.count;Hashes=$crash.type} |
             % { $_.Summary = $_.Hashes | select -First 5  | Join-String -Separator ", "
                 if ($_.Hashes.count -gt 5 ) {
                     $_.Summary += ", ..." }; $_ } |
               % { [PSCustomObject]$_} |
               New-MDTable -Columns ([ordered]@{Failed=$null;Type=$null;Summary=$null}) |
               Out-File $Env:GITHUB_STEP_SUMMARY
-          # The step fails on new deadlocks
-          $LASTEXITCODE=$sd.count
+          # The step fails on new deadlocks and on any crash (SEGV, use-after-free, ...)
+          $LASTEXITCODE = @($sd).count + $crash.count
 
-      # TEMPORARY verification aids for the log_path change; remove once validated.
-      - name: Inspect TSan report capture
+      - name: Manual Inspection TSan report capture
         if: always()
         run: |
           echo "## TSan capture check"
           nfiles=$(ls -1 ${{ github.workspace }}/tsan_reports 2>/dev/null | wc -l)
           in_files=$(cat ${{ github.workspace }}/tsan_reports/* 2>/dev/null | grep -c "WARNING: ThreadSanitizer:" || true)
+          crashes=$(grep -l "ERROR: ThreadSanitizer:" ${{ github.workspace }}/tsan_reports/* 2>/dev/null | wc -l)
           in_stdout=$(grep -c "WARNING: ThreadSanitizer:" log/latest_test/fastdds/stdout_stderr.log 2>/dev/null || true)
           echo "Per-process report files : $nfiles"
           echo "Reports captured in files: $in_files"
-          echo "Reports left in stdout   : $in_stdout   (expected ~0; anything >0 = a process missed the option)"
+          echo "Crash (ERROR) report files: $crashes"
+          echo "Reports left in stdout   : $in_stdout"
+          echo ""
+          echo "## TSan report files dump"
+          echo ""
+          for f in ${{ github.workspace }}/tsan_reports/*; do
+            [ -e "$f" ] || { echo "(no report files found)"; break; }
+            echo "===== BEGIN $f ====="
+            cat "$f"
+            echo "===== END $f ====="
+            echo ""
+          done
 
       - name: Check on failures
         if: ${{ steps.report_summary.outcome == 'failure' }}

--- a/.github/workflows/reusable-sanitizers-ci.yml
+++ b/.github/workflows/reusable-sanitizers-ci.yml
@@ -236,7 +236,8 @@ jobs:
     if: ${{ inputs.run_tsan_fastdds == true }}
     runs-on: ubuntu-22.04
     env:
-      TSAN_OPTIONS: second_deadlock_stack=1 history_size=7 memory_limit_mb=5000
+      # Use log_path so each instrumented process write its report to <log_path>.<pid>. Needed to avoid interleaving
+      TSAN_OPTIONS: second_deadlock_stack=1 history_size=7 memory_limit_mb=5000 log_path=${{ github.workspace }}/tsan_reports/tsan
       # GCC 13.2 (Ubuntu Noble default) produces several data races warnings
       # TODO: For now we keep it at GCC 12 and ubuntu 22 until we figure out what to do with them
       # Although hundreds of tests trigger them, these problems arise from approximately
@@ -329,6 +330,9 @@ jobs:
         run: |
           cat ${{ github.workspace }}/src/fastdds/.github/workflows/config/tsan.meta
 
+      - name: Create TSan reports directory
+        run: mkdir -p ${{ github.workspace }}/tsan_reports
+
       - name: Colcon build
         continue-on-error: false
         uses: eProsima/eProsima-CI/ubuntu/colcon_build@v0
@@ -381,8 +385,10 @@ jobs:
           }
           # Install the report parser module
           Find-Module -Repository PSGallery -Name SanReportParser | Install-Module -Scope CurrentUser -Force
-          # Parse the report files
-          $rp = Show-Tsan -Path ./stdout_stderr.log
+          # Parse the report files. Each process wrote its own tsan.<pid> file via
+          # TSAN_OPTIONS=log_path, so reports are never interleaved across processes.
+          $rp = Get-ChildItem -Path "${{ github.workspace }}/tsan_reports" -Filter 'tsan.*' -ErrorAction SilentlyContinue |
+            ForEach-Object { Show-Tsan -Path $_.FullName }
           # filter duplicates
           $rp = $rp | group md5hash | % { $_.group[0] }
           # Export raw data

--- a/.github/workflows/reusable-sanitizers-ci.yml
+++ b/.github/workflows/reusable-sanitizers-ci.yml
@@ -511,7 +511,9 @@ jobs:
         if: ${{ steps.report_summary.outcome == 'failure' }}
         shell: pwsh
         run: |
-          Write-Host ${{ steps.report_summary.outcome }}
+          $msg = 'Failure: check "Process sanitizer reports" step to see errors'
+          Write-Host "::error title=TSan report::$msg"
+          Write-Host $msg
           exit 1
 
   ubsan_fastdds_build:

--- a/.github/workflows/reusable-sanitizers-ci.yml
+++ b/.github/workflows/reusable-sanitizers-ci.yml
@@ -488,10 +488,11 @@ jobs:
         if: always()
         run: |
           echo "## TSan capture check"
-          nfiles=$(ls -1 ${{ github.workspace }}/tsan_reports 2>/dev/null | wc -l)
+          nfiles=$(ls -1 ${{ github.workspace }}/tsan_reports 2>/dev/null | wc -l || true)
           in_files=$(cat ${{ github.workspace }}/tsan_reports/* 2>/dev/null | grep -c "WARNING: ThreadSanitizer:" || true)
-          crashes=$(grep -l "ERROR: ThreadSanitizer:" ${{ github.workspace }}/tsan_reports/* 2>/dev/null | wc -l)
+          crashes=$(grep -l "ERROR: ThreadSanitizer:" ${{ github.workspace }}/tsan_reports/* 2>/dev/null | wc -l || true)
           in_stdout=$(grep -c "WARNING: ThreadSanitizer:" log/latest_test/fastdds/stdout_stderr.log 2>/dev/null || true)
+          in_stdout=${in_stdout:-0}
           echo "Per-process report files : $nfiles"
           echo "Reports captured in files: $in_files"
           echo "Crash (ERROR) report files: $crashes"

--- a/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDP.cpp
@@ -134,12 +134,18 @@ PDP::~PDP()
 {
     delete resend_participant_info_event_;
 
-    builtin_endpoints_->disable_pdp_readers(mp_RTPSParticipant);
+    if (builtin_endpoints_)
+    {
+        builtin_endpoints_->disable_pdp_readers(mp_RTPSParticipant);
+    }
 
     delete mp_EDP;
 
-    builtin_endpoints_->delete_pdp_endpoints(mp_RTPSParticipant);
-    builtin_endpoints_.reset();
+    if (builtin_endpoints_)
+    {
+        builtin_endpoints_->delete_pdp_endpoints(mp_RTPSParticipant);
+        builtin_endpoints_.reset();
+    }
 
     for (ParticipantProxyData* it : participant_proxies_)
     {

--- a/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
+++ b/src/cpp/rtps/builtin/discovery/participant/PDPServer.cpp
@@ -83,8 +83,11 @@ PDPServer::PDPServer(
 
 PDPServer::~PDPServer()
 {
-    // Stop timed events
-    routine_->cancel_timer();
+    // Stop timed events.
+    if (nullptr != routine_)
+    {
+        routine_->cancel_timer();
+    }
 
     // Disable database
     discovery_db_.disable();

--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -48,6 +48,28 @@ endif()
 message(STATUS "EPROSIMA_TEST_DNS_NOT_SET_UP: '${EPROSIMA_TEST_DNS_NOT_SET_UP}'")
 
 ###############################################################################
+# ThreadSanitizer report attribution
+###############################################################################
+# Make every explicitly-added ctest test write its ThreadSanitizer reports to a file
+# named after the test. Applied only on ThreadSanitizer builds and only when
+# TSAN_REPORTS_DIR is set.
+function(tsan_name_reports)
+    if(NOT CMAKE_CXX_FLAGS MATCHES "sanitize=thread")
+        return()
+    endif()
+    if(NOT DEFINED ENV{TSAN_REPORTS_DIR})
+        return()
+    endif()
+    get_property(_tsan_tests DIRECTORY PROPERTY TESTS)
+    foreach(_tsan_test IN LISTS _tsan_tests)
+        # Sanitize characters that are invalid in a file name (e.g. '/' from parametrized names).
+        string(REGEX REPLACE "[^A-Za-z0-9._-]" "_" _tsan_safe "${_tsan_test}")
+        set_property(TEST ${_tsan_test} APPEND PROPERTY ENVIRONMENT_MODIFICATION
+            "TSAN_OPTIONS=string_append: log_path=$ENV{TSAN_REPORTS_DIR}/${_tsan_safe}")
+    endforeach()
+endfunction()
+
+###############################################################################
 # System tests
 ###############################################################################
 if(SYSTEM_TESTS)

--- a/test/dds/communication/CMakeLists.txt
+++ b/test/dds/communication/CMakeLists.txt
@@ -323,3 +323,6 @@ endif()
 if(UNIX AND NOT(APPLE) AND NOT(QNXNTO) AND NOT(ANDROID))
     add_subdirectory(dyn_network)
 endif()
+
+# Trace each TSan report. No-op if TSan is not enabled
+tsan_name_reports()

--- a/test/dds/communication/dyn_network/CMakeLists.txt
+++ b/test/dds/communication/dyn_network/CMakeLists.txt
@@ -54,3 +54,6 @@ configure_file(launch_ds_no_interfaces.bash
 add_test(NAME dds.communication.ds_init_with_no_interfaces
          COMMAND ${DOCKER_EXECUTABLE} compose -f ${CMAKE_CURRENT_BINARY_DIR}/ds_init_no_interfaces.compose.yml up --exit-code-from server-pub-sub
          WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR})
+
+# Trace each TSan report. No-op if TSan is not enabled
+tsan_name_reports()

--- a/test/dds/communication/security/CMakeLists.txt
+++ b/test/dds/communication/security/CMakeLists.txt
@@ -234,3 +234,5 @@ if(SECURITY)
 
 endif()
 
+# Trace each TSan report. No-op if TSan is not enabled
+tsan_name_reports()

--- a/test/dds/discovery/CMakeLists.txt
+++ b/test/dds/discovery/CMakeLists.txt
@@ -61,3 +61,6 @@ if(NOT ((MSVC OR MSVC_IDE) AND EPROSIMA_INSTALLER) AND fastcdr_FOUND)
         endif()
     endif()
 endif()
+
+# Trace each TSan report. No-op if TSan is not enabled
+tsan_name_reports()

--- a/test/dds/xtypes/CMakeLists.txt
+++ b/test/dds/xtypes/CMakeLists.txt
@@ -137,3 +137,5 @@ if(Python3_Interpreter_FOUND)
     endforeach()
 endif()
 
+# Trace each TSan report. No-op if TSan is not enabled
+tsan_name_reports()

--- a/test/examples/CMakeLists.txt
+++ b/test/examples/CMakeLists.txt
@@ -161,3 +161,6 @@ foreach(example_test ${examples_python_tests})
              COMMAND ${Python3_EXECUTABLE} -m pytest -vrP
              WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/${example_name})
 endforeach()
+
+# Trace each TSan report back to the test that produced it (see tsan_name_reports).
+tsan_name_reports()

--- a/test/performance/latency/CMakeLists.txt
+++ b/test/performance/latency/CMakeLists.txt
@@ -302,3 +302,6 @@ if(Python3_Interpreter_FOUND)
 
     endforeach(latency_test_name)
 endif()
+
+# Trace each TSan report. No-op if TSan is not enabled
+tsan_name_reports()

--- a/test/performance/throughput/CMakeLists.txt
+++ b/test/performance/throughput/CMakeLists.txt
@@ -303,3 +303,6 @@ if(Python3_Interpreter_FOUND)
 
     endforeach(throughput_test_name)
 endif()
+
+# Trace each TSan report. No-op if TSan is not enabled
+tsan_name_reports()

--- a/test/performance/video/CMakeLists.txt
+++ b/test/performance/video/CMakeLists.txt
@@ -236,3 +236,6 @@ if(GST_FOUND)
 else()
     message(STATUS "GStreamer libraries not found. Could not compile VideoTests")
 endif()
+
+# Trace each TSan report. No-op if TSan is not enabled
+tsan_name_reports()

--- a/test/profiling/CMakeLists.txt
+++ b/test/profiling/CMakeLists.txt
@@ -105,3 +105,6 @@ if(Python3_Interpreter_FOUND)
 endif()
 
 add_subdirectory(allocations)
+
+# Trace each TSan report. No-op if TSan is not enabled
+tsan_name_reports()

--- a/test/system/tools/fastdds/CMakeLists.txt
+++ b/test/system/tools/fastdds/CMakeLists.txt
@@ -296,3 +296,6 @@ if(Python3_Interpreter_FOUND)
     )
 
 endif()
+
+# Trace each TSan report. No-op if TSan is not enabled
+tsan_name_reports()

--- a/test/system/tools/fds/CMakeLists.txt
+++ b/test/system/tools/fds/CMakeLists.txt
@@ -157,3 +157,6 @@ target_link_libraries(
     ${CMAKE_DL_LIBS})
 
 gtest_discover_tests(${CLI_MANAGER_TESTS_EXEC})
+
+# Trace each TSan report. No-op if TSan is not enabled
+tsan_name_reports()

--- a/test/unittest/cmake/CMakeLists.txt
+++ b/test/unittest/cmake/CMakeLists.txt
@@ -20,7 +20,7 @@ set(build_dir "${fastdds_BINARY_DIR}/test/force_cxx")
 set(module_dir "${fastdds_SOURCE_DIR}/cmake/common")
 set(script "${CMAKE_CURRENT_LIST_DIR}/force_cxx/build.cmake")
 
-# The C++ sources use fold expressions which were introduced in C++17 
+# The C++ sources use fold expressions which were introduced in C++17
 
 # Tests that C++17 sources can be built enforcing C++17 through CMake
 add_test(NAME cmake.force_standard.positive.builtin
@@ -63,3 +63,6 @@ set_tests_properties(
     cmake.force_standard.negative.builtin
     cmake.force_standard.negative.manual
     PROPERTIES WILL_FAIL TRUE)
+
+# Trace each TSan report. No-op if TSan is not enabled
+tsan_name_reports()


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

There are multiple tests in Fast DDS that spawns new processes to test communication between different processes. Right now, every process writes its TSAN log into the same file, what might cause overlap and interleaved logs. These logs are not properly parsed by the current step in the CI in charge of analyzing them, resulting in warning ilkes: 
```
WARNING: (2) Possible mixed report. Report header without closing the last one: 173037
WARNING: (1) Possible mixed report. Report footer without a clear header matched:
```

This causes certain ambiguity in the report created, as some deadlock or error might be skipped depending on the log position. 

This PR targets this issue by splitting the TSAN log report in separated files per TSAN log, and then processing each file separately.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.2.x 2.14.x 2.6.x

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- _N/A_: Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- _N/A_: Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
