### PR TITLE
Fix array declarations in IDL serialization

### DIFF
--- a/src/cpp/fastdds/xtypes/serializers/idl/dynamic_type_idl.cpp
+++ b/src/cpp/fastdds/xtypes/serializers/idl/dynamic_type_idl.cpp
@@ -651,6 +651,39 @@ ReturnCode_t dyn_type_tree_to_idl(
     return ret;
 }
 
+/**
+ * Write a named type, placing array bounds after the declarator.
+ * @param [in] info Type spelling, member name and dynamic type of the declaration.
+ * @param [out] idl Output stream.
+ * @return RETCODE_OK on success, or RETCODE_BAD_PARAMETER for a malformed array spelling.
+ */
+static ReturnCode_t declaration_to_idl(
+        const TreeNodeType& info,
+        std::ostream& idl) noexcept
+{
+    if (TK_ARRAY == info.dynamic_type->get_kind())
+    {
+        const auto dim_pos = info.type_kind_name.find("[");
+
+        if (std::string::npos == dim_pos)
+        {
+            EPROSIMA_LOG_ERROR(DYNAMIC_TYPE_IDL, "Array type name is not well formed.");
+            return RETCODE_BAD_PARAMETER;
+        }
+
+        const auto kind_name_str = info.type_kind_name.substr(0, dim_pos);
+        const auto dim_str = info.type_kind_name.substr(dim_pos, std::string::npos);
+
+        idl << kind_name_str << " " << info.member_name << dim_str;
+    }
+    else
+    {
+        idl << info.type_kind_name << " " << info.member_name;
+    }
+
+    return RETCODE_OK;
+}
+
 ReturnCode_t alias_to_idl(
         const TreeNode<TreeNodeType>& node,
         std::ostream& idl) noexcept
