### PR TITLE
Fix SharedMem self-deadlock in blocked-processing recovery

### DIFF
--- a/src/cpp/rtps/transport/shared_mem/SharedMemGlobal.hpp
+++ b/src/cpp/rtps/transport/shared_mem/SharedMemGlobal.hpp
@@ -804,7 +804,8 @@ public:
                             node_->listeners_status[i].is_processing)
                     {
                         buffer_descriptor = node_->listeners_status[i].descriptor;
-                        listener_processing_stop(i);
+                        // Already holding empty_cv_mutex: clear in place
+                        node_->listeners_status[i].is_processing = false;
                         return true;
                     }
                 }

--- a/test/unittest/transport/SharedMemTests.cpp
+++ b/test/unittest/transport/SharedMemTests.cpp
@@ -1420,6 +1420,28 @@ TEST_F(SHMTransportTests, port_not_ok_listener_recover)
     thread_listener.join();
 }
 
+//! Regression test for https://github.com/eProsima/Fast-DDS/issues/6485
+TEST_F(SHMTransportTests, recover_blocked_processing_clears_state)
+{
+    auto shared_mem_manager = SharedMemManager::create(domain_name);
+    SharedMemGlobal* shared_mem_global = shared_mem_manager->global_segment();
+
+    auto port = shared_mem_global->open_port(0, 1, 1000);
+    uint32_t listener_index;
+    auto listener = port->create_listener(&listener_index);
+
+    SharedMemSegment::Id segment_id;
+    segment_id.generate();
+    SharedMemGlobal::BufferDescriptor buffer = { segment_id, 0, 0 };
+    port->listener_processing_start(listener_index, buffer);
+
+    SharedMemGlobal::BufferDescriptor recovered;
+    // retrieve listener
+    ASSERT_TRUE(port->get_and_remove_blocked_processing(recovered));
+    // confirm listener was cleared
+    ASSERT_FALSE(port->get_and_remove_blocked_processing(recovered));
+}
+
 //! This test has been updated to avoid flakiness #20993
 TEST_F(SHMTransportTests, buffer_recover)
 {


### PR DESCRIPTION
## Description

`get_and_remove_blocked_processing()` already holds `node_->empty_cv_mutex`
when it calls `listener_processing_stop()`, which attempts to lock the same
non-recursive `std::mutex` again. This re-entrancy self-deadlocks and spins
inside `recover_blocked_processing()` (issue #6485).

Clear `listeners_status[i].is_processing` in place instead, since the mutex is
already held. No mutex type or signature changed, so this is ABI- and
behavior-compatible and safe to backport. Adds a regression test that drives
the recovery path and asserts the listener is cleared without re-blocking.

@Mergifyio backport 3.2.x 2.14.x

Fixes #6485

## Contributor Checklist

- [x] Commit messages follow the project guidelines.
- [x] The code follows the style guidelines of this project.
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally
- _N/A_ Any new/modified methods have been properly documented using Doxygen. (no public API change; existing Doxygen block on the method is still accurate)
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension)
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior.
- [x] Changes are API compatible.
- _N/A_ New feature has been added to the `versions.md` file (if applicable).
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation.
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
