### PR TITLE
Guard matched-status counters with the endpoint mutex

### DIFF
--- a/src/cpp/fastdds/publisher/DataWriterImpl.cpp
+++ b/src/cpp/fastdds/publisher/DataWriterImpl.cpp
@@ -1400,12 +1400,17 @@ const Publisher* DataWriterImpl::get_publisher() const
 }
 
 void DataWriterImpl::InnerDataWriterListener::on_writer_matched(
-        RTPSWriter* /*writer*/,
+        RTPSWriter* writer,
         const MatchingInfo& info)
 {
     std::lock_guard<std::mutex> scoped_lock(matching_info_mutex_);
 
-    data_writer_->update_publication_matched_status(info);
+    {
+        // get_publication_matched_status() reads and resets these counters while
+        // holding the writer mutex, so updating them needs the same protection.
+        std::lock_guard<RecursiveTimedMutex> status_lock(writer->getMutex());
+        data_writer_->update_publication_matched_status(info);
+    }
 
     StatusMask notify_status = StatusMask::publication_matched();
     DataWriterListener* listener = data_writer_->get_listener_for(notify_status);

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.cpp
@@ -941,12 +941,12 @@ void DataReaderImpl::InnerDataReaderListener::on_data_available(
 }
 
 void DataReaderImpl::InnerDataReaderListener::on_reader_matched(
-        RTPSReader* /*reader*/,
+        RTPSReader* reader,
         const MatchingInfo& info)
 {
     std::lock_guard<std::mutex> scoped_lock(matching_info_mutex_);
 
-    data_reader_->update_subscription_matched_status(info);
+    data_reader_->update_subscription_matched_status(reader, info);
 
     StatusMask notify_status = StatusMask::subscription_matched();
     DataReaderListener* listener = data_reader_->get_listener_for(notify_status);
@@ -1164,17 +1164,27 @@ bool DataReaderImpl::on_new_cache_change_added(
 }
 
 void DataReaderImpl::update_subscription_matched_status(
+        RTPSReader* reader,
         const MatchingInfo& status)
 {
     auto count_change = status.status == MATCHED_MATCHING ? 1 : -1;
-    subscription_matched_status_.current_count += count_change;
-    subscription_matched_status_.current_count_change += count_change;
-    if (count_change > 0)
+
     {
-        subscription_matched_status_.total_count += count_change;
-        subscription_matched_status_.total_count_change += count_change;
+        // get_subscription_matched_status() reads and resets these counters while
+        // holding the reader mutex, so updating them needs the same protection.
+        // Scoped to the counters only: the calls below notify user listeners and
+        // read conditions, which must not run with the reader mutex held.
+        std::lock_guard<RecursiveTimedMutex> status_lock(reader->getMutex());
+
+        subscription_matched_status_.current_count += count_change;
+        subscription_matched_status_.current_count_change += count_change;
+        if (count_change > 0)
+        {
+            subscription_matched_status_.total_count += count_change;
+            subscription_matched_status_.total_count_change += count_change;
+        }
+        subscription_matched_status_.last_publication_handle = status.remoteEndpointGuid;
     }
-    subscription_matched_status_.last_publication_handle = status.remoteEndpointGuid;
 
     if (count_change < 0)
     {

--- a/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
+++ b/src/cpp/fastdds/subscriber/DataReaderImpl.hpp
@@ -641,6 +641,7 @@ protected:
             bool trigger_value);
 
     void update_subscription_matched_status(
+            fastdds::rtps::RTPSReader* reader,
             const fastdds::rtps::MatchingInfo& status);
 
     bool on_data_available(

--- a/test/blackbox/common/DDSBlackboxTestsDataReader.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDataReader.cpp
@@ -12,9 +12,12 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <atomic>
+#include <chrono>
 #include <mutex>
 #include <thread>
 #include <type_traits>
+#include <vector>
 
 #include <gtest/gtest.h>
 
@@ -1603,6 +1606,138 @@ TEST_P(DDSDataReader, return_sample_when_writer_disappears)
         EXPECT_EQ(info.instance_handle, instance_handle);
         EXPECT_EQ(info.instance_state, fdds::NOT_ALIVE_NO_WRITERS_INSTANCE_STATE);
     }
+}
+
+/**
+ * @test Regression test for a data race on subscription_matched_status_.
+ *
+ * get_subscription_matched_status() reads the status and resets its change counters under
+ * the reader mutex, while the discovery thread used to update the same struct holding only
+ * InnerDataReaderListener::matching_info_mutex_. Poll the status from a user thread while
+ * DataWriters are created and destroyed, so on_reader_matched() keeps running on the
+ * discovery thread concurrently with the polling.
+ *
+ * The race is only observable under a sanitizer; this test is here for the TSan job.
+ */
+TEST(DDSDataReader, subscription_matched_status_concurrent_with_discovery)
+{
+    using namespace eprosima::fastdds::dds;
+
+    const auto churn_duration = std::chrono::seconds(5);
+
+    auto factory = DomainParticipantFactory::get_instance();
+    uint32_t domain_id = static_cast<uint32_t>(GET_PID()) % 230;
+
+    DomainParticipant* sub_participant = factory->create_participant(domain_id, PARTICIPANT_QOS_DEFAULT);
+    ASSERT_NE(nullptr, sub_participant);
+    DomainParticipant* pub_participant = factory->create_participant(domain_id, PARTICIPANT_QOS_DEFAULT);
+    ASSERT_NE(nullptr, pub_participant);
+
+    TypeSupport type(new HelloWorldPubSubType());
+    ASSERT_EQ(RETCODE_OK, type.register_type(sub_participant));
+    ASSERT_EQ(RETCODE_OK, type.register_type(pub_participant));
+
+    Topic* sub_topic = sub_participant->create_topic(TEST_TOPIC_NAME, type.get_type_name(), TOPIC_QOS_DEFAULT);
+    ASSERT_NE(nullptr, sub_topic);
+    Topic* pub_topic = pub_participant->create_topic(TEST_TOPIC_NAME, type.get_type_name(), TOPIC_QOS_DEFAULT);
+    ASSERT_NE(nullptr, pub_topic);
+
+    Subscriber* subscriber = sub_participant->create_subscriber(SUBSCRIBER_QOS_DEFAULT);
+    ASSERT_NE(nullptr, subscriber);
+    DataReader* reader = subscriber->create_datareader(sub_topic, DATAREADER_QOS_DEFAULT);
+    ASSERT_NE(nullptr, reader);
+
+    Publisher* publisher = pub_participant->create_publisher(PUBLISHER_QOS_DEFAULT);
+    ASSERT_NE(nullptr, publisher);
+
+    // Let the participants discover each other and confirm a writer can match,
+    // otherwise the churn below would never reach on_reader_matched().
+    {
+        DataWriter* warmup = publisher->create_datawriter(pub_topic, DATAWRITER_QOS_DEFAULT);
+        ASSERT_NE(nullptr, warmup);
+        SubscriptionMatchedStatus status;
+        auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+        do
+        {
+            ASSERT_EQ(RETCODE_OK, reader->get_subscription_matched_status(status));
+            if (status.current_count > 0)
+            {
+                break;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+        while (std::chrono::steady_clock::now() < deadline);
+        ASSERT_GT(status.current_count, 0);
+        ASSERT_EQ(RETCODE_OK, publisher->delete_datawriter(warmup));
+    }
+
+    std::atomic<bool> stop{ false };
+    std::atomic<uint64_t> polls{ 0 };
+    std::atomic<int32_t> matches{ 0 };
+
+    std::thread poller([&]()
+            {
+                while (!stop.load(std::memory_order_relaxed))
+                {
+                    SubscriptionMatchedStatus status;
+                    reader->get_subscription_matched_status(status);
+                    matches.fetch_add(status.total_count_change, std::memory_order_relaxed);
+                    polls.fetch_add(1, std::memory_order_relaxed);
+                }
+            });
+
+    // Churn a batch at a time so matches and unmatches keep arriving densely.
+    // Assertions are deferred so that the poller thread is always joined.
+    constexpr size_t batch_size = 10;
+    uint64_t churned = 0;
+    bool create_failed = false;
+    bool delete_failed = false;
+    auto until = std::chrono::steady_clock::now() + churn_duration;
+    while (std::chrono::steady_clock::now() < until && !create_failed && !delete_failed)
+    {
+        std::vector<DataWriter*> writers;
+        for (size_t i = 0; i < batch_size; ++i)
+        {
+            DataWriter* writer = publisher->create_datawriter(pub_topic, DATAWRITER_QOS_DEFAULT);
+            if (nullptr == writer)
+            {
+                create_failed = true;
+                break;
+            }
+            writers.push_back(writer);
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+
+        for (DataWriter* writer : writers)
+        {
+            if (RETCODE_OK != publisher->delete_datawriter(writer))
+            {
+                delete_failed = true;
+                break;
+            }
+            ++churned;
+        }
+    }
+
+    stop.store(true);
+    poller.join();
+
+    EXPECT_FALSE(create_failed);
+    EXPECT_FALSE(delete_failed);
+    EXPECT_GT(churned, 0u);
+    EXPECT_GT(polls.load(), 0u);
+    // The churn must actually have driven matches through the discovery thread,
+    // otherwise this test would exercise nothing.
+    EXPECT_GT(matches.load(), 0);
+
+    EXPECT_EQ(RETCODE_OK, subscriber->delete_datareader(reader));
+    EXPECT_EQ(RETCODE_OK, sub_participant->delete_subscriber(subscriber));
+    EXPECT_EQ(RETCODE_OK, sub_participant->delete_topic(sub_topic));
+    EXPECT_EQ(RETCODE_OK, pub_participant->delete_publisher(publisher));
+    EXPECT_EQ(RETCODE_OK, pub_participant->delete_topic(pub_topic));
+    EXPECT_EQ(RETCODE_OK, factory->delete_participant(sub_participant));
+    EXPECT_EQ(RETCODE_OK, factory->delete_participant(pub_participant));
 }
 
 #ifdef INSTANTIATE_TEST_SUITE_P

--- a/test/blackbox/common/DDSBlackboxTestsDataWriter.cpp
+++ b/test/blackbox/common/DDSBlackboxTestsDataWriter.cpp
@@ -12,8 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <atomic>
 #include <chrono>
 #include <set>
+#include <thread>
+#include <vector>
 
 #include <gtest/gtest.h>
 
@@ -2178,6 +2181,138 @@ TEST(DDSDataWriter, type_support_context_end_to_end)
     EXPECT_EQ(RETCODE_OK, participant->delete_publisher(publisher));
     EXPECT_EQ(RETCODE_OK, participant->delete_subscriber(subscriber));
     EXPECT_EQ(RETCODE_OK, DomainParticipantFactory::get_instance()->delete_participant(participant));
+}
+
+/**
+ * @test Regression test for a data race on publication_matched_status_.
+ *
+ * get_publication_matched_status() reads the status and resets its change counters under
+ * the writer mutex, while the discovery thread used to update the same struct holding only
+ * InnerDataWriterListener::matching_info_mutex_. Poll the status from a user thread while
+ * DataReaders are created and destroyed, so on_writer_matched() keeps running on the
+ * discovery thread concurrently with the polling.
+ *
+ * The race is only observable under a sanitizer; this test is here for the TSan job.
+ */
+TEST(DDSDataWriter, publication_matched_status_concurrent_with_discovery)
+{
+    using namespace eprosima::fastdds::dds;
+
+    const auto churn_duration = std::chrono::seconds(5);
+
+    auto factory = DomainParticipantFactory::get_instance();
+    uint32_t domain_id = static_cast<uint32_t>(GET_PID()) % 230;
+
+    DomainParticipant* pub_participant = factory->create_participant(domain_id, PARTICIPANT_QOS_DEFAULT);
+    ASSERT_NE(nullptr, pub_participant);
+    DomainParticipant* sub_participant = factory->create_participant(domain_id, PARTICIPANT_QOS_DEFAULT);
+    ASSERT_NE(nullptr, sub_participant);
+
+    TypeSupport type(new HelloWorldPubSubType());
+    ASSERT_EQ(RETCODE_OK, type.register_type(pub_participant));
+    ASSERT_EQ(RETCODE_OK, type.register_type(sub_participant));
+
+    Topic* pub_topic = pub_participant->create_topic(TEST_TOPIC_NAME, type.get_type_name(), TOPIC_QOS_DEFAULT);
+    ASSERT_NE(nullptr, pub_topic);
+    Topic* sub_topic = sub_participant->create_topic(TEST_TOPIC_NAME, type.get_type_name(), TOPIC_QOS_DEFAULT);
+    ASSERT_NE(nullptr, sub_topic);
+
+    Publisher* publisher = pub_participant->create_publisher(PUBLISHER_QOS_DEFAULT);
+    ASSERT_NE(nullptr, publisher);
+    DataWriter* writer = publisher->create_datawriter(pub_topic, DATAWRITER_QOS_DEFAULT);
+    ASSERT_NE(nullptr, writer);
+
+    Subscriber* subscriber = sub_participant->create_subscriber(SUBSCRIBER_QOS_DEFAULT);
+    ASSERT_NE(nullptr, subscriber);
+
+    // Let the participants discover each other and confirm a reader can match,
+    // otherwise the churn below would never reach on_writer_matched().
+    {
+        DataReader* warmup = subscriber->create_datareader(sub_topic, DATAREADER_QOS_DEFAULT);
+        ASSERT_NE(nullptr, warmup);
+        PublicationMatchedStatus status;
+        auto deadline = std::chrono::steady_clock::now() + std::chrono::seconds(10);
+        do
+        {
+            ASSERT_EQ(RETCODE_OK, writer->get_publication_matched_status(status));
+            if (status.current_count > 0)
+            {
+                break;
+            }
+            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        }
+        while (std::chrono::steady_clock::now() < deadline);
+        ASSERT_GT(status.current_count, 0);
+        ASSERT_EQ(RETCODE_OK, subscriber->delete_datareader(warmup));
+    }
+
+    std::atomic<bool> stop{ false };
+    std::atomic<uint64_t> polls{ 0 };
+    std::atomic<int32_t> matches{ 0 };
+
+    std::thread poller([&]()
+            {
+                while (!stop.load(std::memory_order_relaxed))
+                {
+                    PublicationMatchedStatus status;
+                    writer->get_publication_matched_status(status);
+                    matches.fetch_add(status.total_count_change, std::memory_order_relaxed);
+                    polls.fetch_add(1, std::memory_order_relaxed);
+                }
+            });
+
+    // Churn a batch at a time so matches and unmatches keep arriving densely.
+    // Assertions are deferred so that the poller thread is always joined.
+    constexpr size_t batch_size = 10;
+    uint64_t churned = 0;
+    bool create_failed = false;
+    bool delete_failed = false;
+    auto until = std::chrono::steady_clock::now() + churn_duration;
+    while (std::chrono::steady_clock::now() < until && !create_failed && !delete_failed)
+    {
+        std::vector<DataReader*> readers;
+        for (size_t i = 0; i < batch_size; ++i)
+        {
+            DataReader* reader = subscriber->create_datareader(sub_topic, DATAREADER_QOS_DEFAULT);
+            if (nullptr == reader)
+            {
+                create_failed = true;
+                break;
+            }
+            readers.push_back(reader);
+        }
+
+        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+
+        for (DataReader* reader : readers)
+        {
+            if (RETCODE_OK != subscriber->delete_datareader(reader))
+            {
+                delete_failed = true;
+                break;
+            }
+            ++churned;
+        }
+    }
+
+    stop.store(true);
+    poller.join();
+
+    EXPECT_FALSE(create_failed);
+    EXPECT_FALSE(delete_failed);
+    EXPECT_GT(churned, 0u);
+    EXPECT_GT(polls.load(), 0u);
+    // The churn must actually have driven matches through the discovery thread,
+    // otherwise this test would exercise nothing.
+    EXPECT_GT(matches.load(), 0);
+
+    EXPECT_EQ(RETCODE_OK, publisher->delete_datawriter(writer));
+    EXPECT_EQ(RETCODE_OK, pub_participant->delete_publisher(publisher));
+    EXPECT_EQ(RETCODE_OK, pub_participant->delete_topic(pub_topic));
+    EXPECT_EQ(RETCODE_OK, sub_participant->delete_subscriber(subscriber));
+    EXPECT_EQ(RETCODE_OK, sub_participant->delete_topic(sub_topic));
+    EXPECT_EQ(RETCODE_OK, factory->delete_participant(pub_participant));
+    EXPECT_EQ(RETCODE_OK, factory->delete_participant(sub_participant));
 }
 
 #ifdef INSTANTIATE_TEST_SUITE_P


### PR DESCRIPTION
## Description

Both matched-status structs are read under the endpoint mutex but written under a
different one, so a user thread polling the status races the discovery thread updating
it.

`DataWriterImpl::get_publication_matched_status()` reads `publication_matched_status_`
and resets its two change counters while holding the writer mutex
(DataWriterImpl.cpp:1603-1608). `update_publication_matched_status()` writes the same
struct, but the only lock held on that path is
`InnerDataWriterListener::matching_info_mutex_`.

`DataReaderImpl` is the same shape: `get_subscription_matched_status()` reads under the
reader mutex (DataReaderImpl.cpp:1198), `update_subscription_matched_status()` writes
under `matching_info_mutex_` only.

TSan on a fully instrumented build, on master (2bad9bcca):

```
WARNING: ThreadSanitizer: data race
  Read of size 4 at 0x726c00004484 by main thread (mutexes: write M0):
    #0 DataWriterImpl::get_publication_matched_status(...) src/cpp/fastdds/publisher/DataWriterImpl.cpp:1606
    #1 DataWriter::get_publication_matched_status(...) src/cpp/fastdds/publisher/DataWriter.cpp:270
  Previous write of size 4 at 0x726c00004484 by thread T4 (mutexes: write M1, write M2, write M3):
    #0 DataWriterImpl::update_publication_matched_status(...) src/cpp/fastdds/publisher/DataWriterImpl.cpp:1589
    #1 DataWriterImpl::InnerDataWriterListener::on_writer_matched(...) src/cpp/fastdds/publisher/DataWriterImpl.cpp:1408
    #2 EDP::pairing_reader_proxy_with_any_local_writer(...) src/cpp/rtps/builtin/discovery/endpoint/EDP.cpp:1312
    ...
    #31 UDPChannelResource::perform_listen_operation(...) src/cpp/rtps/transport/UDPChannelResource.cpp:78
```

M0 is the writer mutex the getter takes; it is not among the mutexes the discovery
thread holds.

### Writer side

`update_publication_matched_status()` only touches the status struct, so the writer
mutex can simply wrap the call. The order is `matching_info_mutex_` then writer mutex,
which is the same order the existing `get_publication_matched_status()` call further
down that callback already establishes.

### Reader side

Here the lock has to be scoped to the counter update only.
`update_subscription_matched_status()` also calls `set_read_communication_status()`,
which invokes user listeners, and `try_notify_read_conditions()`, which deliberately
releases the reader mutex before taking the conditions mutex. Wrapping the whole
function would run user callbacks under the reader mutex and introduce a
reader-mutex-then-conditions-mutex order that does not exist today.

Both sides take the mutex from the endpoint passed to the callback rather than from
`DataWriterImpl::writer_` / `DataReaderImpl::reader_`, because those members are only
assigned after `create_writer()` / `create_reader()` returns.

<!-- @Mergifyio backport 3.2.x 2.14.x -->

### How this was verified

Fast-DDS, Fast-CDR and foonathan_memory all built with `-fsanitize=thread`, Debug,
GCC 13.3, Ubuntu 24.04.

Writer side — one process, two participants, data-sharing, a writer publishing flat out
while 60 late-joining readers are created and destroyed, main thread polling
`get_publication_matched_status()` to wait for each match:

| build | runs | TSan reports |
|---|---|---|
| master | 3 | 3 every run, all of them this race |
| with this change | 3 | 0 |

Reader side — a long-lived DataReader in one participant, a churn thread creating and
destroying DataWriters in a second participant so `on_reader_matched()` fires
repeatedly, main thread polling `get_subscription_matched_status()`. 30s per run, around
3000 writers churned and 15M polls:

| build | runs | TSan reports |
|---|---|---|
| master | 3 | 18-19 every run |
| with this change | 3 | 0 |

Every report in the reader baseline was on this struct — the counters at
DataReaderImpl.cpp:1170-1175 and 1200-1202, plus `InstanceHandleValue_t::operator
unsigned char*()` from copying `last_publication_handle`.

## Contributor Checklist

- [x] Commit messages follow the project guidelines.
- [x] The code follows the style guidelines of this project.
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally

  `DDSDataWriter.publication_matched_status_concurrent_with_discovery` and
  `DDSDataReader.subscription_matched_status_concurrent_with_discovery`. Each keeps one
  long-lived endpoint, polls its matched status from a user thread, and churns batches of
  counterpart endpoints in a second participant so the matched callbacks keep running on
  the discovery thread. A warm-up match is confirmed before the churn starts and the
  tests assert matches were observed, so they cannot silently exercise nothing. Around 5s
  each.

  Measured against master, fully instrumented: 14-18 TSan reports per run across 3 runs,
  every one of them on these two structs. Run individually, 8 for the writer test and 7
  for the reader test. With the fixes, 0 across 3 runs. Without a sanitizer they are
  plain stress tests and pass either way, so the value is in your nightly TSan job.
- [x] Any new/modified methods have been properly documented using Doxygen.
- _N/A_ Any new configuration API has an equivalent XML API
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior.
- [x] Changes are API compatible. <!-- update_subscription_matched_status is private -->
- _N/A_ New feature has been added to the `versions.md` file.
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation.
- [x] Applicable backports have been included in the description.
