### PR TITLE
Guard IOKit main port usage on macOS

### DIFF
--- a/src/cpp/utils/Host.cpp
+++ b/src/cpp/utils/Host.cpp
@@ -24,6 +24,7 @@
 #include <windows.h>
 #include <process.h>
 #elif defined(__APPLE__)
+#include <AvailabilityMacros.h>
 #include <IOKit/IOKitLib.h>
 #else
 #include <unistd.h>
@@ -46,7 +47,11 @@ fastcdr::string_255 Host::compute_machine_id()
     }
     return "";
     #elif defined(__APPLE__)
+    #if MAC_OS_X_VERSION_MIN_REQUIRED < 120000
+    io_registry_entry_t ioRegistryRoot = IORegistryEntryFromPath(kIOMasterPortDefault, "IOService:/");
+    #else
     io_registry_entry_t ioRegistryRoot = IORegistryEntryFromPath(kIOMainPortDefault, "IOService:/");
+    #endif
     if (!ioRegistryRoot)
     {
         return "";


### PR DESCRIPTION
This is part of an effort to contribute RoboStack downstream patches back upstream.

Origin: RoboStack patch/ros-rolling-fastdds.osx.patch, authored by Daisuke Nishimatsu.

Apple documents both kIOMasterPortDefault and kIOMainPortDefault in IOKit. kIOMainPortDefault is the current spelling for newer macOS SDKs, while kIOMasterPortDefault is still needed when targeting older macOS versions. Guarding the constant with MAC_OS_X_VERSION_MIN_REQUIRED avoids referencing the newer symbol for older deployment targets while retaining the deprecation fix for modern builds.

References:
- https://developer.apple.com/documentation/iokit/kiomasterportdefault
- https://developer.apple.com/documentation/iokit/kiomainportdefault