### PR TITLE
[25538] Fix datasharing infinite loop

### DIFF
--- a/src/cpp/rtps/DataSharing/DataSharingListener.cpp
+++ b/src/cpp/rtps/DataSharing/DataSharingListener.cpp
@@ -162,7 +162,7 @@ void DataSharingListener::process_new_data ()
 
         uint64_t last_payload = pool->end();
         bool has_new_payload = true;
-        while (has_new_payload)
+        while (has_new_payload && is_running_.load())
         {
             CacheChange_t ch;
             SequenceNumber_t last_sequence = c_SequenceNumber_Unknown;

--- a/src/cpp/rtps/DataSharing/DataSharingListener.cpp
+++ b/src/cpp/rtps/DataSharing/DataSharingListener.cpp
@@ -197,6 +197,12 @@ void DataSharingListener::process_new_data ()
                     pool->release_payload(ch.serializedPayload);
                     pool->advance_to_next_payload();
                 }
+                else
+                {
+                    // If the reader could not process the data, we will try again later
+                    notification_->notification_->new_data.store(true);
+                    break;
+                }
             }
 
             if (writer_pools_changed_.load(std::memory_order_relaxed))

--- a/src/cpp/rtps/DataSharing/ReaderPool.hpp
+++ b/src/cpp/rtps/DataSharing/ReaderPool.hpp
@@ -211,9 +211,10 @@ public:
                 continue;
             }
 
-            if (last_sn_ != c_SequenceNumber_Unknown && last_sn_ >= cache_change.sequenceNumber)
+            if (last_sn_ != c_SequenceNumber_Unknown && last_sn_ > cache_change.sequenceNumber)
             {
                 // Sequence number went backwards, it was most probably overriden.
+                advance(next_payload_);
                 continue;
             }
 

--- a/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
+++ b/src/cpp/rtps/builtin/discovery/endpoint/EDPSimple.cpp
@@ -293,7 +293,8 @@ void EDPSimple::processPersistentData(
                     return;
                 }
 
-                if (!reader.first->change_received(change_to_add, nullptr, 0))
+                bool will_never_be_accepted = false;
+                if (!reader.first->change_received(change_to_add, nullptr, 0, will_never_be_accepted))
                 {
                     EPROSIMA_LOG_INFO(RTPS_EDP, "EDPServer couldn't process database data not add change "
                         << change_to_add->sequenceNumber);

--- a/src/cpp/rtps/reader/BaseReader.hpp
+++ b/src/cpp/rtps/reader/BaseReader.hpp
@@ -251,7 +251,8 @@ public:
      *
      * @param change  Pointer to the incoming CacheChange_t.
      *
-     * @return true if the reader accepts message.
+     * @return true if the reader processed the message.
+     * @return false if the reader could not process the message, but would be able to do so in the future.
      */
     virtual bool process_data_msg(
             fastdds::rtps::CacheChange_t* change) = 0;

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -605,7 +605,8 @@ bool StatefulReader::process_data_msg(
                     NotifyChanges(pWP);
                     send_ack_if_datasharing(this, history_, pWP, change->sequenceNumber);
                 }
-                return false;
+                // Could process later when `will_never_be_accepted` is false
+                return will_never_be_accepted;
             }
 
             if (!fastdds::rtps::change_is_relevant_for_filter(*change, m_guid, data_filter_))
@@ -628,6 +629,7 @@ bool StatefulReader::process_data_msg(
                         IDSTRING
                         "Reached the maximum number of samples allowed by this reader's QoS. Rejecting change for reader: "
                         << m_guid );
+                // Could process later when a cache is available
                 return false;
             }
 
@@ -647,7 +649,8 @@ bool StatefulReader::process_data_msg(
                     EPROSIMA_LOG_WARNING(RTPS_MSG_IN, IDSTRING "Problem copying DataSharing CacheChange from writer "
                             << change->writerGUID);
                     change_pool_->release_cache(change_to_add);
-                    return false;
+                    // Matched in datasharing_listener_, but no datasharing pool available, irrecoverable error.
+                    return true;
                 }
                 datasharing_pool->get_datasharing_change(change->serializedPayload, *change_to_add);
             }
