### PR TITLE
[25560] Fix shared-memory segment crash on port open

### DIFF
--- a/test/unittest/transport/SharedMemTests.cpp
+++ b/test/unittest/transport/SharedMemTests.cpp
@@ -1391,16 +1391,25 @@ TEST_F(SHMTransportTests, port_corrupt_segment_recovers_on_open)
 
     shared_mem_global->remove_port(0);
 
-    auto port = shared_mem_global->open_port(0, 1, 1000);
-    ASSERT_NO_THROW(port->healthy_check());
+    auto test_case = [&](uint8_t corrupt_byte)
+    {
+        auto port = shared_mem_global->open_port(0, 1, 1000);
+        ASSERT_NO_THROW(port->healthy_check());
 
-    // Damage the allocator structures the way an abruptly terminated peer can.
-    port_mocker.corrupt_segment_allocator(*port);
+        // Damage the allocator structures the way an abruptly terminated peer can.
+        port_mocker.corrupt_segment_allocator(*port, corrupt_byte);
 
-    // Opening the port again should not walk those structures.
-    auto recovered = shared_mem_global->open_port(0, 1, 1000);
-    ASSERT_TRUE(recovered != nullptr);
-    ASSERT_NO_THROW(recovered->healthy_check());
+        // Opening the port again should not walk those structures.
+        auto recovered = shared_mem_global->open_port(0, 1, 1000);
+        ASSERT_TRUE(recovered != nullptr);
+        ASSERT_NO_THROW(recovered->healthy_check());
+    };
+
+    for (uint8_t corrupt_byte = 0xFF; corrupt_byte > 0x00; corrupt_byte--)
+    {
+        test_case(corrupt_byte);
+    }
+    test_case(0x00);
 }
 
 TEST_F(SHMTransportTests, port_not_ok_listener_recover)

--- a/test/unittest/transport/SharedMemTests.cpp
+++ b/test/unittest/transport/SharedMemTests.cpp
@@ -1367,6 +1367,7 @@ TEST_F(SHMTransportTests, dead_listener_sender_port_recover)
     thread_wait_deadlock.join();
 }
 
+// Regression test for https://github.com/eProsima/Fast-DDS/issues/6501
 // Reproduces a crash when opening a port whose segment holds damaged allocator
 // structures.
 //
@@ -1381,8 +1382,8 @@ TEST_F(SHMTransportTests, dead_listener_sender_port_recover)
 // segments: ownership does not protect the traversal.
 //
 // On platforms without gtest's SEH handling this aborts the whole test binary
-// rather than failing one case, which is the other reason it ships disabled.
-TEST_F(SHMTransportTests, port_corrupt_segment_crashes_on_open)
+// rather than failing one case.
+TEST_F(SHMTransportTests, port_corrupt_segment_recovers_on_open)
 {
     auto shared_mem_manager = SharedMemManager::create(domain_name);
     SharedMemGlobal* shared_mem_global = shared_mem_manager->global_segment();
@@ -1396,8 +1397,7 @@ TEST_F(SHMTransportTests, port_corrupt_segment_crashes_on_open)
     // Damage the allocator structures the way an abruptly terminated peer can.
     port_mocker.corrupt_segment_allocator(*port);
 
-    // Opening the port again should not walk those structures. Today it does,
-    // and this is where the process dies.
+    // Opening the port again should not walk those structures.
     auto recovered = shared_mem_global->open_port(0, 1, 1000);
     ASSERT_TRUE(recovered != nullptr);
     ASSERT_NO_THROW(recovered->healthy_check());

--- a/test/unittest/transport/SharedMemTests.cpp
+++ b/test/unittest/transport/SharedMemTests.cpp
@@ -1367,6 +1367,43 @@ TEST_F(SHMTransportTests, dead_listener_sender_port_recover)
     thread_wait_deadlock.join();
 }
 
