### PR TITLE
Set SO_REUSEPORT on multicast input sockets for Apple platforms

### DIFF
--- a/src/cpp/rtps/transport/UDPv4Transport.cpp
+++ b/src/cpp/rtps/transport/UDPv4Transport.cpp
@@ -426,10 +426,14 @@ eProsimaUDPSocket UDPv4Transport::OpenAndBindInputSocket(
     if (is_multicast)
     {
         getSocketPtr(socket)->set_option(ip::udp::socket::reuse_address(true));
-#if defined(__QNX__)
+        // QNX and Apple require SO_REUSEPORT for multiple processes to all
+        // receive the same multicast datagrams; SO_REUSEADDR alone makes the
+        // second bind fail (EADDRINUSE) on Darwin. Linux deliberately omitted:
+        // there SO_REUSEPORT load-balances instead of duplicating delivery.
+#if defined(__QNX__) || defined(__APPLE__)
         getSocketPtr(socket)->set_option(asio::detail::socket_option::boolean<
                     ASIO_OS_DEF(SOL_SOCKET), SO_REUSEPORT>(true));
-#endif // if defined(__QNX__)
+#endif // if defined(__QNX__) || defined(__APPLE__)
     }
     else
     {

--- a/src/cpp/rtps/transport/UDPv6Transport.cpp
+++ b/src/cpp/rtps/transport/UDPv6Transport.cpp
@@ -427,10 +427,14 @@ eProsimaUDPSocket UDPv6Transport::OpenAndBindInputSocket(
     if (is_multicast)
     {
         getSocketPtr(socket)->set_option(ip::udp::socket::reuse_address(true));
-#if defined(__QNX__)
+        // QNX and Apple require SO_REUSEPORT for multiple processes to all
+        // receive the same multicast datagrams; SO_REUSEADDR alone makes the
+        // second bind fail (EADDRINUSE) on Darwin. Linux deliberately omitted:
+        // there SO_REUSEPORT load-balances instead of duplicating delivery.
+#if defined(__QNX__) || defined(__APPLE__)
         getSocketPtr(socket)->set_option(asio::detail::socket_option::boolean<
                     ASIO_OS_DEF(SOL_SOCKET), SO_REUSEPORT>(true));
-#endif // if defined(__QNX__)
+#endif // if defined(__QNX__) || defined(__APPLE__)
     }
     else
     {


### PR DESCRIPTION
## Description

`OpenAndBindInputSocket()` sets `SO_REUSEPORT` on multicast input sockets only for QNX (#272, #350). Apple platforms (macOS/Darwin) have the same BSD requirement: with `SO_REUSEADDR` alone, the second process on a host that binds the SPDP multicast port gets `EADDRINUSE`, the failure is swallowed, and that participant never receives discovery multicast — it silently sees an empty domain while unicast ports bind fine.

This PR extends the existing QNX conditional to `__APPLE__` in both `UDPv4Transport.cpp` and `UDPv6Transport.cpp`.

Linux intentionally unchanged: `SO_REUSEPORT` on Linux load-balances datagrams across sockets rather than duplicating them, which would break multi-process discovery instead of fixing it.

Fixes #6470

## Motivation

Real-world failure: two librealsense processes using an Intel RealSense D555 Ethernet camera on macOS — whichever process binds the multicast port second never discovers the camera. Socket-level repro (no DDS needed) in the linked issue shows `EADDRINUSE` for the second bind without `SO_REUSEPORT` and full duplicate delivery to both sockets with it.

Verified on macOS / Apple Silicon with a live D555 (RealSense PoE camera): without this patch a second concurrently-running process never discovers the remote participant; with it, second-process discovery works.

Full disclosure: our downstream stack also serializes near-simultaneous participant creation — a separate, rarer effect noted in #6470 as out of scope; an end-to-end 22/22 dual-process figure we report elsewhere was measured with both measures in place. The socket-level repro in the issue isolates what **this patch alone** fixes.

## Contributor Checklist

- [x] Commit messages follow the project guidelines + DCO sign-off (`Signed-off-by: Onur Keskin <keskinonur@me.com>`)
- [x] The change reduces to a preprocessor-conditional extension of an already-accepted platform fix (#350); no API/behavior change on non-Apple platforms
- [ ] Tests: existing multicast tests cover the code path on Apple CI runners (none add SO_REUSEPORT-specific coverage; can add a dual-socket unit test if maintainers want one)

## Backport

Please consider backporting to maintained 2.x branches (librealsense currently pins `v2.10.4` / `v2.10.4-realsense`). The change is a one-line platform guard extension plus a short comment.