@@ -675,11 +678,12 @@ bool StatefulReader::process_data_msg(
                         << m_guid << " is "
                         << (fixed_payload_size_ > 0 ? fixed_payload_size_ : (std::numeric_limits<uint32_t>::max)()));
                 change_pool_->release_cache(change_to_add);
+                // Could process later when a payload is available
                 return false;
             }
 
             // Perform reception of cache change
-            if (!change_received(change_to_add, pWP, unknown_missing_changes_up_to))
+            if (!change_received(change_to_add, pWP, unknown_missing_changes_up_to, will_never_be_accepted))
             {
                 EPROSIMA_LOG_INFO(RTPS_MSG_IN,
                         IDSTRING "Change " << change_to_add->sequenceNumber << " not added to history");
@@ -688,14 +692,15 @@ bool StatefulReader::process_data_msg(
                     change_to_add->serializedPayload.payload_owner->release_payload(change_to_add->serializedPayload);
                 }
                 change_pool_->release_cache(change_to_add);
-                return false;
+                // Could process later when `will_never_be_accepted` is false
+                return will_never_be_accepted;
             }
         }
 
         return true;
     }
 
-    return false;
+    return true;
 }
 
 bool StatefulReader::process_data_frag_msg(
@@ -786,7 +791,7 @@ bool StatefulReader::process_data_frag_msg(
             // If this is the first time we have received fragments for this change, add it to history
             if (change_created != nullptr)
             {
-                if (!change_received(change_created, pWP, changes_up_to))
+                if (!change_received(change_created, pWP, changes_up_to, will_never_be_accepted))
                 {
                     EPROSIMA_LOG_INFO(RTPS_MSG_IN,
                             IDSTRING "MessageReceiver not add change " << change_created->sequenceNumber.to64long());
@@ -1086,8 +1091,11 @@ bool StatefulReader::change_removed_by_history(
 bool StatefulReader::change_received(
         CacheChange_t* a_change,
         WriterProxy* prox,
-        size_t unknown_missing_changes_up_to)
+        size_t unknown_missing_changes_up_to,
+        bool& will_never_be_accepted)
 {
+    will_never_be_accepted = true;
+
     //First look for WriterProxy in case is not provided
     if (prox == nullptr)
     {
@@ -1133,6 +1141,7 @@ bool StatefulReader::change_received(
                             }
                         }
 
+                        will_never_be_accepted = false;
                         return true;
                     }
                 }
@@ -1163,11 +1172,11 @@ bool StatefulReader::change_received(
 
     // NOTE: Depending on QoS settings, one change can be removed from history
     // inside the call to history_->received_change
+    will_never_be_accepted = false;
     fastdds::dds::SampleRejectedStatusKind rejection_reason;
     if (history_->received_change(a_change, unknown_missing_changes_up_to, rejection_reason))
     {
         auto payload_length = a_change->serializedPayload.length;
-
         bool ret = true;
 
         if (a_change->is_fully_assembled())
@@ -1183,8 +1192,8 @@ bool StatefulReader::change_received(
             {
                 prox->irrelevant_change_set(a_change->sequenceNumber);
                 send_ack_if_datasharing(this, history_, prox, a_change->sequenceNumber);
+                will_never_be_accepted = true;
                 ret = false;
-
             }
         }
 
@@ -1213,6 +1222,7 @@ bool StatefulReader::change_received(
             {
                 prox->irrelevant_change_set(a_change->sequenceNumber);
                 NotifyChanges(prox);
+                will_never_be_accepted = true;
             }
 
             /* Special case: rejected by REJECTED_BY_UNKNOWN_INSTANCE should never be received again.
@@ -1227,6 +1237,7 @@ bool StatefulReader::change_received(
                         " ignored. Could not compute key in keyed topic.");
                 prox->irrelevant_change_set(a_change->sequenceNumber);
                 NotifyChanges(prox);
+                will_never_be_accepted = true;
             }
         }
     }

--- a/src/cpp/rtps/reader/StatefulReader.cpp
+++ b/src/cpp/rtps/reader/StatefulReader.cpp
@@ -575,7 +575,7 @@ bool StatefulReader::process_data_msg(
     std::unique_lock<RecursiveTimedMutex> lock(mp_mutex);
     if (!is_alive_)
     {
-        return false;
+        return true;
     }
 
     if (acceptMsgFrom(change->writerGUID, &pWP))

--- a/src/cpp/rtps/reader/StatefulReader.hpp
+++ b/src/cpp/rtps/reader/StatefulReader.hpp
@@ -184,7 +184,7 @@ public:
             CacheChange_t* a_change,
             WriterProxy* prox,
             size_t unknown_missing_changes_up_to,
-            bool& will_never_never_be_accepted);
+            bool& will_never_be_accepted);
 
     /**
      * Get the RTPS participant

--- a/src/cpp/rtps/reader/StatefulReader.hpp
+++ b/src/cpp/rtps/reader/StatefulReader.hpp
@@ -172,16 +172,19 @@ public:
     /**
      * This method is called when a new change is received. This method calls the received_change of the History
      * and depending on the implementation performs different actions.
-     * @param a_change Pointer of the change to add.
-     * @param prox Pointer to the WriterProxy that adds the Change.
-     * @param unknown_missing_changes_up_to The number of changes from the same writer with a lower sequence number that
-     *                                      could potentially be received in the future.
-     * @return True if added.
+     * @param [in] a_change                      Pointer of the change to add.
+     * @param [in] prox                          Pointer to the WriterProxy that adds the Change.
+     * @param [in] unknown_missing_changes_up_to The number of changes from the same writer with a lower sequence
+     *                                           number that could potentially be received in the future.
+     * @param [out] will_never_be_accepted       A boolean indicating whether the change could be accepted in the
+     *                                           future or not. This is only relevant when the method returns false.
+     * @return True if added, false otherwise.
      */
     bool change_received(
             CacheChange_t* a_change,
             WriterProxy* prox,
-            size_t unknown_missing_changes_up_to);
+            size_t unknown_missing_changes_up_to,
+            bool& will_never_never_be_accepted);
 
     /**
      * Get the RTPS participant

--- a/src/cpp/rtps/reader/StatefulReader.hpp
+++ b/src/cpp/rtps/reader/StatefulReader.hpp
@@ -115,9 +115,12 @@ public:
             WriterProxy** WP);
 
     /**
-     * Processes a new DATA message.
-     * @param change Pointer to the CacheChange_t.
-     * @return true if the reader accepts messages.
+     * @brief Process an incoming DATA message.
+     *
+     * @param change  Pointer to the incoming CacheChange_t.
+     *
+     * @return true if the reader processed the message.
+     * @return false if the reader could not process the message, but would be able to do so in the future.
      */
     bool process_data_msg(
             CacheChange_t* change) override;

--- a/src/cpp/rtps/reader/StatelessReader.cpp
+++ b/src/cpp/rtps/reader/StatelessReader.cpp
@@ -617,7 +617,8 @@ bool StatelessReader::process_data_msg(
                 {
                     update_last_notified(change->writerGUID, change->sequenceNumber);
                 }
-                return false;
+                // Could process later when `will_never_be_accepted` is false
+                return will_never_be_accepted;
             }
 
             if (!fastdds::rtps::change_is_relevant_for_filter(*change, m_guid, data_filter_))
@@ -635,6 +636,7 @@ bool StatelessReader::process_data_msg(
                         IDSTRING
                         "Reached the maximum number of samples allowed by this reader's QoS. Rejecting change for reader: "
                         << m_guid );
+                // Could process later when a cache is available
                 return false;
             }
 
@@ -660,7 +662,8 @@ bool StatelessReader::process_data_msg(
                     EPROSIMA_LOG_WARNING(RTPS_MSG_IN, IDSTRING "Problem copying DataSharing CacheChange from writer "
                             << change->writerGUID);
                     change_pool_->release_cache(change_to_add);
-                    return false;
+                    // No datasharing pool available, irrecoverable error.
+                    return true;
                 }
                 datasharing_pool->get_datasharing_change(change->serializedPayload, *change_to_add);
             }
@@ -688,6 +691,7 @@ bool StatelessReader::process_data_msg(
                         << m_guid << " is "
                         << (fixed_payload_size_ > 0 ? fixed_payload_size_ : (std::numeric_limits<uint32_t>::max)()));
                 change_pool_->release_cache(change_to_add);
+                // Could process later when a payload is available
                 return false;
             }
 
@@ -701,7 +705,8 @@ bool StatelessReader::process_data_msg(
                     change_to_add->serializedPayload.payload_owner->release_payload(change_to_add->serializedPayload);
                 }
                 change_pool_->release_cache(change_to_add);
-                return false;
+                // A change with a higher sequence number was already received, so this one is discarded forever
+                return true;
             }
         }
     }

