### PR TITLE
Fix FTBFS against OpenSSL 4.0

### DIFF
--- a/src/cpp/rtps/transport/TCPAcceptorSecure.h
+++ b/src/cpp/rtps/transport/TCPAcceptorSecure.h
@@ -20,7 +20,7 @@
 #endif // ifdef OPENSSL_API_COMPAT
 #define OPENSSL_API_COMPAT 10101
 
-#include <asio/ssl.hpp>
+#include <asio/ssl/context.hpp>
 #include <rtps/transport/TCPAcceptor.h>
 #include <rtps/transport/TCPChannelResourceSecure.h>
 

--- a/src/cpp/rtps/transport/TCPChannelResourceSecure.h
+++ b/src/cpp/rtps/transport/TCPChannelResourceSecure.h
@@ -21,7 +21,8 @@
 #define OPENSSL_API_COMPAT 10101
 
 #include "../network/asio.hpp"
-#include <asio/ssl.hpp>
+#include <asio/ssl/context.hpp>
+#include <asio/ssl/stream.hpp>
 #include <asio/strand.hpp>
 #include <rtps/transport/TCPChannelResource.h>
 

--- a/src/cpp/rtps/transport/TCPTransportInterface.h
+++ b/src/cpp/rtps/transport/TCPTransportInterface.h
@@ -43,7 +43,8 @@
 
 #if TLS_FOUND
 #include <rtps/transport/TCPAcceptorSecure.h>
-#include <asio/ssl.hpp>
+#include <asio/ssl/context.hpp>
+#include <asio/ssl/stream.hpp>
 #endif // if TLS_FOUND
 
 #include <statistics/rtps/messages/OutputTrafficManager.hpp>

--- a/src/cpp/security/artifact_providers/FileProvider.cpp
+++ b/src/cpp/security/artifact_providers/FileProvider.cpp
@@ -77,7 +77,7 @@ X509_STORE* FileProvider::load_ca(
                             // Retrieve subject name for future use.
                             if (ca_sn.empty())
                             {
-                                X509_NAME* ca_subject_name = X509_get_subject_name(itmp->x509);
+                                const X509_NAME* ca_subject_name = X509_get_subject_name(itmp->x509);
                                 assert(ca_subject_name != nullptr);
                                 char* ca_subject_name_str = X509_NAME_oneline(ca_subject_name, 0, 0);
                                 assert(ca_subject_name_str != nullptr);

--- a/src/cpp/security/authentication/PKIDH.cpp
+++ b/src/cpp/security/authentication/PKIDH.cpp
@@ -510,7 +510,7 @@ static bool adjust_participant_key(
 {
     assert(cert != nullptr);
 
-    X509_NAME* cert_sn = X509_get_subject_name(cert);
+    OPENSSL_CONST X509_NAME* cert_sn = X509_get_subject_name(cert);
     assert(cert_sn != nullptr);
 
     unsigned char md[SHA256_DIGEST_LENGTH];
@@ -1206,7 +1206,7 @@ ValidationResult_t PKIDH::validate_local_identity(
         if ((*ih)->cert_ != nullptr)
         {
             // Get subject name.
-            X509_NAME* cert_sn = X509_get_subject_name((*ih)->cert_);
+            OPENSSL_CONST X509_NAME* cert_sn = X509_get_subject_name((*ih)->cert_);
             assert(cert_sn != nullptr);
             char* cert_sn_str = X509_NAME_oneline(cert_sn, 0, 0);
             assert(cert_sn_str != nullptr);
@@ -1510,7 +1510,7 @@ ValidationResult_t PKIDH::begin_handshake_reply(
         return ValidationResult_t::VALIDATION_FAILED;
     }
 
-    X509_NAME* cert_sn = X509_get_subject_name(rih->cert_);
+    OPENSSL_CONST X509_NAME* cert_sn = X509_get_subject_name(rih->cert_);
     assert(cert_sn != nullptr);
     char* cert_sn_str = X509_NAME_oneline(cert_sn, 0, 0);
     assert(cert_sn_str != nullptr);
@@ -1935,7 +1935,7 @@ ValidationResult_t PKIDH::process_handshake_request(
         return ValidationResult_t::VALIDATION_FAILED;
     }
 
-    X509_NAME* cert_sn = X509_get_subject_name(rih->cert_);
+    OPENSSL_CONST X509_NAME* cert_sn = X509_get_subject_name(rih->cert_);
     assert(cert_sn != nullptr);
     char* cert_sn_str = X509_NAME_oneline(cert_sn, 0, 0);
     assert(cert_sn_str != nullptr);

--- a/test/unittest/security/authentication/BuiltinPKIDHTests.cpp
+++ b/test/unittest/security/authentication/BuiltinPKIDHTests.cpp
@@ -79,7 +79,7 @@ IdentityToken AuthenticationPluginTest::generate_remote_identity_token_ok(
 
     // dds.cert.sn
     property.name("dds.cert.sn");
-    X509_NAME* cert_sn = X509_get_subject_name(h->cert_);
+    const X509_NAME* cert_sn = X509_get_subject_name(h->cert_);
     char* cert_sn_str = X509_NAME_oneline(cert_sn, 0, 0);
     property.value() = cert_sn_str;
     OPENSSL_free(cert_sn_str);


### PR DESCRIPTION
1. `<asio/ssl.hpp>` pulls in the deprecated `rfc2818_verification`, which no
   longer compiles on OpenSSL 4.0. so include only the
   `asio/ssl` headers we need.

2. `X509_get_subject_name()`  returns a `const` pointer, so store its
   result in a `const` pointer to avoid conversion errors.

Fixes #6432

@Mergifyio backport 3.3.x