+// Reproduces a crash when opening a port whose segment holds damaged allocator
+// structures. Disabled because it currently fails by design: remove the
+// DISABLED_ prefix to observe it.
+//
+// open_port_internal validates an existing segment with check_sanity(), which
+// iterates the allocator's free-block tree through offset pointers stored inside
+// the segment. When those links are inconsistent the traversal reads unmapped
+// memory and the process dies (0xC0000005 on Windows, SIGSEGV elsewhere). The
+// fault is not a C++ exception, so the catch(std::exception&) around the call
+// cannot intercept it.
+//
+// Note the port here is open and owned, so this is not about stale or leftover
+// segments: ownership does not protect the traversal.
+//
+// On platforms without gtest's SEH handling this aborts the whole test binary
+// rather than failing one case, which is the other reason it ships disabled.
+TEST_F(SHMTransportTests, DISABLED_port_corrupt_segment_crashes_on_open)
+{
+    auto shared_mem_manager = SharedMemManager::create(domain_name);
+    SharedMemGlobal* shared_mem_global = shared_mem_manager->global_segment();
+    MockPortSharedMemGlobal port_mocker;
+
+    shared_mem_global->remove_port(0);
+
+    auto port = shared_mem_global->open_port(0, 1, 1000);
+    ASSERT_NO_THROW(port->healthy_check());
+
+    // Damage the allocator structures the way an abruptly terminated peer can.
+    port_mocker.corrupt_segment_allocator(*port);
+
+    // Opening the port again should not walk those structures. Today it does,
+    // and this is where the process dies.
+    auto recovered = shared_mem_global->open_port(0, 1, 1000);
+    ASSERT_TRUE(recovered != nullptr);
+    ASSERT_NO_THROW(recovered->healthy_check());
+}
+
 TEST_F(SHMTransportTests, port_not_ok_listener_recover)
 {
     auto shared_mem_manager = SharedMemManager::create(domain_name);

--- a/test/unittest/transport/SharedMemTests.cpp
+++ b/test/unittest/transport/SharedMemTests.cpp
@@ -1368,8 +1368,7 @@ TEST_F(SHMTransportTests, dead_listener_sender_port_recover)
 }
 
 // Reproduces a crash when opening a port whose segment holds damaged allocator
-// structures. Disabled because it currently fails by design: remove the
-// DISABLED_ prefix to observe it.
+// structures.
 //
 // open_port_internal validates an existing segment with check_sanity(), which
 // iterates the allocator's free-block tree through offset pointers stored inside
@@ -1383,7 +1382,7 @@ TEST_F(SHMTransportTests, dead_listener_sender_port_recover)
 //
 // On platforms without gtest's SEH handling this aborts the whole test binary
 // rather than failing one case, which is the other reason it ships disabled.
-TEST_F(SHMTransportTests, DISABLED_port_corrupt_segment_crashes_on_open)
+TEST_F(SHMTransportTests, port_corrupt_segment_crashes_on_open)
 {
     auto shared_mem_manager = SharedMemManager::create(domain_name);
     SharedMemGlobal* shared_mem_global = shared_mem_manager->global_segment();

--- a/test/unittest/transport/mock/SharedMemGlobalMock.hpp
+++ b/test/unittest/transport/mock/SharedMemGlobalMock.hpp
@@ -15,6 +15,8 @@
 #ifndef _FASTDDS_MOCKSHAREDMEM_GLOBAL_H_
 #define _FASTDDS_MOCKSHAREDMEM_GLOBAL_H_
 
+#include <cstring>
+
 #include <rtps/transport/shared_mem/SharedMemGlobal.hpp>
 
 namespace eprosima {
@@ -107,6 +109,34 @@ public:
         auto listener = port.buffer_->register_listener();
         listener.release();
         port.node_->num_listeners++;
+    }
+
+    /**
+     * Corrupt the allocator structures of a port segment in place.
+     *
+     * Writing the file on disk is unreliable for this: on Windows the segment
+     * may still be mapped or pending delete, so the bytes written are not
+     * necessarily the ones a later open sees. Scribbling directly on the
+     * mapping is unambiguous.
+     *
+     * The boost segment_manager header at the start is left alone so that
+     * open_only still succeeds -- damaging it only produces an exception, which
+     * open_port_internal already handles. What is destroyed here are the
+     * free-block tree links that check_sanity() walks.
+     */
+    static void corrupt_segment_allocator(
+            SharedMemGlobal::Port& port)
+    {
+        constexpr size_t keep_header_bytes = 0x100;
+
+        auto& segment = port.port_segment_->get();
+        auto base = static_cast<char*>(segment.get_address());
+        auto size = static_cast<size_t>(segment.get_size());
+
+        if (size > keep_header_bytes)
+        {
+            std::memset(base + keep_header_bytes, 0xEF, size - keep_header_bytes);
+        }
     }
 
 };

--- a/test/unittest/transport/mock/SharedMemGlobalMock.hpp
+++ b/test/unittest/transport/mock/SharedMemGlobalMock.hpp
@@ -125,7 +125,8 @@ public:
      * free-block tree links that check_sanity() walks.
      */
     static void corrupt_segment_allocator(
-            SharedMemGlobal::Port& port)
+            SharedMemGlobal::Port& port,
+            uint8_t corrupt_value)
     {
         constexpr size_t keep_header_bytes = 0x100;
 
@@ -135,7 +136,7 @@ public:
 
         if (size > keep_header_bytes)
         {
-            std::memset(base + keep_header_bytes, 0xEF, size - keep_header_bytes);
+            std::memset(base + keep_header_bytes, corrupt_value, size - keep_header_bytes);
         }
     }
 