--- a/src/cpp/rtps/reader/StatelessReader.hpp
+++ b/src/cpp/rtps/reader/StatelessReader.hpp
@@ -111,10 +111,12 @@ public:
             CacheChange_t* change) override;
 
     /**
-     * Processes a new DATA message.
+     * @brief Process an incoming DATA message.
      *
-     * @param change Pointer to the CacheChange_t.
-     * @return true if the reader accepts messages from the.
+     * @param change  Pointer to the incoming CacheChange_t.
+     *
+     * @return true if the reader processed the message.
+     * @return false if the reader could not process the message, but would be able to do so in the future.
      */
     bool process_data_msg(
             CacheChange_t* change) override;

--- a/test/blackbox/common/DDSBlackboxTestsDataSharing.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDataSharing.cpp
@@ -12,7 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <chrono>
+#include <cstdlib>
 #include <fstream>
+#include <future>
 #include <sstream>
 #include <thread>
 
@@ -933,6 +936,91 @@ TEST(DDSDataSharing, acknack_reception_when_get_unread_count)
     // Check that the shared files are created on the correct directory
     ASSERT_FALSE(check_shared_file(".", reader.datareader_guid()));
     ASSERT_FALSE(check_shared_file(".", writer.datawriter_guid()));
+}
+
+/*!
+ * Regression test: deleting a data-sharing reader must not hang after one of its samples was
+ * rejected by the reader's own history (resource limits exhausted, nobody drained it).
+ *
+ * DataSharingListener::process_new_data() calls ReaderPool::get_next_unread_payload(), which
+ * returns a valid sample and immediately sets ReaderPool::last_sn_ to its sequence number --
+ * *before* the caller hands the sample to the reader. If DataReader::process_data_msg() then
+ * rejects it (history full), ReaderPool::advance_to_next_payload() is never called, so the very
+ * same slot is re-read on the next loop pass, with last_sn_ already equal to its sequence number.
+ * get_next_unread_payload() treats that as "this payload was overwritten by the writer, discard
+ * it" -- which used to discard without advancing, so it kept re-reading that same, unchanged slot
+ * forever. That spin never returns from get_next_unread_payload(), so DataSharingListener::stop()
+ * -- called from the reader destructor -- hangs forever on listening_thread_.join().
+ *
+ * We give the listener thread a brief moment to process the (accepted then rejected) samples, then destroy the
+ * reader under a watchdog so a hang fails the test instead of blocking the whole suite.
+ */
+TEST(DDSDataSharing, ReaderDeletionWithRejectedSampleDoesNotHang)
+{
+    // Force pure data-sharing (drop all network data messages).
+    auto testTransport = std::make_shared<eprosima::fastdds::rtps::test_UDPv4TransportDescriptor>();
+    testTransport->dropDataMessagesPercentage = 100;
+
+    PubSubReader<FixedSizedPubSubType> reader(TEST_TOPIC_NAME);
+    PubSubWriter<FixedSizedPubSubType> writer(TEST_TOPIC_NAME);
+
+    // KEEP_ALL with room for a single sample, and the reader never calls take()/read(), so the
+    // second sample the listener thread tries to hand over is guaranteed to be rejected.
+    reader.history_kind(eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS)
+            .resource_limits_allocated_samples(1)
+            .resource_limits_max_samples(1)
+            .add_user_transport_to_pparams(testTransport)
+            .disable_builtin_transport()
+            .datasharing_on(".")
+            .reliability(eprosima::fastdds::dds::BEST_EFFORT_RELIABILITY_QOS).init();
+    ASSERT_TRUE(reader.isInitialized());
+
+    writer.history_kind(eprosima::fastdds::dds::KEEP_ALL_HISTORY_QOS)
+            .add_user_transport_to_pparams(testTransport)
+            .disable_builtin_transport()
+            .datasharing_on(".")
+            .reliability(eprosima::fastdds::dds::BEST_EFFORT_RELIABILITY_QOS).init();
+    ASSERT_TRUE(writer.isInitialized());
+
+    writer.wait_discovery();
+    reader.wait_discovery();
+
+    // Send more samples than the reader can ever hold; at least one is guaranteed to be rejected.
+    auto data = default_fixed_sized_data_generator(4);
+    writer.send(data);
+
+    // Give the listener thread time to process the accepted sample and then trip on the rejected
+    // one.
+    std::this_thread::sleep_for(std::chrono::milliseconds(200));
+
+    // Destroying the reader must not hang. Run it on a watchdog thread so a hang fails the test
+    // instead of blocking the whole suite forever.
+    std::promise<void> destroyed_promise;
+    std::future<void> destroyed_future = destroyed_promise.get_future();
+    std::thread destroy_thread([&reader, &destroyed_promise]()
+            {
+                reader.destroy();
+                destroyed_promise.set_value();
+            });
+
+    const bool destroyed_in_time =
+            destroyed_future.wait_for(std::chrono::seconds(10)) == std::future_status::ready;
+
+    EXPECT_TRUE(destroyed_in_time)
+        << "Data-sharing reader destruction hung after a sample was rejected by the reader's own "
+        << "history (DataSharingListener::stop() starved on listening_thread_.join()).";
+
+    if (!destroyed_in_time)
+    {
+        // reader is wedged with participant_ still non-null: letting this function return would
+        // run ~PubSubReader() on the main thread, which calls destroy() again on that same
+        // participant and hangs a second time, unbounded. Bail out of the whole process now that
+        // the failure is already recorded, instead of risking a real, watchdog-less hang.
+        std::_Exit(1);
+    }
+
+    destroy_thread.join();
+    writer.destroy();
 }
 
 #ifdef INSTANTIATE_TEST_SUITE_P