@@ -675,7 +708,8 @@ ReturnCode_t alias_to_idl(
     idl << "typedef ";
 
     // Find the base type of the alias
-    ret = type_kind_to_idl(type_descriptor->base_type(), idl);
+    std::stringstream base_type_idl;
+    ret = type_kind_to_idl(type_descriptor->base_type(), base_type_idl);
 
     if (RETCODE_OK != ret)
     {
@@ -683,7 +717,8 @@ ReturnCode_t alias_to_idl(
         return ret;
     }
 
-    idl << " " << type_name << ";\n";
+    ret = declaration_to_idl(TreeNodeType(type_name, base_type_idl.str(), type_descriptor->base_type()), idl);
+    idl << ";\n";
 
     // Close modules definition (if any)
     close_modules_definition(n_modules, idl);
@@ -1092,14 +1127,23 @@ ReturnCode_t union_to_idl(
 
         idl << TAB_SEPARATOR << TAB_SEPARATOR << tabulate_n(n_modules);
 
-        ret = type_kind_to_idl(member_descriptor->type(), idl);
+        std::stringstream member_type_idl;
+        ret = type_kind_to_idl(member_descriptor->type(), member_type_idl);
 
         if (RETCODE_OK != ret)
         {
             return ret;
         }
 
-        idl << " " << member->get_name().to_string() << ";\n";
+        ret = declaration_to_idl(TreeNodeType(member->get_name().to_string(), member_type_idl.str(),
+                        member_descriptor->type()), idl);
+
+        if (RETCODE_OK != ret)
+        {
+            return ret;
+        }
+
+        idl << ";\n";
     }
 
     // Close type definition
@@ -1122,27 +1166,7 @@ ReturnCode_t node_to_idl(
         idl << "@key ";
     }
 
-    if (TK_ARRAY == node.info.dynamic_type->get_kind())
-    {
-        const auto dim_pos = node.info.type_kind_name.find("[");
-
-        if (std::string::npos == dim_pos)
-        {
-            EPROSIMA_LOG_ERROR(DYNAMIC_TYPE_IDL, "Array type name is not well formed.");
-            return RETCODE_BAD_PARAMETER;
-        }
-
-        const auto kind_name_str = node.info.type_kind_name.substr(0, dim_pos);
-        const auto dim_str = node.info.type_kind_name.substr(dim_pos, std::string::npos);
-
-        idl << kind_name_str << " " << node.info.member_name << dim_str;
-    }
-    else
-    {
-        idl << node.info.type_kind_name << " " << node.info.member_name;
-    }
-
-    return RETCODE_OK;
+    return declaration_to_idl(node.info, idl);
 }
 
 unsigned int open_modules_definition(

--- a/test/unittest/dds/xtypes/serializers/idl/DynTypeIDLTests.cpp
+++ b/test/unittest/dds/xtypes/serializers/idl/DynTypeIDLTests.cpp
@@ -12,6 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+#include <cstdio>
 #include <fstream>
 #include <iostream>
 #include <iterator>
@@ -26,6 +27,8 @@
 #include <fastdds/dds/xtypes/dynamic_types/DynamicType.hpp>
 #include <fastdds/dds/xtypes/dynamic_types/DynamicTypeBuilder.hpp>
 #include <fastdds/dds/xtypes/dynamic_types/DynamicTypeBuilderFactory.hpp>
+#include <fastdds/dds/xtypes/dynamic_types/MemberDescriptor.hpp>
+#include <fastdds/dds/xtypes/dynamic_types/TypeDescriptor.hpp>
 #include <fastdds/dds/xtypes/type_representation/ITypeObjectRegistry.hpp>
 #include <fastdds/dds/xtypes/utils.hpp>
 
@@ -124,6 +127,98 @@ INSTANTIATE_TEST_SUITE_P(
     DynTypeIDLTests,
     ::testing::ValuesIn(test::supported_types)
     );
+
+/**
+ * Verify that array aliases keep bounds after their names,
+ * and that the serialized IDL can be parsed back into the same type.
+ */
+TEST(DynTypeIDLRegressionTests, array_aliases)
+{
+    const std::string input_file = "types/array_declarations/array_declarations.idl";
+    std::ifstream file(input_file);
+    ASSERT_TRUE(file.is_open());
+    const std::string expected{std::istreambuf_iterator<char>(file), std::istreambuf_iterator<char>()};
+
+    auto factory = DynamicTypeBuilderFactory::get_instance();
+    auto builder = factory->create_type_w_uri(input_file, "ArrayDeclarations", {});
+    ASSERT_NE(builder, nullptr);
+    auto type = builder->build();
+    ASSERT_NE(type, nullptr);
+
+    std::stringstream serialized;
+    ASSERT_EQ(idl_serialize(type, serialized), RETCODE_OK);
+    EXPECT_EQ(expected, serialized.str());
+
+    const std::string output_file = "array_declarations_roundtrip.idl";
+    {
+        std::ofstream output(output_file);
+        ASSERT_TRUE(output.is_open());
+        output << serialized.str();
+    }
+    auto reparsed = factory->create_type_w_uri(output_file, "ArrayDeclarations", {});
+    std::remove(output_file.c_str());
+    ASSERT_NE(reparsed, nullptr);
+    EXPECT_TRUE(type->equals(reparsed->build()));
+}
+
+/**
+ * Verify array declarators in both labelled and default union members.
+ */
+TEST(DynTypeIDLRegressionTests, array_union_members)
+{
+    auto factory = DynamicTypeBuilderFactory::get_instance();
+    auto float64_type = factory->get_primitive_type(TK_FLOAT64);
+    auto array_builder = factory->create_array_type(float64_type, {9});
+    auto matrix_builder = factory->create_array_type(float64_type, {2, 3});
+    ASSERT_NE(array_builder, nullptr);
+    ASSERT_NE(matrix_builder, nullptr);
+
+    auto descriptor = traits<TypeDescriptor>::make_shared();
+    descriptor->kind(TK_UNION);
+    descriptor->name("ArrayUnion");
+    descriptor->discriminator_type(factory->get_primitive_type(TK_INT32));
+    auto union_builder = factory->create_type(descriptor);
+    ASSERT_NE(union_builder, nullptr);
+
+    auto member = traits<MemberDescriptor>::make_shared();
+    member->name("values");
+    member->type(array_builder->build());
+    member->label({0, 1});
+    ASSERT_EQ(union_builder->add_member(member), RETCODE_OK);
+
+    member = traits<MemberDescriptor>::make_shared();
+    member->name("matrix");
+    member->type(matrix_builder->build());
+    member->is_default_label(true);
+    ASSERT_EQ(union_builder->add_member(member), RETCODE_OK);
+
+    descriptor = traits<TypeDescriptor>::make_shared();
+    descriptor->kind(TK_STRUCTURE);
+    descriptor->name("ArrayUnionStruct");
+    auto struct_builder = factory->create_type(descriptor);
+    ASSERT_NE(struct_builder, nullptr);
+    member = traits<MemberDescriptor>::make_shared();
+    member->name("selection");
+    member->type(union_builder->build());
+    ASSERT_EQ(struct_builder->add_member(member), RETCODE_OK);
+
+    std::stringstream serialized;
+    ASSERT_EQ(idl_serialize(struct_builder->build(), serialized), RETCODE_OK);
+    EXPECT_EQ(serialized.str(),
+            "union ArrayUnion switch (long)\n"
+            "{\n"
+            "    case 0:\n"
+            "    case 1:\n"
+            "        double values[9];\n"
+            "    default:\n"
+            "        double matrix[2][3];\n"
+            "};\n\n"
+            "@extensibility(APPENDABLE)\n"
+            "struct ArrayUnionStruct\n"
+            "{\n"
+            "    ArrayUnion selection;\n"
+            "};\n");
+}
 
 int main(
         int argc,

--- a/test/unittest/dds/xtypes/serializers/idl/types/array_declarations/array_declarations.idl
+++ b/test/unittest/dds/xtypes/serializers/idl/types/array_declarations/array_declarations.idl
@@ -1,0 +1,13 @@
+typedef double Covariance[9];
+
+typedef double Matrix[2][3];
+
+typedef Covariance CovarianceAlias;
+
+@extensibility(APPENDABLE)
+struct ArrayDeclarations
+{
+    Covariance covariance;
+    Matrix matrix;
+    CovarianceAlias alias;
+};


### PR DESCRIPTION
<!-- Provide a general summary of your changes in the Title above -->
<!-- It must be meaningful and coherent with the changes -->

<!--
    If this PR is still a Work in Progress [WIP], please open it as DRAFT.
    Please consider if any label should be added to this PR.
    If no code has been changed, please add `skip-ci` label.
    If opening the PR as Draft, please consider adding `no-test` label to only build the code but not run CI.
    If documentation PR is still pending, please add `doc-pending` label.
-->

## Description

`idl_serialize()` writes array bounds before the name in typedefs and union members, for example `typedef double[9] Covariance;`. Reuse the struct-member declaration formatting so the bounds follow the name.

The regression tests cover one- and multidimensional arrays, chained aliases, and labelled/default union members. The alias test also parses the emitted IDL and compares the resulting type.

Tested on Ubuntu 24.04 with GCC 13.3, Debug: both new tests fail before the fix; all 16 IDL serialization tests pass after it. Uncrustify passes. Local line coverage of `dynamic_type_idl.cpp` increases from 480/590 (81.36%) to 488/599 (81.47%). The linked nightly coverage server timed out, so this comparison uses the local baseline.

Backport: `3.6.x` has the same serializer; the patch applies cleanly there.

<!--
    Describe changes in detail.
    This includes depicting the context, use case or current behavior and describe the proposed changes.
    If several features/bug fixes are included with these changes, please consider opening separated pull requests.
-->

<!--
    In case of bug fixes, please provide the list of supported branches where this fix should be also merged.
    Please uncomment following line, adjusting the corresponding target branches for the backport.
-->
<!-- @Mergifyio backport 3.6.x -->

<!--
    In case of critical bug fix, please uncomment following line, adjusting the corresponding LTS target branches for the backport.
-->
<!-- @Mergifyio backport 2.6.x 2.14.x -->

<!-- If an issue is already opened, please uncomment next line with the corresponding issue number. -->
Fixes #6509.

<!-- In case the changes are built over a previous pull request, please uncomment next line. -->
<!-- This PR depends on #(PR) and must be merged after that one. -->

## Contributor Checklist

<!--
    - If any of the elements of the following checklist is not applicable, substitute the checkbox [ ] by _N/A_:
    - If any of the elements of the following checklist is not fulfilled on purpose, please provide a reason and substitute the checkbox [ ] with ❌: or __NO__:.
-->

- [x] Commit messages follow the project guidelines. <!-- External contributors should sign the DCO. Fast DDS developers must also refer to the internal Redmine task. -->
- [x] The code follows the style guidelines of this project. <!-- Please refer to the [Quality Declaration](https://github.com/eProsima/Fast-DDS/blob/master/QUALITY.md#linters-and-static-analysis-4v) for more information. -->
- [x] Tests that thoroughly check the new feature have been added/Regression tests checking the bug and its fix have been added; the added tests pass locally <!-- Blackbox tests checking the new functionality are required. Changes that add/modify public API must include unit tests covering all possible cases. In case that no tests are provided, please justify why. -->
- [x] Any new/modified methods have been properly documented using Doxygen. <!-- Even internal classes, and private methods and members should be documented, not only the public API. -->
- _N/A_ Any new configuration API has an equivalent XML API (with the corresponding XSD extension) <!-- C++ configurable parameters should also be configurable using XML files. --> No configuration API changes.
- [x] Changes are backport compatible: they do **NOT** break ABI nor change library core behavior. <!-- Bug fixes should be ABI compatible if possible so a backport to previous affected releases can be made. -->
- [x] Changes are API compatible. <!-- Public API must not be broken within the same major release. -->
- _N/A_ New feature has been added to the `versions.md` file (if applicable). Bug fix; no new feature.
- _N/A_ New feature has been documented/Current behavior is correctly described in the documentation. <!-- Please uncomment following line with the corresponding PR to the documentation project: --> Restores valid IDL output; no documentation change.
    <!-- - Related documentation PR: eProsima/Fast-DDS-docs#(PR) -->
- [x] Applicable backports have been included in the description.

## Reviewer Checklist

- [ ] The PR has a milestone assigned.
- [ ] The title and description correctly express the PR's purpose.
- [ ] Check contributor checklist is correct.
- [ ] If this is a critical bug fix, backports to the critical-only supported branches have been requested.
- [ ] Check CI results: changes do not issue any warning.
- [ ] Check CI results: failing tests are unrelated with the changes.