--- a/thirdparty/boost/include/boost/interprocess/mem_algo/rbtree_best_fit.hpp
+++ b/thirdparty/boost/include/boost/interprocess/mem_algo/rbtree_best_fit.hpp
@@ -634,30 +634,31 @@ bool rbtree_best_fit<MutexFamily, VoidPointer, MemAlignment>::
    //-----------------------
    boost::interprocess::scoped_lock<mutex_type> guard(m_header);
    //-----------------------
-   imultiset_iterator ib(m_header.m_imultiset.begin()), ie(m_header.m_imultiset.end());
-
-   size_type free_memory = 0;
-
-   //Iterate through all blocks obtaining their size
-   for(; ib != ie; ++ib){
-      free_memory += (size_type)ib->m_size*Alignment;
-      algo_impl_t::assert_alignment(&*ib);
-      if(!algo_impl_t::check_alignment(&*ib))
-         return false;
-   }
 
    //Check allocated bytes are less than size
    if(m_header.m_allocated > m_header.m_size){
       return false;
    }
 
+   //Calculate the maximum free memory available in the segment
    size_type block1_off  =
       priv_first_block_offset_from_this(this, m_header.m_extra_hdr_bytes);
+   size_type max_free_memory = m_header.m_size - block1_off;
 
-   //Check free bytes are less than size
-   if(free_memory > (m_header.m_size - block1_off)){
-      return false;
+   //Iterate through all blocks obtaining their size
+   imultiset_iterator ib(m_header.m_imultiset.begin()), ie(m_header.m_imultiset.end());
+   size_type free_memory = 0;
+   for(; ib != ie; ++ib){
+      if(!algo_impl_t::check_alignment(&*ib)){
+         return false;
+      }
+      free_memory += (size_type)ib->m_size*Alignment;
+      //Check free bytes are less than size
+      if(free_memory > max_free_memory){
+         return false;
+      }
    }
+
    return true;
 }
 

--- a/thirdparty/boost/include/boost/interprocess/mem_algo/rbtree_best_fit.hpp
+++ b/thirdparty/boost/include/boost/interprocess/mem_algo/rbtree_best_fit.hpp
@@ -652,6 +652,10 @@ bool rbtree_best_fit<MutexFamily, VoidPointer, MemAlignment>::
       if(!algo_impl_t::check_alignment(&*ib)){
          return false;
       }
+      //A size of 0 is not allowed in the multiset
+      if(!ib->m_size){
+         return false;
+      }
       free_memory += (size_type)ib->m_size*Alignment;
       //Check free bytes are less than size
       if(free_memory > max_free_memory){


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

Reproducer for #6501.

`check_sanity()` walks the allocator's free-block tree through `offset_ptr`s stored inside the segment. When those links are inconsistent the traversal reads unmapped memory and the process dies — `0xC0000005` on Windows, `SIGSEGV` elsewhere. The fault is not a C++ exception, so the `catch (std::exception&)` around the call in `open_port_internal` cannot intercept it.

The test ships `DISABLED_` because it fails by design, and because on platforms without gtest's SEH handling it aborts the whole test binary rather than failing a single case. Remove the prefix, or pass `--gtest_also_run_disabled_tests`, to observe it.

```
[ RUN      ] SHMTransportTests.DISABLED_port_corrupt_segment_crashes_on_open
unknown file: error: SEH exception with code 0xc0000005 thrown in the test body.
[  FAILED  ] SHMTransportTests.DISABLED_port_corrupt_segment_crashes_on_open (77 ms)
```

Opening this to start a discussion on the right fix rather than to propose one. Removing the `check_sanity()` call alone is not sufficient.

------

Enabled the test and added a potential fix.

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
@Mergifyio backport 3.2.x 2.14.x

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
@Mergifyio backport 2.6.x

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
<!-- Fixes #(issue) -->

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_: Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. -->
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_: New feature has been added to the `versions.md` file (if applicable).
- _N/A_: New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: -->
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [x] The PR has a milestone assigned.
- [x] The title and description correctly express the PR's purpose.
- [x] Check contributor checklist is correct.
- [x] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [x] Check CI results: changes do not issue any warning.
- [x] Check CI results: failing tests are unrelated with the changes.