### PR TITLE
TypeLookupRequestListener: sanitize remote continuation point before advancing iterator

### DIFF
--- a/src/cpp/fastdds/builtin/type_lookup_service/TypeLookupRequestListener.cpp
+++ b/src/cpp/fastdds/builtin/type_lookup_service/TypeLookupRequestListener.cpp
@@ -379,6 +379,13 @@ TypeLookup_getTypeDependencies_Out TypeLookupRequestListener::prepare_get_type_d
         if (!continuation_point.empty())
         {
             start_index = calculate_continuation_point(continuation_point) * MAX_DEPENDENCIES_PER_REPLY;
+            // Clamp start_index so an attacker-controlled continuation_point cannot
+            // advance iterators out of bounds. An out-of-range continuation point
+            // yields an empty page and ends the pagination.
+            if (start_index >= type_dependencies.size())
+            {
+                start_index = type_dependencies.size();
+            }
         }
 
         // Copy the dependencies within the specified range directly to out


### PR DESCRIPTION
### Problem

In `TypeLookupRequestListener::prepare_get_type_dependencies_response()`, the `continuation_point` field of a `getTypeDependencies` request is deserialized directly from the network payload and decoded into a `size_t` by `calculate_continuation_point()` without any validation. The decoded value is multiplied by `MAX_DEPENDENCIES_PER_REPLY` and passed to `std::next(type_dependencies.begin(), start_index)` with no bounds check against `type_dependencies.size()`.

A remote participant can first trigger a response with more than `MAX_DEPENDENCIES_PER_REPLY` dependent types, and then resend the same request with a crafted continuation point. This makes `std::next` advance the iterator past `end()` (undefined behavior, typically a crash), and also makes `type_dependencies.size() - start_index` underflow on the following line. Very large continuation points can additionally overflow the multiplication, and make `create_continuation_point()` iterate for an impractically long time.

Default DDS deployments do not authenticate participants, so any peer in the same DDS domain can send such a request.

### Fix

Clamp the decoded continuation point to the last valid page index (`(size + MAX_DEPENDENCIES_PER_REPLY - 1) / MAX_DEPENDENCIES_PER_REPLY - 1`) before computing `start_index`. This:

- keeps `std::next` within the container bounds,
- removes the unsigned underflow in the `end_it` computation,
- removes the multiplication overflow,
- bounds the value passed to `create_continuation_point()`.

Legitimate continuation flows are unaffected: a valid page index still returns the same page, and the reply continuation point is now generated from the sanitized value.