### PR TITLE
fix: interpret permission validity timestamps as UTC

### DIFF
--- a/src/cpp/security/accesscontrol/PermissionsParser.cpp
+++ b/src/cpp/security/accesscontrol/PermissionsParser.cpp
@@ -20,6 +20,7 @@
 #include <iostream>
 #include <sstream>
 #include <iomanip>
+#include <ctime>
 
 #if TIXML2_MAJOR_VERSION >= 6
 #define PRINTLINE(node) node->GetLineNum()
@@ -339,7 +340,11 @@ bool PermissionsParser::parse_validity(
 
                 if (!stream.fail())
                 {
-                    validity.not_before = std::mktime(&time);
+#ifdef _WIN32
+                    validity.not_before = _mkgmtime(&time);
+#else
+                    validity.not_before = timegm(&time);
+#endif // ifdef _WIN32
 #endif // if _MSC_VER != 1800
 
                 tinyxml2::XMLElement* old_node = node;
@@ -360,7 +365,11 @@ bool PermissionsParser::parse_validity(
 
                             if (!stream.fail())
                             {
-                                validity.not_after = std::mktime(&time);
+#ifdef _WIN32
+                                validity.not_after = _mkgmtime(&time);
+#else
+                                validity.not_after = timegm(&time);
+#endif // ifdef _WIN32
 #endif // if _MSC_VER != 1800
                             returned_value = true;
                         }

--- a/test/unittest/security/accesscontrol/AccessControlTests.cpp
+++ b/test/unittest/security/accesscontrol/AccessControlTests.cpp
@@ -12,10 +12,14 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdlib>
+#include <cstring>
 #include <iostream>
 #include <string>
 
 #include <gtest/gtest.h>
+
+#include <security/accesscontrol/PermissionsParser.h>
 
 #include <rtps/builtin/data/ParticipantProxyData.hpp>
 #include <rtps/builtin/data/ReaderProxyData.hpp>
@@ -557,6 +561,98 @@ TEST_F(AccessControlTest, participant_creation_fail_with_empty_topic_expression_
     get_access_handle(subscriber_participant_attr, &access_handle, false);
 
 }
+
+/* Regression test for eProsima/Fast-DDS#6403.
+ *
+ * Verify that permission validity timestamps are interpreted as UTC
+ * regardless of the host timezone.
+ */
+#if _MSC_VER != 1800
+TEST(AccessControlTimestampTest, permission_timestamps_utc_independent_of_tz)
+{
+    struct TzGuard
+    {
+        std::string original;
+        TzGuard(
+                const std::string& tz_value)
+        {
+            const char* tz = std::getenv("TZ");
+            if (tz)
+            {
+                original = tz;
+            }
+#ifdef _WIN32
+            _putenv_s("TZ", tz_value.c_str());
+            _tzset();
+#else
+            setenv("TZ", tz_value.c_str(), 1);
+            tzset();
+#endif
+        }
+        ~TzGuard()
+        {
+            if (original.empty())
+            {
+#ifdef _WIN32
+                _putenv_s("TZ", "");
+#else
+                unsetenv("TZ");
+#endif
+            }
+            else
+            {
+#ifdef _WIN32
+                _putenv_s("TZ", original.c_str());
+#else
+                setenv("TZ", original.c_str(), 1);
+#endif
+            }
+#ifdef _WIN32
+            _tzset();
+#else
+            tzset();
+#endif
+        }
+    };
+
+    // Set a non-UTC timezone.
+    TzGuard tz_guard("UTC-8");
+
+    const char* xml =
+        "<dds>"
+        "<permissions>"
+        "<grant name=\"test_grant\">"
+        "<subject_name>CN=Test</subject_name>"
+        "<validity>"
+        "<not_before>2015-09-15T01:00:00</not_before>"
+        "<not_after>2025-09-15T01:00:00</not_after>"
+        "</validity>"
+        "<allow_rule>"
+        "<domains><id>0</id></domains>"
+        "<publish><topics><topic>test_topic</topic></topics></publish>"
+        "</allow_rule>"
+        "<default>ALLOW</default>"
+        "</grant>"
+        "</permissions>"
+        "</dds>";
+
+    PermissionsParser parser;
+    PermissionsData permissions;
+
+    ASSERT_TRUE(parser.parse_stream(xml, std::strlen(xml)));
+    parser.swap(permissions);
+
+    ASSERT_EQ(permissions.grants.size(), 1u);
+
+    // 2015-09-15T01:00:00 UTC = 1442278800
+    const std::time_t expected_not_before = 1442278800;
+    EXPECT_EQ(permissions.grants[0].validity.not_before, expected_not_before);
+
+    // 2025-09-15T01:00:00 UTC = 1757898000
+    const std::time_t expected_not_after = 1757898000;
+    EXPECT_EQ(permissions.grants[0].validity.not_after, expected_not_after);
+}
+#endif // _MSC_VER != 1800
 
 int main(
         int argc,


### PR DESCRIPTION
std::mktime interprets timezone-unspecified broken-down time as local
time, causing identical permission files to produce different validity
periods depending on the host timezone.

Use timegm on POSIX and _mkgmtime on Windows so the currently supported
timezone-unspecified timestamp format is interpreted consistently as UTC.

This change does not add parsing for explicit Z or +/-HH:MM timezone
suffixes.

Fixes #6403.