--- a/test/mock/xtypes/TypeObjectRegistry/fastdds/xtypes/type_representation/TypeObjectRegistry.hpp
+++ b/test/mock/xtypes/TypeObjectRegistry/fastdds/xtypes/type_representation/TypeObjectRegistry.hpp
@@ -27,6 +27,7 @@
 #include <fastdds/dds/xtypes/dynamic_types/DynamicType.hpp>
 #include <fastdds/dds/xtypes/type_representation/ITypeObjectRegistry.hpp>
 #include <fastdds/dds/xtypes/type_representation/TypeObject.hpp>
+#include <fastdds/xtypes/type_representation/TypeIdentifierWithSizeHashSpecialization.h>
 
 namespace std {
 template<>


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

Fixes an infinite spin in `ReaderPool::get_next_unread_payload()`: when a payload's sequence number no longer looked newer than the last one delivered, the code discarded it without advancing the read pointer, so it kept re-examining the same shared-memory slot forever, hanging `DataSharingListener::stop()`'s thread join on reader teardown.

Also adds a defensive `is_running_` check in the listener's drain loop, plus a deterministic blackbox regression test that reproduces the hang via a rejected sample and verifies the fix.

The meaning of the return value of `process_data_msg` has been changed, with `false` now meaning "Try again later".
The only place where the return value is checked is in `DataSharingListener::process_new_data()`, and the changed method is part of an internal interface, so there is no user behavior change.

With this change, we can now break the loop when the reader informs us to "Try again later", and we don't advance the payload index in that case. Please note the subtle change from `>=` to `>` in `ReaderPool.hpp`, which allows processing the same sequence number several times.

Includes an unrelated one-line fix for a missing include in the TypeObjectRegistry GTest mock that only surfaces as a build failure on newer GCC/libstdc++ (reproduced with GCC 15.2.0).

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.2.x 2.14.x

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.
